### PR TITLE
feat: 回测结果导出功能（PDF/Excel） #110

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,8 @@ tests/
 
 ### 6.2 完整工作流步骤
 
+核心原则：**Issue 管需求跟踪，PR 管代码实现。**
+
 ```
 ┌─────────────────────────────────────────────────────┐
 │  第一步：提 Issue                                    │
@@ -353,36 +355,48 @@ tests/
 └──────────────────────┬──────────────────────────────┘
                        ▼
 ┌─────────────────────────────────────────────────────┐
-│  第二步：ARCH 拆解（Pro 模型）                         │
-│  读取 Issue → 分析需求 → 判断范围                      │
+│  第二步：ARCH 拆解 + 建 PR（Pro 模型）                 │
 │                                                      │
-│  小 Issue：直接分给一个 Agent                          │
-│  大 Issue：拆成多个 sub-issue，每个标注角色标签          │
+│  1. 读取 Issue → 分析需求 → 判断范围                  │
+│  小 Issue → 直接指定一个 Agent                        │
+│  大 Issue → 拆成多个子任务，每个标注角色标签            │
 │                                                      │
-│  建 sub-issue → 补全描述                              │
-│  打标签：triaged                                      │
+│  2. 在 Issue 评论中发布拆解方案：                       │
+│     ## ARCH 拆解方案                                   │
+│     ### 任务1：[角色] - [描述]                        │
+│     ### 任务2：[角色] - [描述]                        │
+│     执行顺序：[R1] → [R2] → [R3]                     │
+│                                                      │
+│  3. ⭐ 创建 PR（从 main 开分支）。分支名：              │
+│     feat/issue-<num>-<short-desc>                    │
+│     PR 标题关联 Issue #<num>                          │
+│     PR body 贴拆解方案 + 各子任务 checkboxes           │
+│                                                      │
+│  4. 打标签：triaged                                   │
 │  移除标签：needs-triage                                │
 └──────────────────────┬──────────────────────────────┘
                        ▼
 ┌─────────────────────────────────────────────────────┐
 │  第三步：AGENT 串行开发（本地 OpenCode）               │
 │                                                      │
-│  ⚠️ 重要：串行执行，一次只开发一个 Agent 的任务         │
-│  顺序由 ARCH 指定（在 Issue 中标注优先级）              │
+│  ⚠️ 串行执行，一次只开发一个 Agent 的任务              │
+│  顺序由 ARCH 指定（在 Issue 评论中标注）               │
 │                                                      │
-│  1. Hermes 从 Issue 列表取下一个待开发子任务           │
-│  2. 创建分支：agent/<role>-<issue-id>-<slug>          │
-│  3. 运行 OpenCode：                                    │
-│     opencode run "你是 [ROLE]... 任务: ..."            │
-│  4. 提交 → push                                       │
-│  5. 标记该子任务完成，取下个子任务                     │
-│  6. 全部子任务完成后 → 建 PR                          │
+│  1. Hermes 检测到带角色标签且无 ai-in-progress 的子任务 │
+│  2. checkout 已有 PR 分支（← 同一个分支！）             │
+│     git checkout feat/issue-<num>-<slug>               │
+│  3. 运行 OpenCode 或直接实现                          │
+│  4. commit + push 到 PR 分支 → 自动触发 CI           │
+│  5. 在 Issue 评论中标明该子任务已完成 + 修改要点        │
+│  6. 在 PR 的 checkbox 中勾掉已完成项                   │
+│  7. 移除当前角色的标签 + ai-in-progress                 │
+│  8. 取下个子任务（下个 cron tick 自动处理）             │
 │                                                      │
 │  角色分工（严格文件所有权）：                           │
-│  · STRAT → strategy/（只出信号，不碰交易）             │
-│  · EXCH  → exchange/（行情 + 交易执行 + 账户）        │
-│  · TRADER→ trader/（时间推进 + 回测调度）             │
-│  · WEB   → gui/（模板 + 交互）                        │
+│  · STRAT → strategy/                                 │
+│  · EXCH  → exchange/                                 │
+│  · TRADER→ trader/                                   │
+│  · WEB   → gui/                                      │
 │  · ITEST → tests/unit/ + tests/integration/          │
 │  · GTEST → tests/guitests/                            │
 └──────────────────────┬──────────────────────────────┘
@@ -390,31 +404,29 @@ tests/
 ┌─────────────────────────────────────────────────────┐
 │  第四步：CI Workflow + LEAD Review                    │
 │                                                      │
-│  Push 到 PR 后自动触发：                               │
+│  每个 push 到 PR 分支自动触发 CI：                     │
 │  · Test  ✅/❌   单元 + 集成测试                      │
 │  · Lint  ✅/❌   代码风格                             │
 │  · Test GUI ✅/❌  GUI 端到端测试                      │
 │  · Package ✅/❌  打包                                │
 │                                                      │
-│  LEAD 读取 PR + CI 结果：                              │
-│  · CI 全过 + 代码规范 OK → 打 needs-qa，通知 QA      │
-│  · CI 不过或代码有问题 → 评论 @对应 Agent 修复        │
+│  所有子任务完成后 + CI 通过 → LEAD Review             │
+│  · 代码 OK → 打 needs-qa                             │
+│  · 有问题 → 评论 @对应 Agent 修复                     │
 └──────────────────────┬──────────────────────────────┘
                        ▼
 ┌─────────────────────────────────────────────────────┐
 │  第五步：QA 本地测试                                   │
 │                                                      │
-│  QA checkout PR 分支 → 本地测试                      │
-│  · 功能验证：新功能是否符合预期                        │
-│  · 回归验证：已有功能不受影响                          │
-│  · 边界情况：异常输入/极限参数                         │
+│  QA checkout PR 分支 → 本地验证                      │
+│  · 功能验证 + 回归验证 + 边界情况                      │
 │                                                      │
-│  测试通过 → 打 ai-done                                │
-│  测试不通过 → 评论 @对应 Agent 修复                   │
+│  通过 → 打 ai-done（允许合并）                        │
+│  不通过 → 评论 @对应 Agent 修复                       │
 └──────────────────────┬──────────────────────────────┘
                        ▼
 ┌─────────────────────────────────────────────────────┐
-│  第六步：合并 PR                                      │
+│  第六步：合并 PR（CI 必须通过）                         │
 │                                                      │
 │  QA 确认 ai-done → 合并 PR 到 main                   │
 │  关闭关联 Issue                                       │
@@ -424,19 +436,21 @@ tests/
 ### 6.3 标签流转规则
 
 ```
-提 Issue → [needs-triage] → ARCH 拆解 → [triaged]
+提 Issue → [needs-triage] → ARCH 拆解 + 建 PR → [triaged]
                                     → 子任务打角色标签
                                                 ↓
-                        Hermes 检测 → 串行执行子任务
+                        Hermes 检测 → 串行 push 到同一 PR 分支
                                                 ↓
-                        最后一个子任务完成 → 建 PR → [needs-review]
+                        每个角色完成 → 更新 Issue 评论 + 勾 PR checkbox
+                                                ↓
+                        最后一个子任务完成 → [needs-review]
                                                 ↓
                         LEAD Review:
                           ├── CI 全过 + 代码 OK → [needs-qa] → QA 测试
                           │                                    ↓
