### PR TITLE
P1: 多策略对比回测 — 同屏对比多个策略的收益率、回撤、夏普率

### DIFF
--- a/gui/templates/backtest_progress.html
+++ b/gui/templates/backtest_progress.html
@@ -233,6 +233,7 @@
         const taskId = '{{ task_id }}';
         const strategy = {{ strategy|tojson }};
         const backUrl = {{ back_url|tojson }};
+        const resultUrl = {{ result_url|default('/view_result')|tojson }};
         const replayDurationMs = 10000;
         let resultData = null;
         let replayFinished = false;
@@ -266,6 +267,17 @@
         }
 
         function buildTradeEntries(result) {
+            // Multi-strategy comparison: show strategy-level summary
+            if (result.strategies) {
+                return [{
+                    kind: 'meta',
+                    title: '多策略对比完成',
+                    time: result.end_date || '',
+                    body: `共 ${result.strategies.length} 个策略参与对比：${
+                        result.strategies.map(s => s.strategy_label || s.strategy_key).join('、')
+                    }`
+                }];
+            }
             const trades = Array.isArray(result.trades_list) ? result.trades_list : [];
             if (!trades.length) {
                 return [{
@@ -387,7 +399,7 @@
             }
             const form = document.createElement('form');
             form.method = 'POST';
-            form.action = '/view_result';
+            form.action = resultUrl;
             const input = document.createElement('input');
             input.type = 'hidden';
             input.name = 'result_json';

--- a/gui/templates/result_compare.html
+++ b/gui/templates/result_compare.html
@@ -1,0 +1,287 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>多策略对比结果 - 量化回测平台</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+      body { font-family: Arial, sans-serif; max-width: 1100px; margin: 2rem auto; padding: 0 1rem; background: #f5f5f5; }
+      h1 { color: #1976d2; text-align: center; }
+      .summary-bar {
+        display: flex; gap: 1rem; flex-wrap: wrap; justify-content: center;
+        background: white; border-radius: 8px; padding: 1rem 1.5rem;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin-bottom: 1.5rem;
+      }
+      .summary-item { text-align: center; }
+      .summary-item .label { font-size: 0.8rem; color: #666; }
+      .summary-item .value { font-size: 1rem; font-weight: bold; color: #1976d2; }
+
+      .chart-container {
+        background: white; border-radius: 8px; padding: 1.5rem;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin-bottom: 1.5rem;
+      }
+      .chart-toolbar { display: flex; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; align-items: center; }
+      .chart-btn {
+        padding: 0.5rem 1rem; background: #1976d2; color: white;
+        border: none; border-radius: 4px; cursor: pointer; font-size: 0.85rem;
+      }
+      .chart-btn:hover { background: #1565c0; }
+      .chart-help { color: #666; font-size: 0.85rem; padding: 0.5rem; background: #f9f9f9; border-radius: 4px; border-left: 3px solid #1976d2; }
+
+      h2 { color: #333; margin-top: 1.5rem; }
+      table { border-collapse: collapse; width: 100%; background: white; box-shadow: 0 2px 4px rgba(0,0,0,0.1); border-radius: 8px; overflow: hidden; }
+      th { background: #1976d2; color: white; padding: 10px 12px; text-align: center; font-size: 0.9rem; }
+      td { padding: 8px 12px; border-bottom: 1px solid #eee; text-align: center; }
+      tr:last-child td { border-bottom: none; }
+      tr:hover td { background: #f5f8ff; }
+      .metric-best { font-weight: bold; color: #2e7d32; }
+      .metric-worst { color: #c62828; }
+      .strategy-header { text-align: left; font-weight: bold; color: #333; }
+
+      .error-msg {
+        background: #fee2e2; color: #b91c1c; padding: 1rem; border-radius: 8px;
+        text-align: center; margin: 2rem 0;
+      }
+
+      .back-link { display: block; text-align: center; margin-top: 2rem; padding: 1rem; }
+      .back-link a { color: #1976d2; text-decoration: none; font-size: 1rem; }
+      .back-link a:hover { text-decoration: underline; }
+
+      @media (max-width: 768px) {
+        table { font-size: 0.85rem; }
+        td, th { padding: 6px 8px; }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>📊 多策略对比回测结果</h1>
+
+    {% if error %}
+    <div class="error-msg">⚠️ {{ error }}</div>
+    <div class="back-link"><a href="/select_strategies_multi">← 返回重新选择策略</a></div>
+    {% else %}
+
+    <div class="summary-bar">
+      <div class="summary-item">
+        <div class="label">股票代码</div>
+        <div class="value">{{ symbol }}</div>
+      </div>
+      <div class="summary-item">
+        <div class="label">回测区间</div>
+        <div class="value">{{ start_date }} → {{ end_date }}</div>
+      </div>
+      <div class="summary-item">
+        <div class="label">参与策略数</div>
+        <div class="value">{{ results|length }}</div>
+      </div>
+    </div>
+
+    <div class="chart-container">
+      <div class="chart-toolbar">
+        <button class="chart-btn" onclick="resetZoom()">🔄 重置缩放</button>
+        <button class="chart-btn" onclick="downloadChart()">💾 导出图片</button>
+        <div class="chart-help">💡 鼠标滚轮缩放，拖拽平移，点击图例切换显示</div>
+      </div>
+      <canvas id="compareChart" width="1000" height="400"></canvas>
+    </div>
+
+    <h2>📋 指标对比</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>策略</th>
+          <th>总收益率</th>
+          <th>年化收益率</th>
+          <th>最大回撤</th>
+          <th>夏普比率</th>
+          <th>总盈亏</th>
+          <th>最终资产</th>
+          <th>交易次数</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for r in results %}
+        {% set metrics = r.get('metrics', {}) %}
+        <tr>
+          <td class="strategy-header">{{ r.get('strategy_label', r.get('strategy_key', '未知')) }}</td>
+          <td class="{{ 'metric-best' if (metrics.get('total_return_rate', 0) | float) == best_return else '' }}">
+            {{ '%.2f'|format((metrics.get('total_return_rate', 0) | float) * 100) if metrics.get('total_return_rate') is defined else '-' }}%
+          </td>
+          <td>{{ '%.2f'|format((metrics.get('annualized_return', 0) | float) * 100) if metrics.get('annualized_return') is defined else '-' }}%</td>
+          <td class="{{ 'metric-best' if (metrics.get('max_drawdown', 0) | float) == best_drawdown else '' }}">
+            {{ '%.2f'|format((metrics.get('max_drawdown', 0) | float) * 100) if metrics.get('max_drawdown') is defined else '-' }}%
+          </td>
+          <td class="{{ 'metric-best' if (metrics.get('sharpe_ratio', 0) | float) == best_sharpe else '' }}">
+            {{ '%.2f'|format(metrics.get('sharpe_ratio', 0) | float) if metrics.get('sharpe_ratio') is defined else '-' }}
+          </td>
+          <td>{{ '%.2f'|format(metrics.get('total_pl', 0) | float) if metrics.get('total_pl') is defined else '-' }}</td>
+          <td>{{ '%.2f'|format(r.get('total_value', r.get('final_cash', 0)) | float) }}</td>
+          <td>{{ r.get('trades', 0) }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <div class="back-link">
+      <a href="/select_strategies_multi">← 返回重新选择策略</a>
+      &nbsp;|&nbsp;
+      <a href="/">🏠 返回首页</a>
+    </div>
+
+    <script>
+      {% set ns = namespace(best_return=-999, best_sharpe=-999, best_drawdown=999) %}
+      {% for r in results %}
+        {% set m = r.get('metrics', {}) %}
+        {% if m.get('total_return_rate') is defined and (m.get('total_return_rate') | float) > ns.best_return %}
+          {% set ns.best_return = (m.get('total_return_rate') | float) %}
+        {% endif %}
+        {% if m.get('sharpe_ratio') is defined and (m.get('sharpe_ratio') | float) > ns.best_sharpe %}
+          {% set ns.best_sharpe = (m.get('sharpe_ratio') | float) %}
+        {% endif %}
+        {% if m.get('max_drawdown') is defined and (m.get('max_drawdown') | float) < ns.best_drawdown %}
+          {% set ns.best_drawdown = (m.get('max_drawdown') | float) %}
+        {% endif %}
+      {% endfor %}
+      // Pass best values to frontend for highlighting
+      const bestReturn = {{ ns.best_return }};
+      const bestSharpe = {{ ns.best_sharpe }};
+      const bestDrawdown = {{ ns.best_drawdown }};
+
+      const colorPalette = [
+        'rgb(25, 118, 210)',
+        'rgb(198, 40, 40)',
+        'rgb(46, 125, 50)',
+        'rgb(255, 160, 0)',
+        'rgb(156, 39, 176)',
+        'rgb(0, 188, 212)',
+        'rgb(233, 30, 99)',
+        'rgb(121, 85, 72)',
+        'rgb(96, 125, 139)',
+        'rgb(255, 87, 34)',
+      ];
+
+      {% if results %}
+      // Build chart datasets from strategy histories
+      const datasets = [];
+      const allLabels = [];
+
+      {% for r in results %}
+      {% if r.get('history') and r['history']|length > 0 %}
+      (function() {
+        const strategyLabel = {{ r.get('strategy_label', r.get('strategy_key', '策略'))|tojson }};
+        const history = {{ r['history']|tojson }};
+        const color = colorPalette[{{ loop.index0 }} % colorPalette.length];
+
+        // Collect labels from this strategy
+        const labels = history.map(h => h.date || '');
+
+        // Normalize to base=100
+        const baseValue = history[0] ? (history[0].total_value || 0) : 1;
+        const values = history.map(h => {
+          const v = h.total_value || 0;
+          return baseValue > 0 ? (v / baseValue) * 100 : 0;
+        });
+
+        // Merge labels
+        labels.forEach((l, i) => {
+          if (allLabels.indexOf(l) === -1) allLabels.push(l);
+        });
+
+        datasets.push({
+          label: strategyLabel,
+          data: values,
+          borderColor: color,
+          backgroundColor: color.replace('rgb', 'rgba').replace(')', ', 0.1)'),
+          tension: 0.1,
+          pointRadius: 0,
+          fill: false,
+          yAxisID: 'y',
+        });
+      })();
+      {% endif %}
+      {% endfor %}
+
+      // Sort labels chronologically
+      allLabels.sort();
+
+      // Reindex data to match allLabels
+      {% for r in results %}
+      {% if r.get('history') and r['history']|length > 0 %}
+      (function() {
+        const history = {{ r['history']|tojson }};
+        const baseValue = history[0] ? (history[0].total_value || 0) : 1;
+        const dataMap = {};
+        history.forEach(h => {
+          const v = h.total_value || 0;
+          dataMap[h.date] = baseValue > 0 ? (v / baseValue) * 100 : 0;
+        });
+        const idx = datasets.length - 1;
+        datasets[idx].data = allLabels.map(date => dataMap[date] !== undefined ? dataMap[date] : null);
+      })();
+      {% endif %}
+      {% endfor %}
+
+      if (datasets.length > 0) {
+        const ctx = document.getElementById('compareChart').getContext('2d');
+        const chart = new Chart(ctx, {
+          type: 'line',
+          data: {
+            labels: allLabels,
+            datasets: datasets,
+          },
+          options: {
+            responsive: true,
+            interaction: { mode: 'index', intersect: false },
+            plugins: {
+              legend: { display: true, position: 'top' },
+              tooltip: {
+                callbacks: {
+                  label: function(context) {
+                    const val = context.parsed.y;
+                    return context.dataset.label + ': ' + (val !== null ? val.toFixed(2) : 'N/A') + ' (起点=100)';
+                  }
+                }
+              }
+            },
+            scales: {
+              x: {
+                display: true,
+                ticks: {
+                  maxTicksLimit: 20,
+                  maxRotation: 45,
+                }
+              },
+              y: {
+                type: 'linear',
+                display: true,
+                position: 'left',
+                title: { display: true, text: '归一化资产（起点=100）' }
+              }
+            }
+          }
+        });
+
+        window.compareChart = chart;
+
+        function resetZoom() {
+          if (chart.resetZoom) chart.resetZoom();
+        }
+
+        function downloadChart() {
+          const url = chart.toBase64Image();
+          const link = document.createElement('a');
+          link.download = '多策略对比_{{ symbol }}_{{ start_date }}.png';
+          link.href = url;
+          link.click();
+        }
+      } else {
+        document.getElementById('compareChart').parentElement.innerHTML = '<p style="color:#999;text-align:center;padding:2rem;">无资产曲线数据</p>';
+      }
+      {% else %}
+      document.getElementById('compareChart').parentElement.innerHTML = '<p style="color:#999;text-align:center;padding:2rem;">无回测结果数据</p>';
+      {% endif %}
+    </script>
+    {% endif %}
+  </body>
+</html>

--- a/gui/templates/select_strategies_multi.html
+++ b/gui/templates/select_strategies_multi.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>多策略对比 - 量化回测平台</title>
+    <style>
+      body { font-family: Arial, sans-serif; max-width: 1000px; margin: 2rem auto; padding: 0 1rem; background: #f5f5f5; }
+      .header {
+        text-align: center;
+        margin-bottom: 1.5rem;
+      }
+      .header h1 { color: #1976d2; margin-bottom: 0.5rem; }
+      .header p { color: #666; font-size: 1.1rem; }
+      .stock-info-bar {
+        background: white;
+        border-radius: 8px;
+        padding: 1rem 1.5rem;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        margin-bottom: 2rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .stock-info-bar .stock-label { color: #666; font-size: 0.9rem; }
+      .stock-info-bar .stock-value { color: #1976d2; font-weight: bold; font-size: 1.2rem; margin-top: 0.25rem; }
+      .stock-info-bar .change-btn {
+        padding: 0.5rem 1rem;
+        background: #f5f5f5;
+        color: #1976d2;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.9rem;
+        text-decoration: none;
+        display: inline-block;
+      }
+      .stock-info-bar .change-btn:hover { background: #e3f2fd; border-color: #1976d2; }
+      .strategy-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1.5rem;
+        margin: 2rem 0;
+      }
+      .strategy-card {
+        border: 2px solid #ddd;
+        border-radius: 8px;
+        padding: 1.5rem;
+        background: white;
+        cursor: pointer;
+        transition: all 0.3s;
+        position: relative;
+      }
+      .strategy-card:hover { box-shadow: 0 4px 8px rgba(0,0,0,0.1); transform: translateY(-2px); }
+      .strategy-card.selected {
+        border-color: #1976d2;
+        background: #e3f2fd;
+      }
+      .strategy-card h3 { margin-top: 0; color: #1976d2; }
+      .strategy-card p { margin: 0.5rem 0; color: #666; line-height: 1.6; }
+      .strategy-card .checkmark {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        width: 24px;
+        height: 24px;
+        border: 2px solid #ddd;
+        border-radius: 4px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 14px;
+        color: white;
+        transition: all 0.3s;
+      }
+      .strategy-card.selected .checkmark {
+        background: #1976d2;
+        border-color: #1976d2;
+      }
+      .action-bar {
+        background: white;
+        border-radius: 8px;
+        padding: 1.5rem;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        margin-bottom: 2rem;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 1rem;
+      }
+      .action-bar .selected-count { color: #666; font-size: 0.95rem; }
+      .action-bar .selected-count strong { color: #1976d2; }
+      .btn-primary {
+        padding: 0.7rem 1.5rem;
+        background: #1976d2;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 1rem;
+        transition: background 0.3s;
+      }
+      .btn-primary:hover { background: #1565c0; }
+      .btn-primary:disabled { background: #ccc; cursor: not-allowed; }
+      .btn-secondary {
+        padding: 0.5rem 1rem;
+        background: #f5f5f5;
+        color: #1976d2;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.9rem;
+        text-decoration: none;
+        display: inline-block;
+      }
+      .btn-secondary:hover { background: #e3f2fd; }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <h1>📈 量化回测平台</h1>
+      <p>多策略对比 — 勾选要对比的策略后提交</p>
+    </div>
+
+    <div class="stock-info-bar">
+      <div>
+        <div class="stock-label">已选择股票</div>
+        <div class="stock-value">{{ stock_code }} - {{ stock_name }}</div>
+      </div>
+      <a href="/" class="change-btn">← 重新选择股票</a>
+    </div>
+
+    <div class="action-bar">
+      <div class="selected-count">已选 <strong id="selectedCount">0</strong> 个策略</div>
+      <div>
+        <button class="btn-primary" id="submitBtn" onclick="submitComparison()" disabled>
+          🚀 开始对比回测
+        </button>
+      </div>
+    </div>
+
+    <div class="strategy-grid">
+      {% for strategy in strategy_specs %}
+      <div class="strategy-card" data-key="{{ strategy.key }}" onclick="toggleStrategy(this)">
+        <div class="checkmark">✓</div>
+        <h3>{{ strategy.icon or '📌' }} {{ strategy.label }}策略</h3>
+        <p><strong>{{ strategy.description or '通用量化策略' }}</strong></p>
+        <p>策略标识：{{ strategy.key }}</p>
+      </div>
+      {% endfor %}
+    </div>
+
+    <script>
+      const selectedStrategies = new Set();
+
+      function toggleStrategy(card) {
+        const key = card.dataset.key;
+        if (selectedStrategies.has(key)) {
+          selectedStrategies.delete(key);
+          card.classList.remove('selected');
+        } else {
+          selectedStrategies.add(key);
+          card.classList.add('selected');
+        }
+        updateUI();
+      }
+
+      function updateUI() {
+        const count = selectedStrategies.size;
+        document.getElementById('selectedCount').textContent = count;
+        document.getElementById('submitBtn').disabled = count < 2;
+      }
+
+      function submitComparison() {
+        if (selectedStrategies.size < 2) {
+          alert('请至少选择 2 个策略进行对比');
+          return;
+        }
+
+        const strategyKeys = Array.from(selectedStrategies);
+        const strategyNames = strategyKeys.map(key => {
+          const card = document.querySelector(`.strategy-card[data-key="${key}"]`);
+          return card ? card.querySelector('h3').textContent.trim() : key;
+        });
+
+        // Save selected strategies to session
+        fetch('/api/select_multi_strategies', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            strategies: strategyKeys,
+            strategy_names: strategyNames
+          })
+        })
+        .then(response => response.json())
+        .then(data => {
+          if (data.success) {
+            // Redirect to time range selection for multi-strategy
+            window.location.href = '/select_time_range?mode=compare';
+          } else {
+            alert('提交失败：' + (data.error || '未知错误'));
+          }
+        })
+        .catch(error => {
+          console.error('Error:', error);
+          alert('网络错误，请重试');
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/gui/templates/select_time_range.html
+++ b/gui/templates/select_time_range.html
@@ -646,9 +646,32 @@
         .then(response => response.json())
         .then(data => {
           if (data.success) {
-            // 跳转到策略配置页面（使用tojson过滤器防止XSS）
-            const strategyType = {{ strategy_type | tojson }};
-            window.location.href = '/strategy/' + encodeURIComponent(strategyType);
+            // Check if we're in multi-strategy compare mode
+            const urlParams = new URLSearchParams(window.location.search);
+            const mode = urlParams.get('mode');
+            if (mode === 'compare') {
+              // For multi-strategy, skip config page and go directly to run
+              // Create a hidden form to POST to /run_multi
+              const form = document.createElement('form');
+              form.method = 'POST';
+              form.action = '/run_multi';
+              const hiddenStart = document.createElement('input');
+              hiddenStart.type = 'hidden';
+              hiddenStart.name = 'start';
+              hiddenStart.value = startFormatted;
+              form.appendChild(hiddenStart);
+              const hiddenEnd = document.createElement('input');
+              hiddenEnd.type = 'hidden';
+              hiddenEnd.name = 'end';
+              hiddenEnd.value = endFormatted;
+              form.appendChild(hiddenEnd);
+              document.body.appendChild(form);
+              form.submit();
+            } else {
+              // 跳转到策略配置页面（使用tojson过滤器防止XSS）
+              const strategyType = {{ strategy_type | tojson }};
+              window.location.href = '/strategy/' + encodeURIComponent(strategyType);
+            }
           } else {
             alert('保存时间段失败：' + (data.error || '未知错误'));
           }

--- a/gui/web.py
+++ b/gui/web.py
@@ -1082,6 +1082,20 @@ def view_result_compare():
         # 过滤掉有错误的策略
         valid_results = [s for s in strategies if 'error' not in s]
 
+        # 计算最优指标（用于高亮）
+        best_return = max(
+            [s.get('metrics', {}).get('total_return_rate', -999) for s in valid_results],
+            default=-999
+        )
+        best_sharpe = max(
+            [s.get('metrics', {}).get('sharpe_ratio', -999) for s in valid_results],
+            default=-999
+        )
+        best_drawdown = min(
+            [s.get('metrics', {}).get('max_drawdown', 999) for s in valid_results],
+            default=999
+        )
+
         return render_template(
             'result_compare.html',
             results=valid_results,
@@ -1089,6 +1103,9 @@ def view_result_compare():
             symbol=res.get('symbol', ''),
             start_date=res.get('start_date', ''),
             end_date=res.get('end_date', ''),
+            best_return=best_return,
+            best_sharpe=best_sharpe,
+            best_drawdown=best_drawdown,
             error=None,
         )
     except Exception as e:

--- a/gui/web.py
+++ b/gui/web.py
@@ -578,6 +578,42 @@ def select_strategy_api():
     return jsonify({'success': True})
 
 
+@app.route('/api/select_multi_strategies', methods=['POST'])
+def select_multi_strategies_api():
+    """多策略对比 — 保存选中的策略列表到session"""
+    data = request.get_json()
+    strategies = data.get('strategies', [])
+    strategy_names = data.get('strategy_names', [])
+
+    if not strategies or len(strategies) < 2:
+        return jsonify({'success': False, 'error': '请至少选择 2 个策略'})
+
+    session['multi_strategies'] = strategies
+    session['multi_strategy_names'] = strategy_names
+    session['strategy_type'] = strategies[0]  # fallback
+    session['strategy_name'] = strategy_names[0] if strategy_names else strategies[0]
+
+    return jsonify({'success': True})
+
+
+@app.route('/select_strategies_multi', methods=['GET'])
+def select_strategies_multi():
+    """多策略选择页面 — 勾选多个策略"""
+    stock_code = session.get('stock_code')
+    stock_name = session.get('stock_name')
+
+    if not stock_code or not stock_name:
+        return _render_stock_selection()
+
+    strategy_specs = _list_strategy_specs()
+    return render_template(
+        'select_strategies_multi.html',
+        stock_code=stock_code,
+        stock_name=stock_name,
+        strategy_specs=strategy_specs,
+    )
+
+
 @app.route('/select_strategy', methods=['GET'])
 def select_strategy():
     """策略选择页面"""
@@ -955,6 +991,111 @@ def view_result():
             return render_template('result_generic.html', error='回测结果格式不正确')
     except Exception as e:
         return render_template('result_generic.html', error=f'解析结果失败: {e}')
+
+
+@app.route('/run_multi', methods=['POST'])
+def run_multi():
+    """多策略对比回测入口"""
+    symbol = session.get('stock_code')
+    if not symbol:
+        symbol = request.form.get('symbol', '600900').strip()
+
+    strategies = session.get('multi_strategies', [])
+    strategy_names = session.get('multi_strategy_names', [])
+
+    if not strategies or len(strategies) < 2:
+        return render_template('result_compare.html',
+                               error='请至少选择 2 个策略进行对比',
+                               strategy_names=[],
+                               results=[])
+
+    form_start = request.form.get('start', '').strip()
+    form_end = request.form.get('end', '').strip()
+
+    start = form_start if form_start else (session.get('backtest_start') or None)
+    end = form_end if form_end else (session.get('backtest_end') or None)
+
+    source = request.form.get('source', 'auto')
+    lot = float(request.form.get('lot') or 100.0)
+    cash = float(request.form.get('cash') or 100000.0)
+
+    progress_mgr = get_progress_manager()
+    task_id = progress_mgr.create_task()
+
+    def progress_callback(current, total):
+        progress_mgr.update_progress(task_id, current, total)
+
+    def run_multi_backtest():
+        try:
+            res = stocks.run_multi_strategy_backtest(
+                symbol=symbol,
+                source=source,
+                start_date=start,
+                end_date=end,
+                lot_size=lot,
+                init_cash=cash,
+                trade_price=stocks.TRADE_PRICE_OPEN,
+                strategies=strategies,
+                progress_callback=progress_callback,
+            )
+
+            if progress_mgr.is_cancelled(task_id):
+                return
+
+            progress_mgr.set_result(task_id, res)
+
+        except Exception as e:
+            progress_mgr.set_error(task_id, str(e))
+
+    if app.testing:
+        run_multi_backtest()
+    else:
+        thread = threading.Thread(target=run_multi_backtest, daemon=True)
+        thread.start()
+
+    return render_template(
+        'backtest_progress.html',
+        task_id=task_id,
+        symbol=symbol,
+        strategy='multi',
+        strategy_label='多策略对比',
+        back_url='/select_strategies_multi',
+        result_url='/view_result_compare',
+    )
+
+
+@app.route('/view_result_compare', methods=['POST'])
+def view_result_compare():
+    """多策略对比结果页面"""
+    result_json = request.form.get('result_json')
+    if not result_json:
+        return render_template('result_compare.html',
+                               error='无法获取回测结果',
+                               strategy_names=[],
+                               results=[])
+
+    try:
+        res = json.loads(result_json)
+        strategies = res.get('strategies', [])
+        strategy_names = [s.get('strategy_label', s.get('strategy_key', '未知')) for s in strategies]
+
+        # 过滤掉有错误的策略
+        valid_results = [s for s in strategies if 'error' not in s]
+
+        return render_template(
+            'result_compare.html',
+            results=valid_results,
+            strategy_names=strategy_names,
+            symbol=res.get('symbol', ''),
+            start_date=res.get('start_date', ''),
+            end_date=res.get('end_date', ''),
+            error=None,
+        )
+    except Exception as e:
+        return render_template('result_compare.html',
+                               error=f'解析结果失败: {e}',
+                               strategy_names=[],
+                               results=[])
 
 
 @app.route('/download/excel', methods=['POST'])

--- a/trader/stocks.py
+++ b/trader/stocks.py
@@ -733,6 +733,147 @@ def export_prepare_pdf_data(
     return prepare_pdf_data(backtest_result, strategy_name=strategy_name)
 
 
+# ---------------------------------------------------------------------------
+# 多策略对比回测
+# ---------------------------------------------------------------------------
+
+
+def run_multi_strategy_backtest(
+    symbol: str = "600900",
+    source: object = "auto",
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    lot_size: float = 100.0,
+    init_cash: float = 100000.0,
+    trade_price: str = TRADE_PRICE_OPEN,
+    strategies: Optional[list[str]] = None,
+    strategies_params: Optional[dict[str, dict[str, Any]]] = None,
+    progress_callback: Optional[Callable[[int, int], None]] = None,
+) -> Dict[str, Any]:
+    """多策略对比回测：一次获取行情数据，多个策略共享运行。
+
+    Args:
+        symbol: 股票代码
+        source: 数据源
+        start_date: 起始日期
+        end_date: 结束日期
+        lot_size: 交易手数
+        init_cash: 初始资金
+        trade_price: 成交价格字段
+        strategies: 策略 key 列表（如 ['sma', 'dual_ma', 'rsi']）
+        strategies_params: 各策略专属参数 {key: {param: value}}
+        progress_callback: 进度回调
+
+    Returns:
+        {
+            'symbol': str,
+            'start_date': str,
+            'end_date': str,
+            'strategies': [
+                {
+                    'key': str,
+                    'label': str,
+                    'metrics': { ... },
+                    'history': [ ... ],
+                    'trades_list': [ ... ],
+                    'init_cash': float,
+                    'final_cash': float,
+                },
+                ...
+            ]
+        }
+    """
+    if not strategies:
+        raise ValueError("strategies 列表不能为空")
+
+    strategies_params = strategies_params or {}
+
+    # 1. 只获取一次行情数据
+    df = _fetch_data_for_backtest(symbol=symbol, source=source, start_date=start_date, end_date=end_date)
+
+    start_date_str = ""
+    end_date_str = ""
+    try:
+        import pandas as _pd
+        if not df.empty and 'date' in df.columns:
+            start_date_str = str(_pd.to_datetime(df['date'].iloc[0]).strftime('%Y-%m-%d'))
+            end_date_str = str(_pd.to_datetime(df['date'].iloc[-1]).strftime('%Y-%m-%d'))
+    except Exception:
+        pass
+
+    results: list[dict[str, Any]] = []
+    total = len(strategies)
+
+    for idx, strategy_key in enumerate(strategies):
+        if progress_callback:
+            progress_callback(idx, total)
+
+        spec = get_strategy_spec(strategy_key)
+        params = strategies_params.get(strategy_key, {})
+
+        try:
+            if spec.module_interface and spec.module_name:
+                # 自动注册的策略模块走通用流程
+                from trader.simulator import Simulator
+
+                module = importlib.import_module(spec.module_name)
+
+                validate_parameters = getattr(module, 'validate_strategy_parameters', None)
+                if callable(validate_parameters):
+                    validate_parameters(**params)
+
+                df_copy = df[["date", "open", "high", "low", "close", "volume"]].copy()
+
+                prepare_backtest_data = getattr(module, 'prepare_backtest_data', None)
+                if callable(prepare_backtest_data):
+                    df_copy = prepare_backtest_data(df=df_copy, source=source, **params)
+
+                create_strategy = getattr(module, 'create_strategy', None)
+                if not callable(create_strategy):
+                    raise RuntimeError(f'策略模块 {spec.module_name} 缺少 create_strategy()')
+
+                strategy = create_strategy(df=df_copy, source=source, **params)
+
+                sim = Simulator(lot_size=lot_size, init_cash=init_cash)
+                sim_res = sim.simulate(
+                    df=df_copy,
+                    strategy=strategy,
+                    symbol=symbol,
+                    trade_price=trade_price,
+                )
+                sim_res.setdefault('init_cash', init_cash)
+                sim_res.setdefault('final_cash', sim_res.get('total_value', init_cash))
+            else:
+                # 简单策略 runner
+                sim_res = spec.runner(
+                    symbol=symbol,
+                    start_date=start_date,
+                    end_date=end_date,
+                    lot_size=lot_size,
+                    init_cash=init_cash,
+                    source=source,
+                    trade_price=trade_price,
+                    **params,
+                )
+        except Exception as e:
+            sim_res = {
+                'error': str(e),
+                'symbol': symbol,
+                'init_cash': init_cash,
+            }
+
+        sim_res['strategy_key'] = strategy_key
+        sim_res['strategy_label'] = spec.label
+        results.append(sim_res)
+
+    return {
+        'symbol': symbol,
+        'start_date': start_date_str,
+        'end_date': end_date_str,
+        'strategies': results,
+    }
+
+
 if __name__ == '__main__':
     # 方便开发时直接运行并快速检查
     try:


### PR DESCRIPTION
## 多策略对比回测

实现多策略同屏对比功能，支持同一股票同一时间段跑多个策略并对比结果。

### 子任务

- [x] **ARCH 拆解**: Issue 拆解与数据流设计
- [x] **TRADER (链式 1)**: `trader/stocks.py` 新增 `run_multi_strategy_backtest()` — 一次跑多个策略共享同一份行情数据
- [x] **WEB 前端 (链式 2)**: 多策略选择页面，支持勾选多个策略后一起提交
- [x] **WEB 前端 (链式 3)**: 对比结果页 `result_compare.html` — Chart.js 叠加多条资产曲线 + 指标对比表格
- [ ] **ITEST**: 单元测试
- [x] **QA 验收**: 端到端测试通过

Closes #119
