### PR TITLE
P0: 统一回测结果渲染 — feat/115-unified-results

### DIFF
--- a/gui/templates/result_generic.html
+++ b/gui/templates/result_generic.html
@@ -1,0 +1,368 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ strategy_name or "策略" }}回测结果</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/hammerjs@2.0.8"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.min.js"></script>
+    <style>
+      body { font-family: Arial, sans-serif; max-width: 1000px; margin: 2rem auto; padding: 0 1rem; }
+      table { border-collapse: collapse; margin-top: 1rem; width: 100%; }
+      td, th { padding: 6px 10px; border: 1px solid #ddd; }
+      .summary { display:flex; gap:1rem; flex-wrap:wrap; }
+      .card { padding:0.6rem 1rem; border:1px solid #eee; border-radius:6px; }
+      .chart-container { 
+        position: relative; 
+        margin: 1rem 0;
+        padding: 1rem;
+        background: #f9f9f9;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      }
+      .chart-toolbar {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+      }
+      .chart-btn {
+        padding: 0.5rem 1rem;
+        background: #1976d2;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.9rem;
+        transition: background 0.3s;
+      }
+      .chart-btn:hover {
+        background: #1565c0;
+      }
+      .chart-btn:active {
+        background: #0d47a1;
+      }
+      .chart-help {
+        color: #666;
+        font-size: 0.85rem;
+        padding: 0.5rem;
+        background: #fff;
+        border-radius: 4px;
+        border-left: 3px solid #1976d2;
+      }
+      .metrics-grid {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin: 1rem 0;
+      }
+      .metric-card {
+        padding: 0.8rem 1.2rem;
+        border: 1px solid #ddd;
+        border-radius: 6px;
+        background: #fafafa;
+        text-align: center;
+        min-width: 120px;
+      }
+      .metric-card .value {
+        font-size: 1.3rem;
+        font-weight: bold;
+        color: #1976d2;
+      }
+      .metric-card .label {
+        font-size: 0.8rem;
+        color: #666;
+        margin-top: 0.3rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>{{ strategy_name or "策略" }}回测结果</h1>
+    <div class="summary">
+      <div class="card"><strong>代码：</strong> {{ result.symbol }}</div>
+      <div class="card"><strong>日期：</strong> {{ result.start_date }} → {{ result.end_date }}</div>
+      <div class="card"><strong>初始资金：</strong> {{ result.init_cash }}</div>
+      {% if result.max_capital_used is defined %}
+      <div class="card"><strong>最大占用资金：</strong> {{ '%.2f'|format(result.max_capital_used) }}</div>
+      {% endif %}
+      {% if result.market_value is defined %}
+      <div class="card"><strong>总共动用资金：</strong> {{ '%.2f'|format(result.market_value) }}</div>
+      {% endif %}
+      <div class="card"><strong>交易次数：</strong> {{ result.trades }}</div>
+      <div class="card"><strong>最终总资产：</strong> {{ result.total_value }}</div>
+      <div class="card"><strong>已实现盈亏：</strong> {{ result.realized_pl }}</div>
+      <div class="card"><strong>未实现盈亏：</strong> {{ result.unrealized_pl }}</div>
+    </div>
+
+    {% if result.metrics is defined and result.metrics %}
+    <h2>关键指标</h2>
+    <div class="metrics-grid">
+      <div class="metric-card">
+        <div class="value">{{ '%.2f'|format(result.metrics.total_return_rate * 100) }}%</div>
+        <div class="label">总收益率</div>
+      </div>
+      <div class="metric-card">
+        <div class="value">{{ '%.2f'|format(result.metrics.annualized_return * 100) }}%</div>
+        <div class="label">年化收益率</div>
+      </div>
+      <div class="metric-card">
+        <div class="value">{{ '%.2f'|format(result.metrics.max_drawdown * 100) }}%</div>
+        <div class="label">最大回撤</div>
+      </div>
+      <div class="metric-card">
+        <div class="value">{{ '%.2f'|format(result.metrics.sharpe_ratio) }}</div>
+        <div class="label">夏普比率</div>
+      </div>
+      <div class="metric-card">
+        <div class="value">{{ '%.2f'|format(result.metrics.total_pl) }}</div>
+        <div class="label">总盈亏</div>
+      </div>
+    </div>
+    {% endif %}
+
+    <div style="margin: 1rem 0; display: flex; gap: 0.5rem; flex-wrap: wrap;">
+      <form method="post" action="/download/excel" style="display:inline;">
+        <input type="hidden" name="result_json" value='{{ result | tojson | forceescape }}'>
+        <input type="hidden" name="strategy_name" value="{{ strategy_name }}">
+        <button type="submit" style="padding:0.5rem 1rem; background:#2e7d32; color:white; border:none; border-radius:4px; cursor:pointer; font-size:0.9rem;">
+          📥 导出 Excel
+        </button>
+      </form>
+      <form method="post" action="/download/pdf" style="display:inline;">
+        <input type="hidden" name="result_json" value='{{ result | tojson | forceescape }}'>
+        <input type="hidden" name="strategy_name" value="{{ strategy_name }}">
+        <button type="submit" style="padding:0.5rem 1rem; background:#c62828; color:white; border:none; border-radius:4px; cursor:pointer; font-size:0.9rem;">
+          📄 导出 PDF
+        </button>
+      </form>
+    </div>
+
+    <h2>资产曲线</h2>
+    <div class="chart-container">
+      <div class="chart-toolbar">
+        <button class="chart-btn" onclick="resetZoom()">🔄 重置缩放</button>
+        <button class="chart-btn" onclick="downloadChart()">💾 导出图片</button>
+        <div class="chart-help">
+          💡 提示：使用鼠标滚轮缩放，拖拽平移，点击图例切换显示
+        </div>
+      </div>
+      <canvas id="chart" width="900" height="300"></canvas>
+    </div>
+
+    <h2>近 50 笔交易</h2>
+    <table>
+      <tr><th>日期</th><th>动作</th><th>价格</th><th>手数</th><th>交易后现金</th><th>交易后持仓</th><th>已实现盈亏</th></tr>
+      {% if result.trades_list %}
+      {% for t in result.trades_list[-50:] %}
+      <tr>
+        <td>{{ t.date }}</td>
+        <td>{{ t.action }}</td>
+        <td>{{ '%.2f'|format(t.price) }}</td>
+        <td>{{ t.shares }}</td>
+        <td>{{ '%.2f'|format(t.cash) }}</td>
+        <td>{{ t.shares_after }}</td>
+        <td>{% if t.realized_pl is defined %}{{ '%.2f'|format(t.realized_pl) }}{% else %}-{% endif %}</td>
+      </tr>
+      {% endfor %}
+      {% else %}
+      <tr><td colspan="7" style="text-align:center; color:#999;">无交易记录</td></tr>
+      {% endif %}
+    </table>
+
+    <p><a href="/">返回</a></p>
+
+    <script>
+      {% if result.history and result.history|length > 0 %}
+      const labels = [
+        {% for h in result.history %}
+          '{{ h.date }}',
+        {% endfor %}
+      ];
+      const totalValueData = [
+        {% for h in result.history %}
+          {{ h.total_value }},
+        {% endfor %}
+      ];
+      const stockPriceData = [
+        {% for h in result.history %}
+          {{ h.last_price if (h.last_price is not none and h.last_price == h.last_price) else 'null' }},
+        {% endfor %}
+      ];
+
+      // 归一化处理：将股价和总资产都转换为以起点为100的指数形式
+      const normalizedTotalValue = [];
+      const normalizedStockPrice = [];
+      
+      // 找到第一个有效的总资产值作为基准
+      const baseValue = totalValueData[0];
+      
+      if (baseValue === null || baseValue === undefined || baseValue <= 0) {
+        console.error('❌ 无效的基准总资产值:', baseValue);
+        document.getElementById('chart').parentElement.innerHTML = '<p style="color:red">数据错误：无法计算资产变化曲线</p>';
+      } else {
+        // 找到第一个有效的股价作为基准
+        let basePrice = null;
+        for (let i = 0; i < stockPriceData.length; i++) {
+          if (stockPriceData[i] !== null && stockPriceData[i] > 0) {
+            basePrice = stockPriceData[i];
+            break;
+          }
+        }
+        
+        if (basePrice === null) {
+          console.warn('⚠️ 未找到有效的股价数据，仅显示总资产曲线');
+        }
+        
+        // 归一化总资产数据
+        for (let i = 0; i < totalValueData.length; i++) {
+          const value = totalValueData[i];
+          if (value !== null && value !== undefined) {
+            normalizedTotalValue.push((value / baseValue) * 100);
+          } else {
+            normalizedTotalValue.push(null);
+          }
+        }
+        
+        // 归一化股价数据
+        if (basePrice !== null) {
+          for (let i = 0; i < stockPriceData.length; i++) {
+            if (stockPriceData[i] !== null) {
+              normalizedStockPrice.push((stockPriceData[i] / basePrice) * 100);
+            } else {
+              normalizedStockPrice.push(null);
+            }
+          }
+        }
+
+        console.log('📊 图表数据检查:');
+        console.log('总资产数据点数:', totalValueData.length);
+        console.log('股价数据点数:', stockPriceData.length);
+        console.log('归一化后总资产起点:', normalizedTotalValue[0]);
+        console.log('归一化后股价起点:', normalizedStockPrice.find(p => p !== null));
+
+        const ctx = document.getElementById('chart').getContext('2d');
+        const chart = new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: labels,
+            datasets: [{
+              label: '总资产变化',
+              data: normalizedTotalValue,
+              borderColor: 'rgb(75, 192, 192)',
+              backgroundColor: 'rgba(75, 192, 192, 0.1)',
+              tension: 0.1,
+              pointRadius: 0,
+              yAxisID: 'y'
+            }, {
+              label: '股价变化',
+              data: normalizedStockPrice,
+              borderColor: 'rgb(255, 99, 132)',
+              backgroundColor: 'rgba(255, 99, 132, 0.1)',
+              tension: 0.1,
+              pointRadius: 0,
+              yAxisID: 'y'
+            }]
+          },
+          options: {
+            responsive: true,
+            interaction: {
+              mode: 'index',
+              intersect: false
+            },
+            plugins: {
+              legend: {
+                display: true,
+                position: 'top',
+                onClick: function(e, legendItem, legend) {
+                  const index = legendItem.datasetIndex;
+                  const ci = legend.chart;
+                  if (ci.isDatasetVisible(index)) {
+                    ci.hide(index);
+                    legendItem.hidden = true;
+                  } else {
+                    ci.show(index);
+                    legendItem.hidden = false;
+                  }
+                }
+              },
+              tooltip: {
+                callbacks: {
+                  label: function(context) {
+                    const datasetLabel = context.dataset.label;
+                    const value = context.parsed.y;
+                    const index = context.dataIndex;
+                    
+                    if (datasetLabel.includes('总资产')) {
+                      const originalValue = totalValueData[index];
+                      if (originalValue !== null && originalValue !== undefined) {
+                        return datasetLabel + ': ' + value.toFixed(2) + ' (原始: ' + originalValue.toFixed(2) + ' 元)';
+                      } else {
+                        return datasetLabel + ': ' + value.toFixed(2);
+                      }
+                    } else {
+                      const originalPrice = stockPriceData[index];
+                      if (originalPrice !== null && originalPrice !== undefined) {
+                        return datasetLabel + ': ' + value.toFixed(2) + ' (原始: ' + originalPrice.toFixed(2) + ' 元)';
+                      } else {
+                        return datasetLabel + ': 无数据';
+                      }
+                    }
+                  }
+                }
+              },
+              zoom: {
+                zoom: {
+                  wheel: {
+                    enabled: true,
+                    speed: 0.15
+                  },
+                  pinch: {
+                    enabled: true
+                  },
+                  mode: 'x'
+                },
+                pan: {
+                  enabled: true,
+                  mode: 'x',
+                  modifierKey: null
+                },
+                limits: {
+                  x: {min: 'original', max: 'original'},
+                  y: {min: 'original', max: 'original'}
+                }
+              }
+            },
+            scales: {
+              x: { display: true },
+              y: {
+                type: 'linear',
+                display: true,
+                position: 'left',
+                title: {
+                  display: true,
+                  text: '相对变化（起点=100）'
+                }
+              }
+            }
+          }
+        });
+
+        function resetZoom() {
+          chart.resetZoom();
+        }
+
+        function downloadChart() {
+          const url = chart.toBase64Image();
+          const link = document.createElement('a');
+          link.download = '回测结果_{{ result.symbol }}_{{ result.start_date }}.png';
+          link.href = url;
+          link.click();
+        }
+      }
+      {% else %}
+      document.getElementById('chart').parentElement.innerHTML = '<p style="color:#999">无持仓变化数据，无法绘制资产曲线</p>';
+      {% endif %}
+    </script>
+  </body>
+</html>

--- a/gui/web.py
+++ b/gui/web.py
@@ -1020,21 +1020,20 @@ def get_result(task_id):
 
 @app.route('/view_result', methods=['POST'])
 def view_result():
-    """查看回测结果"""
+    """查看回测结果 — 统一使用通用模板"""
     result_json = request.form.get('result_json')
     if not result_json:
-        return render_template('result.html', error='无法获取回测结果')
+        return render_template('result_generic.html', error='无法获取回测结果')
 
     try:
         res = json.loads(result_json)
-        # 使用详细模板显示结果
-        if isinstance(res, dict) and ('trades_list' in res or 'history' in res):
+        if isinstance(res, dict):
             strategy_name = session.get('strategy_name', '')
-            return render_template('result_mean.html', result=res, strategy_name=strategy_name)
+            return render_template('result_generic.html', result=res, strategy_name=strategy_name)
         else:
-            return render_template('result.html', error='回测结果格式不正确')
+            return render_template('result_generic.html', error='回测结果格式不正确')
     except Exception as e:
-        return render_template('result.html', error=f'解析结果失败: {e}')
+        return render_template('result_generic.html', error=f'解析结果失败: {e}')
 
 
 @app.route('/download/excel', methods=['POST'])

--- a/gui/web.py
+++ b/gui/web.py
@@ -1108,9 +1108,29 @@ def download_pdf():
         pdf = FPDF()
         pdf.add_page()
 
-        # Register a Unicode font for Chinese character support
-        _CJK_FONT_PATH = '/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc'
-        if os.path.exists(_CJK_FONT_PATH):
+        # Register a Unicode font for Chinese character support via fontconfig
+        def _find_cjk_font():
+            import subprocess
+            try:
+                result = subprocess.run(
+                    ['fc-match', '-f', '%{file}', 'wqy-zenhei,Noto Sans CJK SC,SimHei,Microsoft YaHei,Droid Sans Fallback'],
+                    capture_output=True, text=True, timeout=5
+                )
+                path = result.stdout.strip()
+                if path and os.path.exists(path):
+                    return path
+            except (subprocess.SubprocessError, FileNotFoundError):
+                pass
+            # fallback: scan known directories
+            for d in ['/usr/share/fonts', '/usr/local/share/fonts', os.path.expanduser('~/.fonts')]:
+                for root, _dirs, files in os.walk(d):
+                    for f in files:
+                        if f.endswith(('.ttc', '.ttf')) and any(k in f.lower() for k in ['wqy', 'noto', 'simhei', 'yahei', 'droid']):
+                            return os.path.join(root, f)
+            return None
+
+        _CJK_FONT_PATH = _find_cjk_font()
+        if _CJK_FONT_PATH:
             pdf.add_font('CJK', '', _CJK_FONT_PATH)
             font_body = 'CJK'
             font_body_bold = 'CJK'

--- a/trader/simulator.py
+++ b/trader/simulator.py
@@ -435,6 +435,64 @@ class BacktestExchangeRunner:
             print(f"收益率: {(total_pl / self.init_cash * 100):.2f}%")
             print(f"{'=' * 100}\n")
 
+        # ---- 计算标准化 metrics ----
+        total_pl = final_summary["realized_pl"] + final_summary["unrealized_pl"]
+        total_return_rate = total_pl / self.init_cash if self.init_cash else 0
+
+        # 年化收益率
+        annualized_return = 0.0
+        try:
+            from datetime import datetime
+            s = datetime.strptime(df["date"].iloc[0].strftime("%Y-%m-%d"), "%Y-%m-%d")
+            e = datetime.strptime(df["date"].iloc[-1].strftime("%Y-%m-%d"), "%Y-%m-%d")
+            days = (e - s).days
+            if days > 0:
+                annualized_return = (
+                    (final_summary["total_value"] / self.init_cash) ** (365.0 / days) - 1
+                )
+        except (ValueError, ZeroDivisionError):
+            annualized_return = 0.0
+
+        # 最大回撤
+        max_drawdown = 0.0
+        if history:
+            peak = max(history[0].get("total_value", self.init_cash), self.init_cash)
+            for h in history:
+                tv = h.get("total_value", self.init_cash)
+                if tv > peak:
+                    peak = tv
+                drawdown = (peak - tv) / peak if peak > 0 else 0
+                if drawdown > max_drawdown:
+                    max_drawdown = drawdown
+
+        # 夏普比率（近似）
+        sharpe_ratio = 0.0
+        if len(history) >= 2:
+            try:
+                import statistics
+                daily_returns = []
+                for i in range(1, len(history)):
+                    prev_tv = history[i - 1].get("total_value", self.init_cash)
+                    curr_tv = history[i].get("total_value", self.init_cash)
+                    if prev_tv > 0:
+                        daily_returns.append((curr_tv - prev_tv) / prev_tv)
+                if daily_returns:
+                    avg = statistics.mean(daily_returns)
+                    std = statistics.stdev(daily_returns) if len(daily_returns) > 1 else 0
+                    if std > 0:
+                        sharpe_ratio = (avg * 252 - 0.02) / (std * (252 ** 0.5))
+            except (ValueError, ZeroDivisionError, IndexError):
+                sharpe_ratio = 0.0
+
+        metrics = {
+            "total_return_rate": round(total_return_rate, 4),
+            "annualized_return": round(annualized_return, 4),
+            "max_drawdown": round(max_drawdown, 4),
+            "sharpe_ratio": round(sharpe_ratio, 4),
+            "total_pl": round(total_pl, 2),
+            "final_value": round(final_summary["total_value"], 2),
+        }
+
         return {
             "symbol": symbol,
             "start_date": df["date"].iloc[0].strftime("%Y-%m-%d"),
@@ -453,6 +511,7 @@ class BacktestExchangeRunner:
             "min_cash": round(min_cash, 2),
             "history": history,
             "trades_list": trades_list,
+            "metrics": metrics,
             "pending_orders_left": len(pending_orders),
             "granularity": granularity,
             "enforce_t_plus_one": enforce_t_plus_one,


### PR DESCRIPTION
## Issue #115: 统一回测结果渲染

### 执行清单
- [x] ARCH 拆解（评论已发）
- [x] **TRADER(T1)**: 标准化回测结果字典 — 确保所有策略返回一致的 history/trades_list/metrics 字段
- [x] **WEB(T2+T3)**: result_mean.html → result_generic.html (通用模板)，view_result() 统一渲染
- [x] **TRADER(T4)**: PDF 字体改用 fontconfig 自动查找
- [x] Self-verify: pytest 通过
- [x] LEAD Review
- [ ] QA 验收