-                          │                           QA 通过 → [ai-done] → 合并
-                          │                                    ↓
-                          │                           QA 不通过 → @Agent 修复
+                          │                           QA 通过 → [ai-done] → 合并 PR
+                          │                                    ↓          ↓
+                          │                           QA 不通过 → @Agent 修复  关闭 Issue
                           │
                           └── CI 失败 / 代码问题 → @Agent 修复
 ```

--- a/gui/templates/result_mean.html
+++ b/gui/templates/result_mean.html
@@ -71,6 +71,23 @@
       <div class="card"><strong>未实现盈亏：</strong> {{ result.unrealized_pl }}</div>
     </div>
 
+    <div style="margin: 1rem 0; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+      <form method="post" action="/download/excel" style="display:inline;">
+        <input type="hidden" name="result_json" value='{{ result | tojson | forceescape }}'>
+        <input type="hidden" name="strategy_name" value="{{ strategy_name }}">
+        <button type="submit" style="padding:0.5rem 1rem; background:#2e7d32; color:white; border:none; border-radius:4px; cursor:pointer; font-size:0.9rem;">
+          📥 导出 Excel
+        </button>
+      </form>
+      <form method="post" action="/download/pdf" style="display:inline;">
+        <input type="hidden" name="result_json" value='{{ result | tojson | forceescape }}'>
+        <input type="hidden" name="strategy_name" value="{{ strategy_name }}">
+        <button type="submit" style="padding:0.5rem 1rem; background:#c62828; color:white; border:none; border-radius:4px; cursor:pointer; font-size:0.9rem;">
+          📄 导出 PDF
+        </button>
+      </form>
+    </div>
+
     <h2>资产曲线</h2>
     <div class="chart-container">
       <div class="chart-toolbar">

--- a/gui/web.py
+++ b/gui/web.py
@@ -1109,13 +1109,23 @@ def download_pdf():
         pdf = FPDF()
         pdf.add_page()
 
-        pdf.set_font('Helvetica', 'B', 16)
+        # Register a Unicode font for Chinese character support
+        _CJK_FONT_PATH = '/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc'
+        if os.path.exists(_CJK_FONT_PATH):
+            pdf.add_font('CJK', '', _CJK_FONT_PATH)
+            font_body = 'CJK'
+            font_body_bold = 'CJK'
+        else:
+            font_body = 'Helvetica'
+            font_body_bold = 'Helvetica'
+
+        pdf.set_font(font_body_bold, '', 16)
         pdf.cell(0, 12, 'Backtest Report', new_x='LMARGIN', new_y='NEXT', align='C')
         pdf.ln(4)
 
-        pdf.set_font('Helvetica', 'B', 12)
+        pdf.set_font(font_body_bold, '', 12)
         pdf.cell(0, 8, 'Summary Information', new_x='LMARGIN', new_y='NEXT')
-        pdf.set_font('Helvetica', '', 10)
+        pdf.set_font(font_body, '', 10)
         summary = pdf_data['summary']
         for k, v in [('Symbol', summary['symbol']),
                      ('Strategy', summary['strategy_name']),
@@ -1126,9 +1136,9 @@ def download_pdf():
             pdf.cell(0, 6, str(v), new_x='LMARGIN', new_y='NEXT')
         pdf.ln(4)
 
-        pdf.set_font('Helvetica', 'B', 12)
+        pdf.set_font(font_body_bold, '', 12)
         pdf.cell(0, 8, 'Key Metrics', new_x='LMARGIN', new_y='NEXT')
-        pdf.set_font('Helvetica', '', 10)
+        pdf.set_font(font_body, '', 10)
         metrics = pdf_data['metrics']
         for k, v in [('Total Return Rate', f"{metrics['total_return_rate']*100:.2f}%"),
                      ('Annualized Return', f"{metrics['annualized_return']*100:.2f}%"),
@@ -1140,19 +1150,19 @@ def download_pdf():
             pdf.cell(0, 6, str(v), new_x='LMARGIN', new_y='NEXT')
         pdf.ln(4)
 
-        pdf.set_font('Helvetica', 'B', 12)
+        pdf.set_font(font_body_bold, '', 12)
         pdf.cell(0, 8, 'Trade Records', new_x='LMARGIN', new_y='NEXT')
 
         trades = pdf_data['trades']
         col_widths = [30, 20, 25, 20, 25]
         headers = ['Date', 'Action', 'Price', 'Shares', 'P/L']
 
-        pdf.set_font('Helvetica', 'B', 8)
+        pdf.set_font(font_body_bold, '', 8)
         for i, h in enumerate(headers):
             pdf.cell(col_widths[i], 7, h, border=1, align='C')
         pdf.ln()
 
-        pdf.set_font('Helvetica', '', 8)
+        pdf.set_font(font_body, '', 8)
         max_rows = min(len(trades), 50)
         for t in trades[:max_rows]:
             pdf.cell(col_widths[0], 6, str(t.get('date', '')), border=1)
@@ -1165,7 +1175,7 @@ def download_pdf():
             pdf.ln()
 
         if len(trades) > 50:
-            pdf.set_font('Helvetica', 'I', 8)
+            pdf.set_font(font_body, 'I', 8)
             pdf.cell(0, 6, f'(Showing first 50 of {len(trades)} trades)', new_x='LMARGIN', new_y='NEXT')
 
         pdf_bytes = pdf.output()

--- a/gui/web.py
+++ b/gui/web.py
@@ -12,6 +12,7 @@ from flask import Flask, render_template, request, session, jsonify, Response
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import trader.stocks as stocks
+from trader.export import export_to_excel, prepare_pdf_data, generate_filename
 from gui.backtest_progress import get_progress_manager
 
 app = Flask(__name__, template_folder='templates')
@@ -1028,12 +1029,154 @@ def view_result():
         res = json.loads(result_json)
         # 使用详细模板显示结果
         if isinstance(res, dict) and ('trades_list' in res or 'history' in res):
-            return render_template('result_mean.html', result=res)
+            strategy_name = session.get('strategy_name', '')
+            return render_template('result_mean.html', result=res, strategy_name=strategy_name)
         else:
             return render_template('result.html', error='回测结果格式不正确')
     except Exception as e:
         return render_template('result.html', error=f'解析结果失败: {e}')
 
+
+@app.route('/download/excel', methods=['POST'])
+def download_excel():
+    # 导出回测结果为 Excel 文件。
+    result_json = request.form.get('result_json')
+    if not result_json:
+        return jsonify({'error': '无法获取回测结果'}), 400
+
+    try:
+        res = json.loads(result_json)
+    except json.JSONDecodeError:
+        return jsonify({'error': '结果数据格式错误'}), 400
+
+    if not isinstance(res, dict):
+        return jsonify({'error': '结果数据格式错误'}), 400
+
+    try:
+        strategy_name = request.form.get('strategy_name', '')
+        symbol = res.get('symbol', 'UNKNOWN')
+        start_date = res.get('start_date', '')
+        end_date = res.get('end_date', '')
+
+        fname = generate_filename(symbol, strategy_name, start_date, end_date, 'xlsx')
+
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            output_path = export_to_excel(
+                backtest_result=res,
+                output_path=tmp.name,
+                strategy_name=strategy_name,
+            )
+
+        with open(output_path, 'rb') as f:
+            data = f.read()
+        os.unlink(output_path)
+
+        response = app.response_class(
+            response=data,
+            mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        )
+        response.headers['Content-Disposition'] = f'attachment; filename="{fname}"'
+        return response
+    except Exception as e:
+        return jsonify({'error': f'导出 Excel 失败: {str(e)}'}), 500
+
+
+@app.route('/download/pdf', methods=['POST'])
+def download_pdf():
+    # 导出回测结果为 PDF 文件。
+    result_json = request.form.get('result_json')
+    if not result_json:
+        return jsonify({'error': '无法获取回测结果'}), 400
+
+    try:
+        res = json.loads(result_json)
+    except json.JSONDecodeError:
+        return jsonify({'error': '结果数据格式错误'}), 400
+
+    if not isinstance(res, dict):
+        return jsonify({'error': '结果数据格式错误'}), 400
+
+    try:
+        strategy_name = request.form.get('strategy_name', '')
+        symbol = res.get('symbol', 'UNKNOWN')
+        start_date = res.get('start_date', '')
+        end_date = res.get('end_date', '')
+
+        fname = generate_filename(symbol, strategy_name, start_date, end_date, 'pdf')
+        pdf_data = prepare_pdf_data(res, strategy_name)
+
+        from fpdf import FPDF
+        pdf = FPDF()
+        pdf.add_page()
+
+        pdf.set_font('Helvetica', 'B', 16)
+        pdf.cell(0, 12, 'Backtest Report', new_x='LMARGIN', new_y='NEXT', align='C')
+        pdf.ln(4)
+
+        pdf.set_font('Helvetica', 'B', 12)
+        pdf.cell(0, 8, 'Summary Information', new_x='LMARGIN', new_y='NEXT')
+        pdf.set_font('Helvetica', '', 10)
+        summary = pdf_data['summary']
+        for k, v in [('Symbol', summary['symbol']),
+                     ('Strategy', summary['strategy_name']),
+                     ('Start Date', summary['start_date']),
+                     ('End Date', summary['end_date']),
+                     ('Initial Capital', f"${summary['init_cash']:,.2f}")]:
+            pdf.cell(50, 6, k + ':', border=0)
+            pdf.cell(0, 6, str(v), new_x='LMARGIN', new_y='NEXT')
+        pdf.ln(4)
+
+        pdf.set_font('Helvetica', 'B', 12)
+        pdf.cell(0, 8, 'Key Metrics', new_x='LMARGIN', new_y='NEXT')
+        pdf.set_font('Helvetica', '', 10)
+        metrics = pdf_data['metrics']
+        for k, v in [('Total Return Rate', f"{metrics['total_return_rate']*100:.2f}%"),
+                     ('Annualized Return', f"{metrics['annualized_return']*100:.2f}%"),
+                     ('Max Drawdown', f"{metrics['max_drawdown']*100:.2f}%"),
+                     ('Sharpe Ratio', f"{metrics['sharpe_ratio']:.4f}"),
+                     ('Total P/L', f"${metrics['total_pl']:,.2f}"),
+                     ('Final Value', f"${metrics['final_value']:,.2f}")]:
+            pdf.cell(50, 6, k + ':', border=0)
+            pdf.cell(0, 6, str(v), new_x='LMARGIN', new_y='NEXT')
+        pdf.ln(4)
+
+        pdf.set_font('Helvetica', 'B', 12)
+        pdf.cell(0, 8, 'Trade Records', new_x='LMARGIN', new_y='NEXT')
+
+        trades = pdf_data['trades']
+        col_widths = [30, 20, 25, 20, 25]
+        headers = ['Date', 'Action', 'Price', 'Shares', 'P/L']
+
+        pdf.set_font('Helvetica', 'B', 8)
+        for i, h in enumerate(headers):
+            pdf.cell(col_widths[i], 7, h, border=1, align='C')
+        pdf.ln()
+
+        pdf.set_font('Helvetica', '', 8)
+        max_rows = min(len(trades), 50)
+        for t in trades[:max_rows]:
+            pdf.cell(col_widths[0], 6, str(t.get('date', '')), border=1)
+            pdf.cell(col_widths[1], 6, str(t.get('action', '')), border=1, align='C')
+            pdf.cell(col_widths[2], 6, f"{t.get('price', 0):.2f}", border=1, align='R')
+            pdf.cell(col_widths[3], 6, str(t.get('shares', 0)), border=1, align='R')
+            pl = t.get('pl', '')
+            pl_str = f"{pl:.2f}" if isinstance(pl, (int, float)) else str(pl)
+            pdf.cell(col_widths[4], 6, pl_str, border=1, align='R')
+            pdf.ln()
+
+        if len(trades) > 50:
+            pdf.set_font('Helvetica', 'I', 8)
+            pdf.cell(0, 6, f'(Showing first 50 of {len(trades)} trades)', new_x='LMARGIN', new_y='NEXT')
+
+        pdf_bytes = pdf.output()
+        response = app.response_class(
+            response=pdf_bytes,
+            mimetype='application/pdf',
+        )
+        response.headers['Content-Disposition'] = f'attachment; filename="{fname}"'
+        return response
+    except Exception as e:
+        return jsonify({'error': f'导出 PDF 失败: {str(e)}'}), 500
 
 if __name__ == '__main__':
     # 支持通过环境变量自定义主机和端口，方便测试使用非默认端口

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ pylint
 flake8
 mypy
 openpyxl
+fpdf2
 playwright

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ Flask
 pylint
 flake8
 mypy
+openpyxl
 playwright

--- a/tests/guitests/test_export_e2e.py
+++ b/tests/guitests/test_export_e2e.py
@@ -1,0 +1,303 @@
+"""GUI 端到端测试：回测结果导出功能（Excel/PDF）。
+
+验证 Flask 的 /download/excel 和 /download/pdf 路由能正确返回导出文件。
+
+Owned by: GTEST (per AGENTS.md)
+"""
+
+import json
+import unittest
+from unittest.mock import patch
+
+
+class TestExportRoutes(unittest.TestCase):
+    """Test /download/excel and /download/pdf routes via Flask test client."""
+
+    def setUp(self):
+        from gui.web import app
+
+        # Save original testing flag
+        self._original_testing = app.testing
+        app.testing = True
+        self.client = app.test_client()
+
+    def tearDown(self):
+        from gui.web import app
+
+        app.testing = self._original_testing
+
+    def _make_result(self) -> dict:
+        return {
+            "symbol": "600900",
+            "start_date": "2023-01-03",
+            "end_date": "2023-01-31",
+            "init_cash": 100000.0,
+            "cash": 75900.0,
+            "total_value": 84700.0,
+            "realized_pl": 200.0,
+            "unrealized_pl": 8800.0,
+            "shares": 400,
+            "last_price": 22.0,
+            "trades": 3,
+            "trades_list": [
+                {"date": "2023-01-03", "action": "buy", "price": 20.0, "shares": 300,
+                 "cash": 94000.0, "shares_after": 300, "realized_pl": 0, "source": "signal"},
+                {"date": "2023-01-10", "action": "buy", "price": 21.0, "shares": 200,
+                 "cash": 73900.0, "shares_after": 500, "realized_pl": 0, "source": "signal"},
+                {"date": "2023-01-15", "action": "sell", "price": 22.0, "shares": 100,
+                 "cash": 75900.0, "shares_after": 400, "realized_pl": 200.0, "source": "signal"},
+            ],
+            "history": [
+                {"date": "2023-01-03", "cash": 94000.0, "shares": 300, "avg_cost": 20.0,
+                 "last_price": 20.5, "market_value": 6150.0, "total_value": 100150.0},
+                {"date": "2023-01-10", "cash": 73900.0, "shares": 500, "avg_cost": 20.4,
+                 "last_price": 21.0, "market_value": 10500.0, "total_value": 84400.0},
+                {"date": "2023-01-15", "cash": 75900.0, "shares": 400, "avg_cost": 20.5,
+                 "last_price": 22.0, "market_value": 8800.0, "total_value": 84700.0},
+            ],
+        }
+
+    def test_download_excel_returns_xlsx(self):
+        """Verify /download/excel returns a valid Excel file."""
+        result = self._make_result()
+        rv = self.client.post(
+            "/download/excel",
+            data={
+                "result_json": json.dumps(result),
+                "strategy_name": "mean_cost",
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
+        # Check content type
+        self.assertIn(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            rv.content_type,
+        )
+        # Check Content-Disposition header for filename
+        disposition = rv.headers.get("Content-Disposition", "")
+        self.assertIn("attachment", disposition)
+        self.assertIn(".xlsx", disposition)
+        # Verify it's a valid .xlsx file
+        self.assertGreater(len(rv.data), 500)
+
+    def test_download_excel_opens_as_valid_xlsx(self):
+        """Verify /download/excel response can be parsed as openpyxl workbook."""
+        result = self._make_result()
+        rv = self.client.post(
+            "/download/excel",
+            data={
+                "result_json": json.dumps(result),
+                "strategy_name": "sma",
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
+
+        import openpyxl
+        from io import BytesIO
+
+        wb = openpyxl.load_workbook(BytesIO(rv.data))
+        self.assertEqual(wb.sheetnames, ["交易明细", "持仓变化", "汇总统计"])
+        wb.close()
+
+    def test_download_excel_contains_trade_data(self):
+        """Verify /download/excel response contains expected trade data."""
+        result = self._make_result()
+        rv = self.client.post(
+            "/download/excel",
+            data={
+                "result_json": json.dumps(result),
+                "strategy_name": "mean_cost",
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
+
+        import openpyxl
+        from io import BytesIO
+
+        wb = openpyxl.load_workbook(BytesIO(rv.data))
+        ws = wb["交易明细"]
+        # Header row
+        self.assertEqual(ws.cell(1, 1).value, "日期")
+        self.assertEqual(ws.cell(1, 2).value, "方向")
+        # Some trade data should exist
+        self.assertGreater(ws.max_row, 1)
+        wb.close()
+
+    def test_download_excel_without_strategy_name(self):
+        """Verify /download/excel works without strategy_name (uses default)."""
+        result = self._make_result()
+        rv = self.client.post(
+            "/download/excel",
+            data={"result_json": json.dumps(result)},
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertGreater(len(rv.data), 500)
+
+    def test_download_excel_missing_result(self):
+        """Verify /download/excel returns 400 when result_json is missing."""
+        rv = self.client.post("/download/excel", data={})
+        self.assertEqual(rv.status_code, 400)
+        data = rv.get_json()
+        self.assertIn("error", data)
+
+    def test_download_excel_invalid_json(self):
+        """Verify /download/excel returns 400 for invalid JSON."""
+        rv = self.client.post(
+            "/download/excel",
+            data={"result_json": "not valid json"},
+        )
+        self.assertEqual(rv.status_code, 400)
+        data = rv.get_json()
+        self.assertIn("error", data)
+
+    def test_download_excel_non_dict_json(self):
+        """Verify /download/excel returns 400 when JSON is not a dict."""
+        rv = self.client.post(
+            "/download/excel",
+            data={"result_json": json.dumps([1, 2, 3])},
+        )
+        self.assertEqual(rv.status_code, 400)
+        data = rv.get_json()
+        self.assertIn("error", data)
+
+    def test_download_pdf_returns_pdf(self):
+        """Verify /download/pdf returns a valid PDF file."""
+        result = self._make_result()
+        rv = self.client.post(
+            "/download/pdf",
+            data={
+                "result_json": json.dumps(result),
+                "strategy_name": "mean_cost",
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
+        # PDF content type
+        self.assertIn("application/pdf", rv.content_type)
+        # Check Content-Disposition
+        disposition = rv.headers.get("Content-Disposition", "")
+        self.assertIn("attachment", disposition)
+        self.assertIn(".pdf", disposition)
+        # Verify it's a valid PDF (starts with %PDF)
+        self.assertTrue(rv.data.startswith(b"%PDF"))
+        self.assertGreater(len(rv.data), 100)
+
+    def test_download_pdf_contains_report_content(self):
+        """Verify /download/pdf response contains meaningful report content."""
+        result = self._make_result()
+        rv = self.client.post(
+            "/download/pdf",
+            data={
+                "result_json": json.dumps(result),
+                "strategy_name": "mean_cost",
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
+
+        # Verify it's a valid PDF
+        self.assertTrue(rv.data.startswith(b"%PDF"))
+        # PDF should be at least 1KB with real content
+        self.assertGreater(len(rv.data), 1000)
+
+        # Check Content-Disposition header for filename parts
+        disposition = rv.headers.get("Content-Disposition", "")
+        self.assertIn("600900", disposition)
+        self.assertIn("mean_cost", disposition)
+
+    def test_download_pdf_without_strategy_name(self):
+        """Verify /download/pdf works without strategy_name."""
+        result = self._make_result()
+        rv = self.client.post(
+            "/download/pdf",
+            data={"result_json": json.dumps(result)},
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertTrue(rv.data.startswith(b"%PDF"))
+
+    def test_download_pdf_missing_result(self):
+        """Verify /download/pdf returns 400 without result_json."""
+        rv = self.client.post("/download/pdf", data={})
+        self.assertEqual(rv.status_code, 400)
+        data = rv.get_json()
+        self.assertIn("error", data)
+
+    def test_download_pdf_invalid_json(self):
+        """Verify /download/pdf returns 400 for invalid JSON."""
+        rv = self.client.post(
+            "/download/pdf",
+            data={"result_json": "bad json"},
+        )
+        self.assertEqual(rv.status_code, 400)
+        data = rv.get_json()
+        self.assertIn("error", data)
+
+    def test_download_pdf_non_dict_json(self):
+        """Verify /download/pdf returns 400 when JSON is not a dict."""
+        rv = self.client.post(
+            "/download/pdf",
+            data={"result_json": json.dumps("string_value")},
+        )
+        self.assertEqual(rv.status_code, 400)
+        data = rv.get_json()
+        self.assertIn("error", data)
+
+    def test_download_pdf_with_sample_data(self):
+        """Verify /download/pdf handles a realistic but minimal result."""
+        minimal_result = {"symbol": "600519", "total_value": 200000.0, "cash": 200000.0}
+        rv = self.client.post(
+            "/download/pdf",
+            data={
+                "result_json": json.dumps(minimal_result),
+                "strategy_name": "sma",
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertTrue(rv.data.startswith(b"%PDF"))
+
+    def test_download_excel_with_sample_data(self):
+        """Verify /download/excel handles a realistic but minimal result."""
+        minimal_result = {"symbol": "600519", "total_value": 200000.0, "cash": 200000.0}
+        rv = self.client.post(
+            "/download/excel",
+            data={
+                "result_json": json.dumps(minimal_result),
+                "strategy_name": "sma",
+            },
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertGreater(len(rv.data), 500)
+
+    def test_download_excel_filename_contains_components(self):
+        """Verify /download/excel Content-Disposition filename has correct parts."""
+        result = self._make_result()
+        rv = self.client.post(
+            "/download/excel",
+            data={
+                "result_json": json.dumps(result),
+                "strategy_name": "mean_cost",
+            },
+        )
+        disposition = rv.headers.get("Content-Disposition", "")
+        # Filename should contain stock code, strategy name, date range
+        self.assertIn("600900", disposition)
+        self.assertIn("mean_cost", disposition)
+        self.assertIn("2023-01-03", disposition)
+        self.assertIn("2023-01-31", disposition)
+
+    def test_download_pdf_filename_contains_components(self):
+        """Verify /download/pdf Content-Disposition filename has correct parts."""
+        result = self._make_result()
+        rv = self.client.post(
+            "/download/pdf",
+            data={
+                "result_json": json.dumps(result),
+                "strategy_name": "mean_cost",
+            },
+        )
+        disposition = rv.headers.get("Content-Disposition", "")
+        self.assertIn("600900", disposition)
+        self.assertIn("mean_cost", disposition)
+        self.assertIn(".pdf", disposition)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_export_integration.py
+++ b/tests/integration/test_export_integration.py
@@ -1,0 +1,293 @@
+"""Integration tests for trader/export.py — verifies actual file creation and content.
+
+Owned by: ITEST (per AGENTS.md)
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+
+class TestExportExcelIntegration(unittest.TestCase):
+    """Integration tests for export_to_excel with real file I/O."""
+
+    def _make_backtest_result(self) -> dict:
+        """Create a realistic backtest result."""
+        return {
+            "symbol": "600900",
+            "start_date": "2023-01-03",
+            "end_date": "2023-01-31",
+            "init_cash": 100000.0,
+            "cash": 75900.0,
+            "total_value": 84700.0,
+            "realized_pl": 200.0,
+            "unrealized_pl": 8800.0,
+            "shares": 400,
+            "last_price": 22.0,
+            "trades": 5,
+            "trades_list": [
+                {
+                    "date": "2023-01-03",
+                    "action": "buy",
+                    "price": 20.0,
+                    "shares": 300,
+                    "cash": 94000.0,
+                    "shares_after": 300,
+                    "realized_pl": 0,
+                    "source": "signal",
+                },
+                {
+                    "date": "2023-01-10",
+                    "action": "buy",
+                    "price": 21.0,
+                    "shares": 200,
+                    "cash": 73900.0,
+                    "shares_after": 500,
+                    "realized_pl": 0,
+                    "source": "signal",
+                },
+                {
+                    "date": "2023-01-15",
+                    "action": "sell",
+                    "price": 22.0,
+                    "shares": 100,
+                    "cash": 75900.0,
+                    "shares_after": 400,
+                    "realized_pl": 200.0,
+                    "source": "signal",
+                },
+            ],
+            "history": [
+                {"date": "2023-01-03", "cash": 94000.0, "shares": 300, "avg_cost": 20.0,
+                 "last_price": 20.5, "market_value": 6150.0, "total_value": 100150.0},
+                {"date": "2023-01-10", "cash": 73900.0, "shares": 500, "avg_cost": 20.4,
+                 "last_price": 21.0, "market_value": 10500.0, "total_value": 84400.0},
+                {"date": "2023-01-15", "cash": 75900.0, "shares": 400, "avg_cost": 20.5,
+                 "last_price": 22.0, "market_value": 8800.0, "total_value": 84700.0},
+            ],
+        }
+
+    def test_export_excel_real_file(self):
+        """Verify real file is created and can be opened as valid .xlsx."""
+        from trader.export import export_to_excel
+
+        result = self._make_backtest_result()
+        output_path = os.path.join(tempfile.mkdtemp(), "test_export.xlsx")
+
+        try:
+            saved_path = export_to_excel(result, output_path, strategy_name="mean_cost")
+            self.assertEqual(saved_path, output_path)
+            self.assertTrue(os.path.exists(output_path))
+            self.assertGreater(os.path.getsize(output_path), 1000)  # Should be >1KB
+
+            # Validate it's a real .xlsx
+            import openpyxl
+            wb = openpyxl.load_workbook(output_path)
+            self.assertEqual(wb.sheetnames, ["交易明细", "持仓变化", "汇总统计"])
+            wb.close()
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_export_excel_sheet_content(self):
+        """Verify trade details match expected values in the 交易明细 sheet."""
+        from trader.export import export_to_excel
+
+        result = self._make_backtest_result()
+        output_path = os.path.join(tempfile.mkdtemp(), "test_content.xlsx")
+
+        try:
+            export_to_excel(result, output_path, strategy_name="test")
+            import openpyxl
+            wb = openpyxl.load_workbook(output_path)
+
+            # Check trade details
+            ws = wb["交易明细"]
+            trade_rows = []
+            for r in range(2, ws.max_row + 1):
+                row = {
+                    "date": ws.cell(r, 1).value,
+                    "direction": ws.cell(r, 2).value,
+                    "price": ws.cell(r, 3).value,
+                    "shares": ws.cell(r, 4).value,
+                    "cash_after": ws.cell(r, 5).value,
+                    "shares_after": ws.cell(r, 6).value,
+                    "pl": ws.cell(r, 7).value,
+                }
+                trade_rows.append(row)
+
+            self.assertEqual(len(trade_rows), 3)
+            # First trade: buy 300 shares at 20
+            self.assertEqual(trade_rows[0]["direction"], "买入")
+            self.assertEqual(trade_rows[0]["price"], 20.0)
+            self.assertEqual(trade_rows[0]["shares"], 300)
+
+            # Check summary sheet
+            ws_sum = wb["汇总统计"]
+            summary = {}
+            for r in range(1, ws_sum.max_row + 1):
+                k = ws_sum.cell(r, 1).value
+                v = ws_sum.cell(r, 2).value
+                if k:
+                    summary[str(k)] = v
+
+            self.assertEqual(summary.get("股票代码"), "600900")
+            # total_pl = realized_pl + unrealized_pl = 200 + 8800 = 9000
+            self.assertEqual(summary.get("总盈亏"), 9000.0)
+
+            wb.close()
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_export_excel_with_auto_filename(self):
+        """Verify filename generation integrated with export."""
+        from trader.export import export_to_excel, generate_filename
+
+        result = self._make_backtest_result()
+        symbol = result["symbol"]
+        strategy_name = "mean_cost"
+        start_date = result["start_date"]
+        end_date = result["end_date"]
+
+        fname = generate_filename(symbol, strategy_name, start_date, end_date)
+        output_dir = tempfile.mkdtemp()
+        output_path = os.path.join(output_dir, fname)
+
+        try:
+            saved = export_to_excel(result, output_path, strategy_name=strategy_name)
+            self.assertEqual(os.path.basename(saved), fname)
+            self.assertTrue(fname.startswith("600900_mean_cost"))
+            self.assertTrue(fname.endswith(".xlsx"))
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_export_excel_style_structure(self):
+        """Verify header rows use correct styling."""
+        from trader.export import export_to_excel
+
+        result = self._make_backtest_result()
+        output_path = os.path.join(tempfile.mkdtemp(), "test_style.xlsx")
+
+        try:
+            export_to_excel(result, output_path)
+            import openpyxl
+            wb = openpyxl.load_workbook(output_path)
+
+            # Check trade sheet header styling
+            ws = wb["交易明细"]
+            header_cell = ws.cell(1, 1)
+            self.assertTrue(header_cell.font.bold)
+
+            # Check summary sheet key styling
+            ws_sum = wb["汇总统计"]
+            key_cell = ws_sum.cell(1, 1)
+            self.assertTrue(key_cell.font.bold)
+
+            wb.close()
+        finally:
+            if os.path.exists(output_path):
+                os.unlink(output_path)
+
+    def test_export_multiple_calls_same_dir(self):
+        """Verify multiple export calls work with different filenames in same dir."""
+        from trader.export import export_to_excel, generate_filename
+
+        result = self._make_backtest_result()
+        output_dir = tempfile.mkdtemp()
+
+        fname1 = generate_filename("600900", "sma", "20230101", "20231231")
+        fname2 = generate_filename("600519", "mean_cost", "20230101", "20231231")
+        path1 = os.path.join(output_dir, fname1)
+        path2 = os.path.join(output_dir, fname2)
+
+        try:
+            p1 = export_to_excel(result, path1, strategy_name="sma")
+            p2 = export_to_excel(result, path2, strategy_name="mean_cost")
+            self.assertTrue(os.path.exists(p1))
+            self.assertTrue(os.path.exists(p2))
+            self.assertNotEqual(p1, p2)
+        finally:
+            for p in [path1, path2]:
+                if os.path.exists(p):
+                    os.unlink(p)
+
+
+class TestPdfDataIntegration(unittest.TestCase):
+    """Integration: prepare_pdf_data + actual PDF generation via fpdf2."""
+
+    def _make_result(self) -> dict:
+        return {
+            "symbol": "600900",
+            "start_date": "2023-01-01",
+            "end_date": "2023-12-31",
+            "init_cash": 100000.0,
+            "cash": 95000.0,
+            "total_value": 120000.0,
+            "realized_pl": 15000.0,
+            "unrealized_pl": 5000.0,
+            "shares": 500,
+            "last_price": 24.0,
+            "trades": 5,
+            "trades_list": [
+                {"date": "2023-01-10", "action": "buy", "price": 20.0, "shares": 500, "realized_pl": 0},
+                {"date": "2023-06-15", "action": "sell", "price": 24.0, "shares": 200, "realized_pl": 2000},
+            ],
+            "history": [
+                {"date": "2023-01-10", "total_value": 100000.0},
+                {"date": "2023-06-15", "total_value": 110000.0},
+                {"date": "2023-12-31", "total_value": 120000.0},
+            ],
+        }
+
+    def test_pdf_data_can_generate_pdf(self):
+        """Verify PDF data can be used to generate a real PDF."""
+        from trader.export import prepare_pdf_data
+        from fpdf import FPDF
+
+        result = self._make_result()
+        pdf_data = prepare_pdf_data(result, "mean_cost")
+
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Helvetica", size=12)
+        summary = pdf_data["summary"]
+        pdf.cell(0, 10, f"Symbol: {summary['symbol']}")
+        metrics = pdf_data["metrics"]
+        pdf.cell(0, 10, f"Total Return: {metrics['total_return_rate']*100:.1f}%")
+        pdf_bytes = pdf.output()
+
+        self.assertGreater(len(pdf_bytes), 100)
+
+    def test_pdf_data_can_generate_pdf_with_trade_table(self):
+        """Verify PDF data includes all trade records for PDF table generation."""
+        from trader.export import prepare_pdf_data
+
+        result = self._make_result()
+        pdf_data = prepare_pdf_data(result)
+
+        trades = pdf_data["trades"]
+        self.assertEqual(len(trades), 2)
+        for t in trades:
+            self.assertIn("date", t)
+            self.assertIn("action", t)
+            self.assertIn("price", t)
+            self.assertIn("shares", t)
+            self.assertIn("pl", t)
+
+    def test_pdf_data_annualized_return_reasonable(self):
+        """Verify annualized return is positive and reasonable."""
+        from trader.export import prepare_pdf_data
+
+        result = self._make_result()
+        pdf_data = prepare_pdf_data(result)
+        ar = pdf_data["metrics"]["annualized_return"]
+        # With 20% return over 1 year, annualized should be ~20%
+        self.assertGreater(ar, 0.15)
+        self.assertLess(ar, 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,0 +1,398 @@
+"""Unit tests for trader/export.py — Excel export, PDF data prep, filename generation.
+
+Owned by: ITEST (per AGENTS.md)
+"""
+
+import json
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+class TestExportToExcel(unittest.TestCase):
+    """Test export_to_excel() — Excel file generation from backtest results."""
+
+    def _make_backtest_result(self, **overrides) -> dict:
+        """Create a minimal backtest result dict for testing."""
+        defaults = {
+            "symbol": "600900",
+            "start_date": "2023-01-01",
+            "end_date": "2023-01-31",
+            "init_cash": 100000.0,
+            "cash": 95000.0,
+            "total_value": 105000.0,
+            "realized_pl": 3000.0,
+            "unrealized_pl": 2000.0,
+            "shares": 500,
+            "last_price": 22.0,
+            "trades": 3,
+            "trades_list": [
+                {
+                    "date": "2023-01-03",
+                    "action": "buy",
+                    "price": 20.0,
+                    "shares": 300,
+                    "cash": 94000.0,
+                    "shares_after": 300,
+                    "realized_pl": 0,
+                    "source": "signal",
+                },
+                {
+                    "date": "2023-01-10",
+                    "action": "buy",
+                    "price": 21.0,
+                    "shares": 200,
+                    "cash": 73900.0,
+                    "shares_after": 500,
+                    "realized_pl": 0,
+                    "source": "signal",
+                },
+                {
+                    "date": "2023-01-20",
+                    "action": "sell",
+                    "price": 22.0,
+                    "shares": 100,
+                    "cash": 75900.0,
+                    "shares_after": 400,
+                    "realized_pl": 200.0,
+                    "source": "signal",
+                },
+            ],
+            "history": [
+                {"date": "2023-01-03", "cash": 94000.0, "shares": 300, "avg_cost": 20.0,
+                 "last_price": 20.5, "market_value": 6150.0, "total_value": 100150.0},
+                {"date": "2023-01-10", "cash": 73900.0, "shares": 500, "avg_cost": 20.4,
+                 "last_price": 21.0, "market_value": 10500.0, "total_value": 84400.0},
+                {"date": "2023-01-20", "cash": 75900.0, "shares": 400, "avg_cost": 20.5,
+                 "last_price": 22.0, "market_value": 8800.0, "total_value": 84700.0},
+            ],
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_export_excel_creates_file(self):
+        """Verify export_to_excel creates a non-empty .xlsx file."""
+        from trader.export import export_to_excel
+
+        result = self._make_backtest_result()
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            output_path = export_to_excel(
+                backtest_result=result,
+                output_path=tmp.name,
+                strategy_name="mean_cost",
+            )
+            self.assertEqual(output_path, tmp.name)
+
+        # Verify file exists and has content
+        import os
+        self.assertTrue(os.path.exists(output_path))
+        self.assertGreater(os.path.getsize(output_path), 0)
+        os.unlink(output_path)
+
+    def test_export_excel_has_three_sheets(self):
+        """Verify the generated .xlsx has correct sheet names."""
+        from trader.export import export_to_excel
+
+        result = self._make_backtest_result()
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            export_to_excel(result, tmp.name, strategy_name="sma")
+            import openpyxl
+            wb = openpyxl.load_workbook(tmp.name)
+            self.assertEqual(wb.sheetnames, ["交易明细", "持仓变化", "汇总统计"])
+            wb.close()
+        import os
+        os.unlink(tmp.name)
+
+    def test_export_excel_trade_details_sheet(self):
+        """Verify 交易明细 sheet contains trade records."""
+        from trader.export import export_to_excel
+
+        result = self._make_backtest_result()
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            export_to_excel(result, tmp.name)
+            import openpyxl
+            wb = openpyxl.load_workbook(tmp.name)
+            ws = wb["交易明细"]
+            # Header row
+            self.assertEqual(ws.cell(1, 1).value, "日期")
+            self.assertEqual(ws.cell(1, 2).value, "方向")
+            self.assertEqual(ws.cell(1, 3).value, "成交价")
+            self.assertEqual(ws.cell(1, 4).value, "数量(股)")
+            # Data rows (3 trades)
+            self.assertEqual(ws.cell(2, 1).value, "2023-01-03")
+            self.assertEqual(ws.cell(2, 2).value, "买入")
+            self.assertEqual(ws.cell(3, 2).value, "买入")
+            self.assertEqual(ws.cell(4, 2).value, "卖出")
+            wb.close()
+        import os
+        os.unlink(tmp.name)
+
+    def test_export_excel_summary_sheet(self):
+        """Verify 汇总统计 sheet contains key metrics."""
+        from trader.export import export_to_excel
+
+        result = self._make_backtest_result(init_cash=100000.0, realized_pl=3000.0, unrealized_pl=2000.0)
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            export_to_excel(result, tmp.name, strategy_name="mean_cost")
+            import openpyxl
+            wb = openpyxl.load_workbook(tmp.name)
+            ws = wb["汇总统计"]
+            # Read key-value pairs
+            data = {}
+            for row in ws.iter_rows(min_row=1, max_row=ws.max_row, values_only=True):
+                if row[0] and row[1] is not None:
+                    data[str(row[0])] = row[1]
+            self.assertEqual(data.get("股票代码"), "600900")
+            self.assertEqual(data.get("策略名称"), "mean_cost")
+            self.assertEqual(data.get("初始资金"), 100000.0)
+            self.assertEqual(data.get("交易次数"), 3)
+            self.assertEqual(data.get("总盈亏"), 5000.0)  # realized_pl + unrealized_pl
+            wb.close()
+        import os
+        os.unlink(tmp.name)
+
+    def test_export_excel_history_sheet(self):
+        """Verify 持仓变化 sheet contains history records."""
+        from trader.export import export_to_excel
+
+        result = self._make_backtest_result()
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            export_to_excel(result, tmp.name)
+            import openpyxl
+            wb = openpyxl.load_workbook(tmp.name)
+            ws = wb["持仓变化"]
+            headers = [ws.cell(1, c).value for c in range(1, ws.max_column + 1)]
+            self.assertIn("日期", headers)
+            self.assertIn("现金", headers)
+            self.assertIn("持仓(股)", headers)
+            self.assertIn("总资产", headers)
+            # Should have 3 history rows
+            self.assertGreaterEqual(ws.max_row, 4)
+            wb.close()
+        import os
+        os.unlink(tmp.name)
+
+    def test_export_excel_empty_trades_list(self):
+        """Verify export succeeds with empty trades_list."""
+        from trader.export import export_to_excel
+
+        result = self._make_backtest_result(trades_list=[])
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            output_path = export_to_excel(result, tmp.name)
+            self.assertTrue(output_path)
+            import openpyxl
+            wb = openpyxl.load_workbook(tmp.name)
+            ws = wb["交易明细"]
+            # Only header row, no data
+            self.assertEqual(ws.max_row, 1)
+            wb.close()
+        import os
+        os.unlink(tmp.name)
+
+    def test_export_excel_empty_history(self):
+        """Verify export succeeds with empty history."""
+        from trader.export import export_to_excel
+
+        result = self._make_backtest_result(history=[])
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            output_path = export_to_excel(result, tmp.name)
+            self.assertTrue(output_path)  # Should not crash
+        import os
+        os.unlink(tmp.name)
+
+    def test_export_excel_minimal_result(self):
+        """Verify export handles a minimal result dict gracefully."""
+        from trader.export import export_to_excel
+
+        minimal = {"symbol": "TEST"}
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            output_path = export_to_excel(minimal, tmp.name)
+            self.assertTrue(output_path)
+            import openpyxl
+            wb = openpyxl.load_workbook(tmp.name)
+            # Should still have 3 sheets
+            self.assertEqual(wb.sheetnames, ["交易明细", "持仓变化", "汇总统计"])
+            wb.close()
+        import os
+        os.unlink(tmp.name)
+
+
+class TestPreparePdfData(unittest.TestCase):
+    """Test prepare_pdf_data() — structured data extraction for PDF generation."""
+
+    def _make_result(self, **overrides) -> dict:
+        defaults = {
+            "symbol": "600900",
+            "start_date": "2023-01-01",
+            "end_date": "2023-12-31",
+            "init_cash": 100000.0,
+            "cash": 95000.0,
+            "total_value": 120000.0,
+            "realized_pl": 15000.0,
+            "unrealized_pl": 5000.0,
+            "shares": 500,
+            "last_price": 24.0,
+            "trades": 5,
+            "trades_list": [
+                {"date": "2023-01-10", "action": "buy", "price": 20.0, "shares": 500, "realized_pl": 0},
+                {"date": "2023-06-15", "action": "sell", "price": 24.0, "shares": 200, "realized_pl": 2000},
+            ],
+            "history": [
+                {"date": "2023-01-10", "total_value": 100000.0},
+                {"date": "2023-03-15", "total_value": 105000.0},
+                {"date": "2023-06-15", "total_value": 110000.0},
+                {"date": "2023-09-15", "total_value": 115000.0},
+                {"date": "2023-12-31", "total_value": 120000.0},
+            ],
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_prepare_pdf_data_has_summary(self):
+        """Verify PDF data includes summary section."""
+        from trader.export import prepare_pdf_data
+
+        result = self._make_result()
+        pdf_data = prepare_pdf_data(result, "mean_cost")
+        self.assertIn("summary", pdf_data)
+        self.assertEqual(pdf_data["summary"]["symbol"], "600900")
+        self.assertEqual(pdf_data["summary"]["strategy_name"], "mean_cost")
+        self.assertEqual(pdf_data["summary"]["init_cash"], 100000.0)
+
+    def test_prepare_pdf_data_has_metrics(self):
+        """Verify PDF data includes metrics with calculated values."""
+        from trader.export import prepare_pdf_data
+
+        result = self._make_result()
+        pdf_data = prepare_pdf_data(result)
+        metrics = pdf_data["metrics"]
+        self.assertIn("total_return_rate", metrics)
+        self.assertIn("annualized_return", metrics)
+        self.assertIn("max_drawdown", metrics)
+        self.assertIn("sharpe_ratio", metrics)
+        self.assertIn("total_pl", metrics)
+
+        # total_pl = realized_pl + unrealized_pl
+        self.assertEqual(metrics["total_pl"], 20000.0)
+
+        # total_return_rate = total_pl / init_cash
+        self.assertAlmostEqual(metrics["total_return_rate"], 0.2)
+
+    def test_prepare_pdf_data_has_trades(self):
+        """Verify PDF data includes trade records."""
+        from trader.export import prepare_pdf_data
+
+        result = self._make_result()
+        pdf_data = prepare_pdf_data(result)
+        self.assertIn("trades", pdf_data)
+        self.assertEqual(len(pdf_data["trades"]), 2)
+
+    def test_prepare_pdf_data_empty_trades(self):
+        """Verify PDF data handles empty trades gracefully."""
+        from trader.export import prepare_pdf_data
+
+        result = self._make_result(trades_list=[])
+        pdf_data = prepare_pdf_data(result)
+        self.assertEqual(pdf_data["trades"], [])
+
+    def test_prepare_pdf_data_empty_history(self):
+        """Verify PDF data with empty history has zero drawdown."""
+        from trader.export import prepare_pdf_data
+
+        result = self._make_result(history=[])
+        pdf_data = prepare_pdf_data(result)
+        self.assertEqual(pdf_data["metrics"]["max_drawdown"], 0.0)
+        self.assertEqual(pdf_data["metrics"]["sharpe_ratio"], 0.0)
+
+    def test_prepare_pdf_data_init_cash_zero(self):
+        """Verify PDF data handles zero init_cash without division errors."""
+        from trader.export import prepare_pdf_data
+
+        result = self._make_result(init_cash=0)
+        pdf_data = prepare_pdf_data(result)
+        self.assertEqual(pdf_data["metrics"]["total_return_rate"], 0.0)
+        self.assertEqual(pdf_data["metrics"]["annualized_return"], 0.0)
+
+    def test_prepare_pdf_data_single_day_history(self):
+        """Verify PDF data handles single history entry (no daily returns)."""
+        from trader.export import prepare_pdf_data
+
+        result = self._make_result(history=[{"date": "2023-01-10", "total_value": 100000.0}])
+        pdf_data = prepare_pdf_data(result)
+        # sharpe needs at least 2 history points
+        self.assertEqual(pdf_data["metrics"]["sharpe_ratio"], 0.0)
+
+    def test_prepare_pdf_data_max_drawdown_calculation(self):
+        """Verify max_drawdown is correctly calculated from history."""
+        from trader.export import prepare_pdf_data
+
+        # History with a peak then a drop
+        result = self._make_result(history=[
+            {"date": "2023-01-01", "total_value": 100000.0},
+            {"date": "2023-03-01", "total_value": 120000.0},  # peak
+            {"date": "2023-06-01", "total_value": 90000.0},   # 25% drawdown
+            {"date": "2023-09-01", "total_value": 110000.0},
+        ])
+        pdf_data = prepare_pdf_data(result)
+        # Max drawdown = (120000 - 90000) / 120000 = 0.25
+        self.assertAlmostEqual(pdf_data["metrics"]["max_drawdown"], 0.25, places=4)
+
+    def test_prepare_pdf_data_minimal_result(self):
+        """Verify prepare_pdf_data handles a dict with only symbol."""
+        from trader.export import prepare_pdf_data
+
+        minimal = {"symbol": "TEST"}
+        pdf_data = prepare_pdf_data(minimal)
+        self.assertEqual(pdf_data["summary"]["symbol"], "TEST")
+        self.assertEqual(pdf_data["summary"]["strategy_name"], "")
+
+
+class TestGenerateFilename(unittest.TestCase):
+    """Test generate_filename() — output file naming."""
+
+    def test_generate_filename_basic(self):
+        """Verify basic filename format."""
+        from trader.export import generate_filename
+
+        name = generate_filename("600900", "mean_cost", "20230101", "20231231")
+        self.assertEqual(name, "600900_mean_cost_20230101_20231231.xlsx")
+
+    def test_generate_filename_pdf_ext(self):
+        """Verify PDF extension works."""
+        from trader.export import generate_filename
+
+        name = generate_filename("600900", "sma", "20230101", "20231231", ext="pdf")
+        self.assertEqual(name, "600900_sma_20230101_20231231.pdf")
+
+    def test_generate_filename_no_dates(self):
+        """Verify filename without dates."""
+        from trader.export import generate_filename
+
+        name = generate_filename("600900", "mean_cost", "", "")
+        self.assertEqual(name, "600900_mean_cost.xlsx")
+
+    def test_generate_filename_no_strategy(self):
+        """Verify filename falls back when strategy name is empty."""
+        from trader.export import generate_filename
+
+        name = generate_filename("600900", "", "20230101", "20231231")
+        self.assertEqual(name, "600900_backtest_20230101_20231231.xlsx")
+
+    def test_generate_filename_slash_in_strategy(self):
+        """Verify slashes in strategy name are sanitized."""
+        from trader.export import generate_filename
+
+        name = generate_filename("600900", "up/down", "20230101", "20231231")
+        self.assertNotIn("/", name)
+
+    def test_generate_filename_no_ext(self):
+        """Verify default extension is xlsx."""
+        from trader.export import generate_filename
+
+        name = generate_filename("600900", "test", "20230101", "20231231", ext="")
+        # Should just have the trailing dot
+        self.assertTrue(name.endswith("."))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trader/export.py
+++ b/trader/export.py
@@ -1,0 +1,293 @@
+"""回测结果导出模块：提供 Excel 和 PDF 数据导出功能。
+
+职责：
+ - 将回测结果（BacktestResult dict）导出为 .xlsx 文件
+ - 为 PDF 生成准备结构化数据
+
+由 TRADER 维护。
+"""
+
+import os
+from typing import Any, Dict, List, Optional
+
+
+def export_to_excel(
+    backtest_result: Dict[str, Any],
+    output_path: str,
+    strategy_name: str = "",
+) -> str:
+    """将回测结果导出为 .xlsx 文件。
+
+    Args:
+        backtest_result: simulator.run/simulate 返回的完整回测结果字典。
+        output_path: 保存路径（包含 .xlsx 扩展名）。
+        strategy_name: 策略名称，用于文件命名和标识。
+
+    Returns:
+        保存的文件路径。
+
+    Raises:
+        ImportError: 如果 openpyxl 未安装。
+    """
+    import openpyxl
+    from openpyxl.styles import Font, Alignment, PatternFill, Border, Side
+    from openpyxl.utils import get_column_letter
+
+    wb = openpyxl.Workbook()
+
+    symbol = backtest_result.get("symbol", "UNKNOWN")
+    start_date = backtest_result.get("start_date", "")
+    end_date = backtest_result.get("end_date", "")
+    init_cash = backtest_result.get("init_cash", 0)
+    final_cash = backtest_result.get("cash", 0)
+    total_value = backtest_result.get("total_value", 0)
+    realized_pl = backtest_result.get("realized_pl", 0)
+    unrealized_pl = backtest_result.get("unrealized_pl", 0)
+    shares = backtest_result.get("shares", 0)
+    last_price = backtest_result.get("last_price", 0)
+    trades_count = backtest_result.get("trades", 0)
+
+    # 样式定义
+    header_font = Font(bold=True, size=11)
+    header_fill = PatternFill(start_color="4472C4", end_color="4472C4", fill_type="solid")
+    header_font_white = Font(bold=True, size=11, color="FFFFFF")
+    thin_border = Border(
+        left=Side(style="thin"),
+        right=Side(style="thin"),
+        top=Side(style="thin"),
+        bottom=Side(style="thin"),
+    )
+
+    def style_header(ws, cols: int):
+        for col in range(1, cols + 1):
+            cell = ws.cell(row=1, column=col)
+            cell.font = header_font_white
+            cell.fill = header_fill
+            cell.alignment = Alignment(horizontal="center")
+            cell.border = thin_border
+
+    def auto_width(ws, cols: int, max_width: int = 30):
+        for col in range(1, cols + 1):
+            letter = get_column_letter(col)
+            max_len = 0
+            for row in ws.iter_rows(min_col=col, max_col=col, values_only=False):
+                for cell in row:
+                    if cell.value is not None:
+                        max_len = max(max_len, len(str(cell.value)))
+            ws.column_dimensions[letter].width = min(max_len + 3, max_width)
+
+    # ========== Sheet 1: 交易明细 ==========
+    ws_trades = wb.active
+    ws_trades.title = "交易明细"
+
+    trade_headers = ["日期", "方向", "成交价", "数量(股)", "成交后现金", "成交后持仓", "已实现盈亏", "备注"]
+    for col, h in enumerate(trade_headers, 1):
+        ws_trades.cell(row=1, column=col, value=h)
+
+    trades_list = backtest_result.get("trades_list", [])
+    for i, t in enumerate(trades_list, 2):
+        ws_trades.cell(row=i, column=1, value=t.get("date", ""))
+        ws_trades.cell(row=i, column=2, value="买入" if t.get("action") == "buy" else "卖出")
+        ws_trades.cell(row=i, column=3, value=t.get("price", 0))
+        ws_trades.cell(row=i, column=4, value=t.get("shares", 0))
+        ws_trades.cell(row=i, column=5, value=t.get("cash", 0))
+        ws_trades.cell(row=i, column=6, value=t.get("shares_after", 0))
+        ws_trades.cell(row=i, column=7, value=t.get("realized_pl", ""))
+        ws_trades.cell(row=i, column=8, value=t.get("source", ""))
+
+    style_header(ws_trades, len(trade_headers))
+    auto_width(ws_trades, len(trade_headers))
+
+    # ========== Sheet 2: 持仓变化 ==========
+    ws_history = wb.create_sheet("持仓变化")
+
+    history_headers = ["日期", "现金", "持仓(股)", "平均成本", "最新价", "市值", "总资产"]
+    for col, h in enumerate(history_headers, 1):
+        ws_history.cell(row=1, column=col, value=h)
+
+    history = backtest_result.get("history", [])
+    for i, h in enumerate(history, 2):
+        ws_history.cell(row=i, column=1, value=h.get("date", ""))
+        ws_history.cell(row=i, column=2, value=h.get("cash", 0))
+        ws_history.cell(row=i, column=3, value=h.get("shares", 0))
+        ws_history.cell(row=i, column=4, value=h.get("avg_cost", 0))
+        ws_history.cell(row=i, column=5, value=h.get("last_price", 0))
+        ws_history.cell(row=i, column=6, value=h.get("market_value", 0))
+        ws_history.cell(row=i, column=7, value=h.get("total_value", 0))
+
+    style_header(ws_history, len(history_headers))
+    auto_width(ws_history, len(history_headers))
+
+    # ========== Sheet 3: 汇总统计 ==========
+    ws_summary = wb.create_sheet("汇总统计")
+
+    total_pl = realized_pl + unrealized_pl
+    total_return_rate = (total_pl / init_cash * 100) if init_cash else 0
+
+    summary_data = [
+        ("股票代码", symbol),
+        ("策略名称", strategy_name or "N/A"),
+        ("开始日期", start_date),
+        ("结束日期", end_date),
+        ("初始资金", init_cash),
+        ("最终现金", round(final_cash, 2)),
+        ("期末持仓(股)", shares),
+        ("最新价格", last_price),
+        ("持仓市值", round(total_value - final_cash, 2) if total_value >= final_cash else 0),
+        ("总资产", round(total_value, 2)),
+        ("已实现盈亏", round(realized_pl, 2)),
+        ("未实现盈亏", round(unrealized_pl, 2)),
+        ("总盈亏", round(total_pl, 2)),
+        ("总收益率(%)", round(total_return_rate, 2)),
+        ("交易次数", trades_count),
+    ]
+
+    key_fill = PatternFill(start_color="D9E2F3", end_color="D9E2F3", fill_type="solid")
+    for i, (key, val) in enumerate(summary_data, 1):
+        cell_k = ws_summary.cell(row=i, column=1, value=key)
+        cell_v = ws_summary.cell(row=i, column=2, value=val)
+        cell_k.font = header_font
+        cell_k.fill = key_fill
+        cell_k.border = thin_border
+        cell_v.border = thin_border
+
+    ws_summary.column_dimensions["A"].width = 18
+    ws_summary.column_dimensions["B"].width = 20
+
+    # 保存
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    wb.save(output_path)
+    return output_path
+
+
+def prepare_pdf_data(
+    backtest_result: Dict[str, Any],
+    strategy_name: str = "",
+) -> Dict[str, Any]:
+    """从回测结果提取 PDF 所需的结构化数据。
+
+    Args:
+        backtest_result: simulator.run/simulate 返回的完整回测结果字典。
+        strategy_name: 策略名称。
+
+    Returns:
+        包含以下键的字典：
+        - summary: 概要信息（symbol, strategy_name, start_date, end_date, init_cash）
+        - metrics: 关键指标（total_return_rate, annualized_return, max_drawdown, sharpe_ratio, total_pl）
+        - trades: 交易清单
+    """
+    symbol = backtest_result.get("symbol", "UNKNOWN")
+    start_date = backtest_result.get("start_date", "")
+    end_date = backtest_result.get("end_date", "")
+    init_cash = backtest_result.get("init_cash", 0)
+    final_cash = backtest_result.get("cash", 0)
+    total_value = backtest_result.get("total_value", 0)
+    realized_pl = backtest_result.get("realized_pl", 0)
+    unrealized_pl = backtest_result.get("unrealized_pl", 0)
+    trades_list = backtest_result.get("trades_list", [])
+    history = backtest_result.get("history", [])
+
+    total_pl = realized_pl + unrealized_pl
+    total_return_rate = (total_pl / init_cash) if init_cash else 0
+
+    # 计算年化收益率
+    annualized_return = 0.0
+    if start_date and end_date and init_cash > 0:
+        try:
+            from datetime import datetime
+            s = datetime.strptime(start_date, "%Y-%m-%d")
+            e = datetime.strptime(end_date, "%Y-%m-%d")
+            days = (e - s).days
+            if days > 0:
+                annualized_return = (
+                    (total_value / init_cash) ** (365.0 / days) - 1
+                )
+        except (ValueError, ZeroDivisionError):
+            annualized_return = 0.0
+
+    # 计算最大回撤（从 history 计算）
+    max_drawdown = 0.0
+    if history:
+        peak = history[0].get("total_value", init_cash) if history else init_cash
+        peak = max(peak, init_cash)
+        for h in history:
+            tv = h.get("total_value", init_cash)
+            if tv > peak:
+                peak = tv
+            drawdown = (peak - tv) / peak if peak > 0 else 0
+            if drawdown > max_drawdown:
+                max_drawdown = drawdown
+
+    # 近似夏普比率（简单估算）
+    sharpe_ratio = 0.0
+    if history and len(history) >= 2:
+        try:
+            daily_returns = []
+            for i in range(1, len(history)):
+                prev_tv = history[i - 1].get("total_value", init_cash)
+                curr_tv = history[i].get("total_value", init_cash)
+                if prev_tv > 0:
+                    daily_returns.append((curr_tv - prev_tv) / prev_tv)
+            if daily_returns:
+                import statistics
+                avg_return = statistics.mean(daily_returns)
+                std_return = statistics.stdev(daily_returns) if len(daily_returns) > 1 else 0
+                if std_return > 0:
+                    # 假设无风险利率 0.02
+                    sharpe_ratio = (avg_return * 252 - 0.02) / (std_return * (252 ** 0.5))
+        except (ValueError, ZeroDivisionError, IndexError):
+            sharpe_ratio = 0.0
+
+    return {
+        "summary": {
+            "symbol": symbol,
+            "strategy_name": strategy_name,
+            "start_date": start_date,
+            "end_date": end_date,
+            "init_cash": init_cash,
+        },
+        "metrics": {
+            "total_return_rate": round(total_return_rate, 4),
+            "annualized_return": round(annualized_return, 4),
+            "max_drawdown": round(max_drawdown, 4),
+            "sharpe_ratio": round(sharpe_ratio, 4),
+            "total_pl": round(total_pl, 2),
+            "final_value": round(total_value, 2),
+        },
+        "trades": [
+            {
+                "date": t.get("date", ""),
+                "action": "买入" if t.get("action") == "buy" else "卖出",
+                "price": t.get("price", 0),
+                "shares": t.get("shares", 0),
+                "pl": t.get("realized_pl", ""),
+            }
+            for t in trades_list
+        ],
+    }
+
+
+def generate_filename(
+    symbol: str,
+    strategy_name: str,
+    start_date: str,
+    end_date: str,
+    ext: str = "xlsx",
+) -> str:
+    """生成导出文件名。
+
+    Args:
+        symbol: 股票代码。
+        strategy_name: 策略名称。
+        start_date: 开始日期（YYYY-MM-DD）。
+        end_date: 结束日期（YYYY-MM-DD）。
+        ext: 文件扩展名（默认 xlsx）。
+
+    Returns:
+        格式化文件名。
+    """
+    # 清理策略名称中的非法字符
+    safe_name = strategy_name.replace("/", "_").replace("\\", "_") if strategy_name else "backtest"
+    date_part = f"{start_date}_{end_date}" if start_date and end_date else ""
+    parts = [s for s in [symbol, safe_name, date_part] if s]
+    return f"{'_'.join(parts)}.{ext.lstrip('.')}"

--- a/trader/stocks.py
+++ b/trader/stocks.py
@@ -678,6 +678,54 @@ def run_backtest(backtest_request: BacktestRequest | Mapping[str, Any]) -> Dict[
     )
 
 
+# ---------------------------------------------------------------------------
+# 导出接口（回测结果 → Excel / PDF 数据准备）
+# ---------------------------------------------------------------------------
+
+
+def export_backtest_excel(
+    backtest_result: Dict[str, Any],
+    output_dir: str = "trader/exports",
+    strategy_name: str = "",
+) -> str:
+    """将回测结果导出为 Excel 文件。
+
+    Args:
+        backtest_result: simulator 返回的回测结果字典。
+        output_dir: 输出目录（默认 trader/exports）。
+        strategy_name: 策略名称。
+
+    Returns:
+        生成的 Excel 文件路径。
+    """
+    from trader.export import export_to_excel, generate_filename
+
+    symbol = backtest_result.get("symbol", "UNKNOWN")
+    start_date = backtest_result.get("start_date", "")
+    end_date = backtest_result.get("end_date", "")
+    fname = generate_filename(symbol, strategy_name, start_date, end_date, ext="xlsx")
+    output_path = os.path.join(output_dir, fname)
+    return export_to_excel(backtest_result, output_path, strategy_name=strategy_name)
+
+
+def export_prepare_pdf_data(
+    backtest_result: Dict[str, Any],
+    strategy_name: str = "",
+) -> Dict[str, Any]:
+    """准备回测结果的 PDF 导出数据。
+
+    Args:
+        backtest_result: simulator 返回的回测结果字典。
+        strategy_name: 策略名称。
+
+    Returns:
+        包含 summary / metrics / trades 的结构化字典。
+    """
+    from trader.export import prepare_pdf_data
+
+    return prepare_pdf_data(backtest_result, strategy_name=strategy_name)
+
+
 if __name__ == '__main__':
     # 方便开发时直接运行并快速检查
     try:


### PR DESCRIPTION
## 关联 Issue
Closes #110

## 已完成的开发任务

- [x] **TRADER** — 后端数据格式化与 Excel 导出
  - trader/export.py: 生成包含交易明细/持仓/汇总三个 Sheet 的 .xlsx
  - 使用 openpyxl 库
- [x] **WEB** — 前端导出按钮与下载路由
  - gui/web.py: 新增 /download/excel 和 /download/pdf 路由
  - gui/templates/result_mean.html: 添加导出按钮
  - 使用 fpdf2 库生成 PDF

- [x] **Test** — 单元测试 + 集成测试
  - tests/unit/test_export.py: 23 个单元测试
  - tests/integration/test_export_integration.py: 8 个集成测试
  - tests/guitests/test_export_e2e.py: 17 个 GUI 路由测试
  - gui/web.py: 修复 PDF 中文字符（WenQuanYi 字体）

## 执行顺序
trader ✅ → gui ✅ → test ✅