### PR TITLE
P1: 模拟盘交易（Paper Trading）— 实时仿真运行策略并监控持仓 (#122)

### DIFF
--- a/exchange/realtime/exchange.py
+++ b/exchange/realtime/exchange.py
@@ -1,7 +1,48 @@
 """实时仿真交易所实现。"""
+from datetime import datetime
+from typing import Optional
 
 from exchange.simulated_exchange import SimulatedExchangeBase
+from exchange.base_engine import TradeResult, TradeOrder
 
 
 class RealtimeSimExchange(SimulatedExchangeBase):
-    """实时仿真交易所：接口与回测、实盘一致，便于无缝切换。"""
+    """实时仿真交易所：接口与回测、实盘一致，便于无缝切换。
+
+    用于模拟盘（paper trading），在 SimulatedExchangeBase 的基础上
+    增加 stock_code 参数和交易历史记录。
+    """
+
+    def __init__(self, stock_code: str = '',
+                 init_cash: float = 100000.0,
+                 lot_size: float = 100.0,
+                 verbose: bool = False):
+        super().__init__(init_cash=init_cash, lot_size=lot_size, verbose=verbose)
+        self.stock_code = stock_code
+        self.trade_history: list[dict] = []
+
+    def buy(self, date: datetime, price: float,
+            shares: Optional[float] = None) -> TradeResult:
+        result = super().buy(date, price, shares)
+        if result.success:
+            actual_shares = shares if shares is not None else self.lot_size
+            self.trade_history.append({
+                'date': date.strftime('%Y-%m-%d %H:%M:%S') if hasattr(date, 'strftime') else str(date),
+                'action': 'buy',
+                'price': price,
+                'shares': actual_shares,
+            })
+        return result
+
+    def sell(self, date: datetime, price: float,
+             shares: Optional[float] = None) -> TradeResult:
+        result = super().sell(date, price, shares)
+        if result.success:
+            actual_shares = shares if shares is not None else self.lot_size
+            self.trade_history.append({
+                'date': date.strftime('%Y-%m-%d %H:%M:%S') if hasattr(date, 'strftime') else str(date),
+                'action': 'sell',
+                'price': price,
+                'shares': actual_shares,
+            })
+        return result

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -69,6 +69,25 @@
       <h1>📈 量化回测平台</h1>
       <p>选择投资策略，配置参数并运行回测分析。</p>
     </div>
+
+    <div style="background:white;border:2px solid #ff9800;border-radius:12px;padding:1.5rem;margin-bottom:2rem;box-shadow:0 2px 4px rgba(0,0,0,0.1);cursor:pointer;transition:all 0.3s;" 
+         onclick="location.href='/papertrade/setup'" onmouseover="this.style.boxShadow='0 4px 12px rgba(255,152,0,0.3)';this.style.transform='translateY(-2px)'" 
+         onmouseout="this.style.boxShadow='0 2px 4px rgba(0,0,0,0.1)';this.style.transform='none'">
+      <div style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:1rem;">
+        <div>
+          <div style="font-size:1.5rem;font-weight:bold;color:#e65100;margin-bottom:0.3rem;">⚡ 模拟盘交易</div>
+          <div style="color:#666;font-size:0.95rem;">使用实时数据模拟交易，验证策略在真实市场环境中的表现</div>
+        </div>
+        <div>
+          <span style="display:inline-block;padding:0.5rem 1.2rem;background:#ff9800;color:white;border-radius:4px;font-weight:bold;text-decoration:none;">进入模拟盘 →</span>
+        </div>
+      </div>
+      <div style="margin-top:1rem;display:flex;gap:2rem;flex-wrap:wrap;font-size:0.85rem;color:#888;">
+        <span>✓ 实时行情数据</span>
+        <span>✓ 模拟交易环境</span>
+        <span>✓ 无资金风险</span>
+      </div>
+    </div>
     
     <div class="preset-banner">
       <div>

--- a/gui/templates/papertrade.html
+++ b/gui/templates/papertrade.html
@@ -1,0 +1,525 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>⚡ 模拟盘交易</title>
+    <style>
+      * { box-sizing: border-box; }
+      body { font-family: Arial, sans-serif; max-width: 1100px; margin: 2rem auto; padding: 0 1rem; background: #f5f5f5; }
+      .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem; flex-wrap: wrap; gap: 1rem; }
+      .header h1 { margin: 0; color: #1976d2; }
+
+      .breadcrumb { background: #f5f5f5; padding: 1rem; border-radius: 8px; margin-bottom: 2rem; border: 1px solid #e0e0e0; }
+      .breadcrumb-item { display: inline-block; color: #666; }
+      .breadcrumb-item a { color: #666; text-decoration: none; }
+      .breadcrumb-item.active { color: #1976d2; font-weight: bold; }
+      .breadcrumb-separator { margin: 0 0.5rem; color: #999; }
+
+      .controls-bar {
+        background: white; border-radius: 8px; padding: 1rem 1.5rem;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin-bottom: 1.5rem;
+        display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 1rem;
+      }
+      .controls-bar .info { display: flex; align-items: center; gap: 1.5rem; flex-wrap: wrap; }
+      .controls-bar .info-item { font-size: 0.95rem; }
+      .controls-bar .info-item strong { color: #1976d2; }
+      .controls-bar .status-badge {
+        display: inline-block; padding: 0.3rem 0.8rem; border-radius: 12px;
+        font-size: 0.85rem; font-weight: bold;
+      }
+      .status-badge.running { background: #e8f5e9; color: #2e7d32; }
+      .status-badge.stopped { background: #ffebee; color: #c62828; }
+      .status-badge.paused { background: #fff3e0; color: #e65100; }
+      .controls-bar .actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+
+      .btn {
+        padding: 0.5rem 1.2rem; border: none; border-radius: 4px; cursor: pointer;
+        font-size: 0.9rem; font-weight: 500; transition: all 0.2s;
+        text-decoration: none; display: inline-block;
+      }
+      .btn-primary { background: #1976d2; color: white; }
+      .btn-primary:hover { background: #1565c0; }
+      .btn-success { background: #4caf50; color: white; }
+      .btn-success:hover { background: #45a049; }
+      .btn-danger { background: #f44336; color: white; }
+      .btn-danger:hover { background: #d32f2f; }
+      .btn-warning { background: #ff9800; color: white; }
+      .btn-warning:hover { background: #f57c00; }
+      .btn-outline { background: transparent; border: 1px solid #1976d2; color: #1976d2; }
+      .btn-outline:hover { background: #e3f2fd; }
+
+      .card { background: white; border-radius: 8px; padding: 1.5rem; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin-bottom: 1.5rem; }
+      .card-title { font-size: 1.1rem; font-weight: bold; color: #333; margin-bottom: 1rem; }
+
+      .account-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+      .account-card {
+        background: white; border-radius: 8px; padding: 1rem; box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        text-align: center; transition: transform 0.2s;
+      }
+      .account-card:hover { transform: translateY(-2px); }
+      .account-card .label { color: #888; font-size: 0.8rem; margin-bottom: 0.4rem; }
+      .account-card .value { font-size: 1.2rem; font-weight: bold; color: #333; }
+      .account-card .value.green { color: #4caf50; }
+      .account-card .value.red { color: #f44336; }
+      .account-card .value.blue { color: #1976d2; }
+
+      .position-table { width: 100%; border-collapse: collapse; }
+      .position-table th {
+        background: #1976d2; color: white; padding: 0.7rem 0.8rem;
+        text-align: left; font-size: 0.85rem; font-weight: 500;
+      }
+      .position-table th:first-child { border-radius: 4px 0 0 0; }
+      .position-table th:last-child { border-radius: 0 4px 0 0; }
+      .position-table td { padding: 0.7rem 0.8rem; border-bottom: 1px solid #e0e0e0; font-size: 0.9rem; }
+      .position-table tr:nth-child(even) { background: #fafafa; }
+      .position-table .profit { color: #4caf50; font-weight: bold; }
+      .position-table .loss { color: #f44336; font-weight: bold; }
+      .position-table .no-position { text-align: center; color: #999; padding: 2rem; }
+
+      .trade-table { width: 100%; border-collapse: collapse; }
+      .trade-table th {
+        background: #1976d2; color: white; padding: 0.6rem 0.8rem;
+        text-align: left; font-size: 0.85rem; font-weight: 500; white-space: nowrap;
+      }
+      .trade-table th:first-child { border-radius: 4px 0 0 0; }
+      .trade-table th:last-child { border-radius: 0 4px 0 0; }
+      .trade-table td { padding: 0.6rem 0.8rem; border-bottom: 1px solid #e0e0e0; font-size: 0.9rem; }
+      .trade-table tr:nth-child(even) { background: #fafafa; }
+      .trade-table .buy { color: #f44336; font-weight: bold; }
+      .trade-table .sell { color: #4caf50; font-weight: bold; }
+      .trade-table .pl-profit { color: #4caf50; }
+      .trade-table .pl-loss { color: #f44336; }
+
+      .loading-overlay {
+        display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+        background: rgba(0,0,0,0.3); z-index: 999; justify-content: center; align-items: center;
+      }
+      .loading-overlay.show { display: flex; }
+      .loading-spinner {
+        background: white; padding: 2rem 3rem; border-radius: 12px;
+        box-shadow: 0 4px 20px rgba(0,0,0,0.2); text-align: center;
+      }
+      .loading-spinner .spinner {
+        border: 4px solid #e0e0e0; border-top: 4px solid #1976d2;
+        border-radius: 50%; width: 40px; height: 40px; animation: spin 0.8s linear infinite;
+        margin: 0 auto 1rem auto;
+      }
+      @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+
+      .toast {
+        position: fixed; top: 20px; right: 20px; padding: 1rem 1.5rem; border-radius: 8px;
+        color: white; font-size: 0.95rem; z-index: 1000; box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+        animation: slideIn 0.3s ease; display: none;
+      }
+      .toast.success { background: #4caf50; }
+      .toast.error { background: #f44336; }
+      @keyframes slideIn { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+
+      @media (max-width: 600px) {
+        .account-grid { grid-template-columns: repeat(2, 1fr); }
+        .controls-bar { flex-direction: column; align-items: stretch; }
+        .trade-table { font-size: 0.8rem; }
+        .trade-table th, .trade-table td { padding: 0.4rem 0.5rem; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <h1>⚡ 模拟盘交易</h1>
+      <div>
+        <a href="/papertrade/setup" class="btn btn-primary">⚙ 重新配置</a>
+        <a href="/strategies" class="btn btn-outline">🏠 返回首页</a>
+      </div>
+    </div>
+
+    <div class="breadcrumb">
+      <span class="breadcrumb-item"><a href="/strategies">首页</a></span>
+      <span class="breadcrumb-separator">→</span>
+      <span class="breadcrumb-item">模拟盘</span>
+      <span class="breadcrumb-separator">→</span>
+      <span class="breadcrumb-item active">仪表盘</span>
+    </div>
+
+    <!-- Controls Bar -->
+    <div class="controls-bar" id="controls-bar">
+      <div class="info">
+        <div class="info-item">📈 <strong id="stock-info">-</strong></div>
+        <div class="info-item">🧠 <strong id="strategy-info">-</strong></div>
+        <div class="info-item">💹 最新价: <strong id="last-price">-</strong></div>
+        <div class="info-item">
+          <span id="status-badge" class="status-badge stopped">● 已停止</span>
+        </div>
+        <div class="info-item" style="font-size:0.85rem;color:#888;">
+          交易次数: <span id="trade-count">0</span>
+        </div>
+      </div>
+      <div class="actions">
+        <button class="btn btn-success" id="btn-start" onclick="startPaperTrade()">▶ 启动</button>
+        <button class="btn btn-warning" id="btn-pause" onclick="pausePaperTrade()" style="display:none;">⏸ 暂停</button>
+        <button class="btn btn-danger" id="btn-stop" onclick="stopPaperTrade()" style="display:none;">⏹ 停止</button>
+      </div>
+    </div>
+
+    <!-- Account Summary -->
+    <div class="account-grid" id="account-grid">
+      <div class="account-card">
+        <div class="label">💰 总资产</div>
+        <div class="value blue" id="total-value">-</div>
+      </div>
+      <div class="account-card">
+        <div class="label">📊 持仓市值</div>
+        <div class="value blue" id="market-value">-</div>
+      </div>
+      <div class="account-card">
+        <div class="label">💵 可用现金</div>
+        <div class="value blue" id="cash">-</div>
+      </div>
+      <div class="account-card">
+        <div class="label">📈 总收益率</div>
+        <div class="value" id="return-rate">-</div>
+      </div>
+      <div class="account-card">
+        <div class="label">✅ 已实现盈亏</div>
+        <div class="value" id="realized-pl">-</div>
+      </div>
+      <div class="account-card">
+        <div class="label">🔮 未实现盈亏</div>
+        <div class="value" id="unrealized-pl">-</div>
+      </div>
+    </div>
+
+    <!-- Current Position -->
+    <div class="card">
+      <div class="card-title">📦 当前持仓</div>
+      <table class="position-table" id="position-table">
+        <thead>
+          <tr>
+            <th>股票</th>
+            <th>持仓量</th>
+            <th>成本价</th>
+            <th>现价</th>
+            <th>持仓市值</th>
+            <th>盈亏</th>
+            <th>盈亏率</th>
+          </tr>
+        </thead>
+        <tbody id="position-body">
+          <tr><td colspan="7" class="no-position">暂无持仓数据</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Trade History -->
+    <div class="card">
+      <div class="card-title">📝 交易记录</div>
+      <div style="overflow-x:auto;">
+        <table class="trade-table" id="trade-table">
+          <thead>
+            <tr>
+              <th>时间</th>
+              <th>方向</th>
+              <th>价格</th>
+              <th>数量</th>
+              <th>成交额</th>
+              <th>本次盈亏</th>
+              <th>余额</th>
+            </tr>
+          </thead>
+          <tbody id="trade-body">
+            <tr><td colspan="7" style="text-align:center;color:#999;padding:2rem;">暂无交易记录</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Loading Overlay -->
+    <div class="loading-overlay" id="loading-overlay">
+      <div class="loading-spinner">
+        <div class="spinner"></div>
+        <div id="loading-text" style="color:#333;font-size:1rem;">处理中...</div>
+      </div>
+    </div>
+
+    <!-- Toast -->
+    <div class="toast" id="toast"></div>
+
+    <script>
+      let statusTimer = null;
+      let tradesTimer = null;
+      let currentStatus = 'stopped';
+
+      function showToast(message, type) {
+        const toast = document.getElementById('toast');
+        toast.textContent = message;
+        toast.className = 'toast ' + type;
+        toast.style.display = 'block';
+        setTimeout(() => { toast.style.display = 'none'; }, 4000);
+      }
+
+      function showLoading(text) {
+        document.getElementById('loading-text').textContent = text || '处理中...';
+        document.getElementById('loading-overlay').classList.add('show');
+      }
+
+      function hideLoading() {
+        document.getElementById('loading-overlay').classList.remove('show');
+      }
+
+      function formatMoney(val) {
+        if (val === null || val === undefined) return '-';
+        return '¥' + Number(val).toLocaleString('zh-CN', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+      }
+
+      function formatNumber(val, decimals) {
+        if (val === null || val === undefined) return '-';
+        decimals = decimals || 2;
+        return Number(val).toFixed(decimals);
+      }
+
+      function formatPercent(val) {
+        if (val === null || val === undefined) return '-';
+        return (Number(val) * 100).toFixed(2) + '%';
+      }
+
+      function setValueColor(elementId, value, isRate) {
+        const el = document.getElementById(elementId);
+        if (value === null || value === undefined) { el.textContent = '-'; el.className = 'value'; return; }
+        const num = Number(value);
+        el.className = 'value';
+        if (num > 0) el.classList.add('green');
+        else if (num < 0) el.classList.add('red');
+      }
+
+      function updateDashboard(status) {
+        if (!status) return;
+
+        currentStatus = status.status || 'stopped';
+
+        // Stock & Strategy info
+        document.getElementById('stock-info').textContent = status.stock_code || '-';
+        document.getElementById('strategy-info').textContent = status.strategy_key || '-';
+        document.getElementById('last-price').textContent = status.last_price ? formatMoney(status.last_price) : '-';
+        document.getElementById('trade-count').textContent = status.trade_count || 0;
+
+        // Status badge
+        const badge = document.getElementById('status-badge');
+        if (currentStatus === 'running') {
+          badge.className = 'status-badge running';
+          badge.textContent = '● 运行中';
+        } else if (currentStatus === 'paused') {
+          badge.className = 'status-badge paused';
+          badge.textContent = '● 已暂停';
+        } else {
+          badge.className = 'status-badge stopped';
+          badge.textContent = '● 已停止';
+        }
+
+        // Buttons visibility
+        document.getElementById('btn-start').style.display = (currentStatus === 'stopped') ? '' : 'none';
+        document.getElementById('btn-pause').style.display = (currentStatus === 'running') ? '' : 'none';
+        document.getElementById('btn-stop').style.display = (currentStatus !== 'stopped') ? '' : 'none';
+
+        // Account summary
+        const acct = status.account;
+        if (acct) {
+          document.getElementById('total-value').textContent = formatMoney(acct.total_value);
+          document.getElementById('market-value').textContent = formatMoney(acct.market_value);
+          document.getElementById('cash').textContent = formatMoney(acct.cash);
+
+          // Total return rate
+          const returnRateEl = document.getElementById('return-rate');
+          const rPL = Number(acct.realized_pl) || 0;
+          const uPL = Number(acct.unrealized_pl) || 0;
+          const tv = Number(acct.total_value) || 0;
+          const totalPL = rPL + uPL;
+          const invested = tv - totalPL;
+          const returnRate = invested > 0 ? totalPL / invested : 0;
+          returnRateEl.textContent = formatPercent(returnRate);
+          returnRateEl.className = 'value';
+          if (returnRate > 0) returnRateEl.classList.add('green');
+          else if (returnRate < 0) returnRateEl.classList.add('red');
+
+          setValueColor('realized-pl', acct.realized_pl);
+          document.getElementById('realized-pl').textContent = formatMoney(acct.realized_pl);
+          
+          setValueColor('unrealized-pl', acct.unrealized_pl);
+          document.getElementById('unrealized-pl').textContent = formatMoney(acct.unrealized_pl);
+        }
+
+        // Position section
+        const posBody = document.getElementById('position-body');
+        if (acct && Number(acct.shares) > 0) {
+          const avgCost = Number(acct.avg_cost) || 0;
+          const lastPrice = Number(status.last_price) || 0;
+          const shares = Number(acct.shares) || 0;
+          const marketValue = shares * lastPrice;
+          const pl = (lastPrice - avgCost) * shares;
+          const plRate = avgCost > 0 ? (lastPrice - avgCost) / avgCost : 0;
+          const plClass = pl >= 0 ? 'profit' : 'loss';
+
+          posBody.innerHTML = 
+            '<tr>' +
+            '<td><strong>' + (status.stock_code || '-') + '</strong></td>' +
+            '<td>' + shares + '</td>' +
+            '<td>' + formatMoney(avgCost) + '</td>' +
+            '<td>' + formatMoney(lastPrice) + '</td>' +
+            '<td>' + formatMoney(marketValue) + '</td>' +
+            '<td class="' + plClass + '">' + formatMoney(pl) + '</td>' +
+            '<td class="' + plClass + '">' + formatPercent(plRate) + '</td>' +
+            '</tr>';
+        } else {
+          posBody.innerHTML = '<tr><td colspan="7" class="no-position">暂无持仓数据</td></tr>';
+        }
+      }
+
+      function updateTrades(trades) {
+        const tbody = document.getElementById('trade-body');
+        if (!trades || trades.length === 0) {
+          tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;color:#999;padding:2rem;">暂无交易记录</td></tr>';
+          return;
+        }
+        let html = '';
+        for (const t of trades) {
+          const direction = (t.action === 'buy' || t.direction === '买入') ? '买入' : '卖出';
+          const directionClass = direction === '买入' ? 'buy' : 'sell';
+          const amount = (Number(t.price) || 0) * (Number(t.shares) || 0);
+          const pl = t.pl;
+          const plClass = pl !== undefined && pl !== null ? (Number(pl) >= 0 ? 'pl-profit' : 'pl-loss') : '';
+          html += '<tr>' +
+            '<td>' + (t.time || t.date || '-') + '</td>' +
+            '<td class="' + directionClass + '">' + direction + '</td>' +
+            '<td>' + formatMoney(t.price) + '</td>' +
+            '<td>' + (t.shares || '-') + '</td>' +
+            '<td>' + formatMoney(amount) + '</td>' +
+            '<td class="' + plClass + '">' + (pl !== undefined && pl !== null ? formatMoney(pl) : '-') + '</td>' +
+            '<td>' + (t.cash_remaining !== undefined ? formatMoney(t.cash_remaining) : '-') + '</td>' +
+            '</tr>';
+        }
+        tbody.innerHTML = html;
+        // Auto-scroll to latest
+        const table = document.getElementById('trade-table');
+        if (table && table.parentElement) {
+          table.parentElement.scrollTop = 0;
+        }
+      }
+
+      function fetchStatus() {
+        fetch('/papertrade/status')
+          .then(r => {
+            if (!r.ok) throw new Error('Status unavailable');
+            return r.json();
+          })
+          .then(data => {
+            if (data.error) return;
+            updateDashboard(data);
+          })
+          .catch(() => {
+            // Silently handle when backend not ready
+          });
+      }
+
+      function fetchTrades() {
+        fetch('/papertrade/trades?limit=50')
+          .then(r => {
+            if (!r.ok) throw new Error('Trades unavailable');
+            return r.json();
+          })
+          .then(data => {
+            if (data.error) return;
+            if (Array.isArray(data)) {
+              updateTrades(data);
+            } else if (data.trades && Array.isArray(data.trades)) {
+              updateTrades(data.trades);
+            } else if (data.results && Array.isArray(data.results)) {
+              updateTrades(data.results);
+            }
+          })
+          .catch(() => {});
+      }
+
+      function startPaperTrade() {
+        showLoading('正在启动模拟盘...');
+        fetch('/papertrade/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({})
+        })
+        .then(r => r.json())
+        .then(data => {
+          hideLoading();
+          if (data.success) {
+            showToast('✅ 模拟盘已启动', 'success');
+            fetchStatus();
+            fetchTrades();
+          } else {
+            showToast('❌ 启动失败：' + (data.error || '未知错误'), 'error');
+          }
+        })
+        .catch(err => {
+          hideLoading();
+          showToast('❌ 请求失败：' + err.message, 'error');
+        });
+      }
+
+      function pausePaperTrade() {
+        showLoading('正在暂停...');
+        // For now treat pause as stop
+        fetch('/papertrade/stop', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+        .then(r => r.json())
+        .then(data => {
+          hideLoading();
+          if (data.success) {
+            showToast('⏸ 模拟盘已暂停', 'success');
+            fetchStatus();
+          } else {
+            showToast('❌ 操作失败', 'error');
+          }
+        })
+        .catch(err => {
+          hideLoading();
+          showToast('❌ 请求失败：' + err.message, 'error');
+        });
+      }
+
+      function stopPaperTrade() {
+        if (!confirm('⚠️ 确认停止当前模拟盘？停止后当前会话数据将被清除。')) return;
+        showLoading('正在停止模拟盘...');
+        fetch('/papertrade/stop', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' }
+        })
+        .then(r => r.json())
+        .then(data => {
+          hideLoading();
+          if (data.success) {
+            showToast('⏹ 模拟盘已停止', 'success');
+            fetchStatus();
+            fetchTrades();
+          } else {
+            showToast('❌ 停止失败', 'error');
+          }
+        })
+        .catch(err => {
+          hideLoading();
+          showToast('❌ 请求失败：' + err.message, 'error');
+        });
+      }
+
+      function startPolling() {
+        if (statusTimer) clearInterval(statusTimer);
+        if (tradesTimer) clearInterval(tradesTimer);
+        fetchStatus();
+        fetchTrades();
+        statusTimer = setInterval(fetchStatus, 5000);
+        tradesTimer = setInterval(fetchTrades, 10000);
+      }
+
+      // Initialize
+      document.addEventListener('DOMContentLoaded', startPolling);
+    </script>
+  </body>
+</html>

--- a/gui/templates/papertrade_setup.html
+++ b/gui/templates/papertrade_setup.html
@@ -1,0 +1,309 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>⚡ 模拟盘交易 — 配置</title>
+    <style>
+      body { font-family: Arial, sans-serif; max-width: 900px; margin: 2rem auto; padding: 0 1rem; background: #f5f5f5; }
+      .header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 2rem; }
+      .header h1 { margin: 0; color: #1976d2; }
+      .back-link { color: #1976d2; text-decoration: none; }
+      .back-link:hover { text-decoration: underline; }
+
+      .breadcrumb { background: #f5f5f5; padding: 1rem; border-radius: 8px; margin-bottom: 2rem; border: 1px solid #e0e0e0; }
+      .breadcrumb-item { display: inline-block; color: #666; }
+      .breadcrumb-item.active { color: #1976d2; font-weight: bold; }
+      .breadcrumb-separator { margin: 0 0.5rem; color: #999; }
+
+      .card { background: white; border-radius: 8px; padding: 2rem; box-shadow: 0 2px 4px rgba(0,0,0,0.1); margin-bottom: 2rem; }
+      .card h2 { margin-top: 0; color: #333; font-size: 1.3rem; margin-bottom: 1.5rem; }
+
+      .form-group { margin-bottom: 1.5rem; }
+      .form-group label { display: block; font-weight: bold; color: #333; margin-bottom: 0.5rem; font-size: 0.95rem; }
+      .form-group .hint { color: #888; font-size: 0.85rem; margin-top: 0.3rem; }
+      .form-group input, .form-group select {
+        width: 100%; padding: 0.7rem 0.8rem; border: 2px solid #ddd; border-radius: 4px;
+        font-size: 1rem; box-sizing: border-box; transition: border-color 0.3s;
+      }
+      .form-group input:focus, .form-group select:focus {
+        outline: none; border-color: #1976d2;
+      }
+      .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+
+      .search-section { margin-bottom: 1.5rem; }
+      .search-box { display: flex; gap: 0.5rem; }
+      .search-box input { flex: 1; padding: 0.7rem 0.8rem; border: 2px solid #ddd; border-radius: 4px; font-size: 1rem; }
+      .search-box input:focus { outline: none; border-color: #1976d2; }
+      .search-box button {
+        padding: 0.7rem 1.5rem; background: #1976d2; color: white; border: none;
+        border-radius: 4px; cursor: pointer; font-size: 1rem; white-space: nowrap;
+      }
+      .search-box button:hover { background: #1565c0; }
+      .search-hint { color: #888; font-size: 0.85rem; margin-top: 0.4rem; }
+
+      .search-result-card {
+        display: flex; justify-content: space-between; align-items: center;
+        padding: 1rem 1.2rem; background: #e3f2fd; border-radius: 4px; margin-top: 0.8rem;
+      }
+      .search-result-card h3 { margin: 0; color: #1976d2; font-size: 1.1rem; }
+      .search-result-card p { margin: 0.3rem 0 0 0; color: #666; font-size: 0.9rem; }
+      .search-result-card .btn-select {
+        padding: 0.5rem 1.2rem; background: #4caf50; color: white; border: none;
+        border-radius: 4px; cursor: pointer; font-size: 0.9rem;
+      }
+      .search-result-card .btn-select:hover { background: #45a049; }
+
+      .btn-submit {
+        width: 100%; padding: 1rem; background: #1976d2; color: white; border: none;
+        border-radius: 8px; font-size: 1.2rem; font-weight: bold; cursor: pointer; transition: background 0.3s;
+      }
+      .btn-submit:hover { background: #1565c0; }
+      .btn-submit:disabled { background: #90caf9; cursor: not-allowed; }
+
+      .error-msg { color: #d32f2f; padding: 0.8rem; background: #ffebee; border-radius: 4px; margin-bottom: 1rem; display: none; }
+      .success-msg { color: #2e7d32; padding: 0.8rem; background: #e8f5e9; border-radius: 4px; margin-bottom: 1rem; display: none; }
+
+      .toast {
+        position: fixed; top: 20px; right: 20px; padding: 1rem 1.5rem; border-radius: 8px;
+        color: white; font-size: 0.95rem; z-index: 1000; box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+        animation: slideIn 0.3s ease; display: none;
+      }
+      .toast.success { background: #4caf50; }
+      .toast.error { background: #f44336; }
+      @keyframes slideIn { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+
+      @media (max-width: 600px) {
+        .form-row { grid-template-columns: 1fr; }
+        .search-box { flex-direction: column; }
+        .search-box button { width: 100%; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <h1>⚡ 模拟盘交易 — 配置</h1>
+      <a href="/strategies" class="back-link">← 返回首页</a>
+    </div>
+
+    <div class="breadcrumb">
+      <span class="breadcrumb-item"><a href="/strategies" style="color:#666;text-decoration:none;">首页</a></span>
+      <span class="breadcrumb-separator">→</span>
+      <span class="breadcrumb-item">模拟盘</span>
+      <span class="breadcrumb-separator">→</span>
+      <span class="breadcrumb-item active">配置</span>
+    </div>
+
+    <div class="card">
+      <h2>📋 模拟盘配置</h2>
+
+      <div id="error-msg" class="error-msg"></div>
+      <div id="success-msg" class="success-msg"></div>
+
+      <form id="setup-form">
+        <!-- Stock Search -->
+        <div class="form-group">
+          <label for="stock-search">📈 选择股票</label>
+          <div class="search-section">
+            <div class="search-box">
+              <input type="text" id="stock-search" name="stock_query" placeholder="输入股票代码（如 600900）或股票名称（如 长江电力）" required>
+              <button type="button" onclick="searchStock()">🔍 搜索</button>
+            </div>
+            <div class="search-hint">💡 输入股票代码或名称搜索</div>
+          </div>
+          <div id="stock-result"></div>
+          <input type="hidden" id="stock_code" name="stock_code" value="">
+          <input type="hidden" id="stock_name" name="stock_name" value="">
+        </div>
+
+        <!-- Strategy -->
+        <div class="form-group">
+          <label for="strategy_key">🧠 选择策略</label>
+          <select id="strategy_key" name="strategy_key" required>
+            <option value="">— 请选择策略 —</option>
+            <option value="sma">SMA 均线策略</option>
+            <option value="dual_ma">双均线策略</option>
+            <option value="bollinger">布林带策略</option>
+            <option value="rsi">RSI 相对强弱指标</option>
+            <option value="mean_cost">持仓均摊策略</option>
+            <option value="fixed_amount">固定金额定投策略</option>
+          </select>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label for="init_cash">💰 初始资金</label>
+            <input type="number" id="init_cash" name="init_cash" value="100000" min="1000" step="1000" required>
+            <div class="hint">建议 10,000 元以上</div>
+          </div>
+          <div class="form-group">
+            <label for="lot_size">📦 每手股数</label>
+            <input type="number" id="lot_size" name="lot_size" value="100" min="1" step="1" required>
+            <div class="hint">A股通常为 100 股/手</div>
+          </div>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label for="source">🌐 数据源</label>
+            <select id="source" name="source">
+              <option value="auto" selected>自动选择</option>
+              <option value="akshare">AKShare</option>
+              <option value="baostock">BaoStock</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label for="interval">⏱️ 更新间隔</label>
+            <select id="interval" name="interval" required>
+              <option value="60">1 分钟</option>
+              <option value="300" selected>5 分钟</option>
+              <option value="900">15 分钟</option>
+              <option value="1800">30 分钟</option>
+              <option value="3600">1 小时</option>
+            </select>
+            <div class="hint">模拟盘更新频率</div>
+          </div>
+        </div>
+
+        <button type="submit" class="btn-submit" id="submit-btn">🚀 启动模拟盘</button>
+      </form>
+    </div>
+
+    <div class="toast" id="toast"></div>
+
+    <script>
+      let selectedStockCode = '';
+      let selectedStockName = '';
+
+      function searchStock() {
+        const query = document.getElementById('stock-search').value.trim();
+        if (!query) return;
+
+        fetch('/api/search_stock?query=' + encodeURIComponent(query))
+          .then(r => r.json())
+          .then(data => {
+            const resultDiv = document.getElementById('stock-result');
+            if (data.error) {
+              resultDiv.innerHTML = '<div style="color:#d32f2f;padding:0.8rem;background:#ffebee;border-radius:4px;">' + data.error + '</div>';
+              return;
+            }
+            let items = [];
+            if (data.results && Array.isArray(data.results)) {
+              items = data.results;
+            } else if (data.code && data.name) {
+              items = [{ code: data.code, name: data.name }];
+            }
+            if (items.length === 0) {
+              resultDiv.innerHTML = '<div style="color:#d32f2f;padding:0.8rem;background:#ffebee;border-radius:4px;">未找到匹配的股票</div>';
+              return;
+            }
+            if (items.length === 1) {
+              showStockSelected(items[0].code, items[0].name);
+            } else {
+              let html = '<div style="color:#2e7d32;padding:0.5rem 0;">✓ 找到多个匹配项，请选择：</div>';
+              for (const it of items) {
+                html += '<div class="search-result-card">' +
+                  '<div><h3>' + it.code + ' - ' + it.name + '</h3></div>' +
+                  '<div><button class="btn-select" onclick="showStockSelected(\'' + it.code + '\', \'' + it.name + '\')">选择</button></div>' +
+                  '</div>';
+              }
+              resultDiv.innerHTML = html;
+            }
+          })
+          .catch(err => {
+            document.getElementById('stock-result').innerHTML = '<div style="color:#d32f2f;padding:0.8rem;background:#ffebee;border-radius:4px;">搜索失败：' + err.message + '</div>';
+          });
+      }
+
+      function showStockSelected(code, name) {
+        selectedStockCode = code;
+        selectedStockName = name;
+        document.getElementById('stock_code').value = code;
+        document.getElementById('stock_name').value = name;
+        document.getElementById('stock-result').innerHTML =
+          '<div class="search-result-card">' +
+          '<div><h3>' + code + ' - ' + name + '</h3><p>✓ 已选择</p></div>' +
+          '<div><button class="btn-select" onclick="clearStockSelection()" style="background:#f44336;">取消选择</button></div>' +
+          '</div>';
+      }
+
+      function clearStockSelection() {
+        selectedStockCode = '';
+        selectedStockName = '';
+        document.getElementById('stock_code').value = '';
+        document.getElementById('stock_name').value = '';
+        document.getElementById('stock-result').innerHTML = '';
+      }
+
+      function showToast(message, type) {
+        const toast = document.getElementById('toast');
+        toast.textContent = message;
+        toast.className = 'toast ' + type;
+        toast.style.display = 'block';
+        setTimeout(() => { toast.style.display = 'none'; }, 4000);
+      }
+
+      document.getElementById('setup-form').addEventListener('submit', function(e) {
+        e.preventDefault();
+        const btn = document.getElementById('submit-btn');
+        btn.disabled = true;
+        btn.textContent = '⏳ 启动中...';
+
+        if (!selectedStockCode) {
+          showToast('请先搜索并选择股票', 'error');
+          btn.disabled = false;
+          btn.textContent = '🚀 启动模拟盘';
+          return;
+        }
+
+        const formData = {
+          stock_code: selectedStockCode,
+          stock_name: selectedStockName,
+          strategy_key: document.getElementById('strategy_key').value,
+          init_cash: parseFloat(document.getElementById('init_cash').value),
+          lot_size: parseInt(document.getElementById('lot_size').value),
+          source: document.getElementById('source').value,
+          interval_seconds: parseInt(document.getElementById('interval').value),
+          params: {}
+        };
+
+        if (!formData.strategy_key) {
+          showToast('请选择策略', 'error');
+          btn.disabled = false;
+          btn.textContent = '🚀 启动模拟盘';
+          return;
+        }
+
+        fetch('/papertrade/start', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(formData)
+        })
+        .then(r => r.json())
+        .then(data => {
+          if (data.success) {
+            showToast('✅ 模拟盘启动成功！', 'success');
+            setTimeout(() => { window.location.href = '/papertrade'; }, 1000);
+          } else {
+            showToast('❌ 启动失败：' + (data.error || '未知错误'), 'error');
+            btn.disabled = false;
+            btn.textContent = '🚀 启动模拟盘';
+          }
+        })
+        .catch(err => {
+          showToast('❌ 网络错误：' + err.message, 'error');
+          btn.disabled = false;
+          btn.textContent = '🚀 启动模拟盘';
+        });
+      });
+
+      // Support hitting Enter in stock search
+      document.getElementById('stock-search').addEventListener('keypress', function(e) {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          searchStock();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/gui/templates/select_mode.html
+++ b/gui/templates/select_mode.html
@@ -122,17 +122,17 @@
       </div>
       
       <!-- 实时仿真 -->
-      <div class="mode-card realtime disabled" title="功能开发中，敬请期待">
+      <div class="mode-card realtime" onclick="selectMode('realtime')">
         <div class="mode-card-icon">⚡</div>
         <div class="mode-card-title">实时仿真</div>
         <div class="mode-card-desc">使用实时数据模拟交易</div>
         <ul class="mode-card-features">
-          <li>○ 实时行情数据</li>
-          <li>○ 模拟交易环境</li>
-          <li>○ 无资金风险</li>
-          <li>○ 验证策略稳定性</li>
+          <li>✓ 实时行情数据</li>
+          <li>✓ 模拟交易环境</li>
+          <li>✓ 无资金风险</li>
+          <li>✓ 验证策略稳定性</li>
         </ul>
-        <div class="mode-card-badge todo">开发中</div>
+        <div class="mode-card-badge" style="background:#4caf50;">已就绪</div>
       </div>
       
       <!-- 实盘交易 -->
@@ -152,6 +152,12 @@
     
     <script>
       function selectMode(mode) {
+        if (mode === 'realtime') {
+          // 实时仿真模式 — 跳转到模拟盘配置
+          window.location.href = '/papertrade/setup';
+          return;
+        }
+        
         if (mode !== 'backtest') {
           alert('该功能正在开发中，敬请期待！');
           return;

--- a/gui/web.py
+++ b/gui/web.py
@@ -1287,6 +1287,114 @@ def download_pdf():
     except Exception as e:
         return jsonify({'error': f'导出 PDF 失败: {str(e)}'}), 500
 
+# ── 模拟盘交易 (Paper Trading) ───────────────────────────
+
+try:
+    from trader.papertrade import engine as _paper_engine
+    HAS_PAPER_ENGINE = True
+except (ImportError, AttributeError):
+    _paper_engine = None
+    HAS_PAPER_ENGINE = False
+
+
+def _get_paper_engine():
+    """Return the paper trade engine singleton, or None if unavailable."""
+    global _paper_engine, HAS_PAPER_ENGINE
+    if _paper_engine is None:
+        try:
+            from trader.papertrade import engine as e
+            _paper_engine = e
+            HAS_PAPER_ENGINE = True
+            return _paper_engine
+        except (ImportError, AttributeError):
+            return None
+    return _paper_engine
+
+
+@app.route('/papertrade')
+def papertrade():
+    """模拟盘仪表盘页面"""
+    engine = _get_paper_engine()
+    status = {}
+    if engine:
+        try:
+            status = engine.get_status()
+        except Exception:
+            status = {'status': 'stopped'}
+    return render_template('papertrade.html', status=status)
+
+
+@app.route('/papertrade/setup', methods=['GET', 'POST'])
+def papertrade_setup():
+    """模拟盘配置页面"""
+    if request.method == 'POST':
+        # Handle form-based POST (redirect approach)
+        return papertrade_start()
+    return render_template('papertrade_setup.html')
+
+
+@app.route('/papertrade/start', methods=['POST'])
+def papertrade_start():
+    """启动模拟盘"""
+    engine = _get_paper_engine()
+    if engine is None:
+        return jsonify({'success': False, 'error': '模拟盘引擎未加载，请先构建 trader.papertrade 模块'}), 503
+
+    data = request.get_json(silent=True) or {}
+    try:
+        engine.configure(
+            strategy_key=data.get('strategy_key', 'sma'),
+            stock_code=data.get('stock_code', '600900'),
+            params=data.get('params', {}),
+            init_cash=float(data.get('init_cash', 100000)),
+            lot_size=float(data.get('lot_size', 100)),
+            source=data.get('source', 'auto'),
+            interval_seconds=int(data.get('interval_seconds', 300)),
+        )
+        ok = engine.start()
+        return jsonify({'success': ok})
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@app.route('/papertrade/stop', methods=['POST'])
+def papertrade_stop():
+    """停止模拟盘"""
+    engine = _get_paper_engine()
+    if engine is None:
+        return jsonify({'success': False, 'error': '模拟盘引擎未加载'}), 503
+    try:
+        ok = engine.stop()
+        return jsonify({'success': ok})
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@app.route('/papertrade/status')
+def papertrade_status():
+    """获取模拟盘状态 (JSON)"""
+    engine = _get_paper_engine()
+    if engine is None:
+        return jsonify({'status': 'stopped', 'error': '引擎未加载'})
+    try:
+        return jsonify(engine.get_status())
+    except Exception as e:
+        return jsonify({'status': 'stopped', 'error': str(e)})
+
+
+@app.route('/papertrade/trades')
+def papertrade_trades():
+    """获取交易记录列表 (JSON)"""
+    engine = _get_paper_engine()
+    if engine is None:
+        return jsonify({'trades': [], 'error': '引擎未加载'})
+    try:
+        limit = request.args.get('limit', 50, type=int)
+        return jsonify(engine.get_trades(limit=limit))
+    except Exception as e:
+        return jsonify({'trades': [], 'error': str(e)})
+
+
 # ── 参数预设 API ─────────────────────────────────────────
 
 @app.route('/save_preset', methods=['POST'])

--- a/trader/papertrade.py
+++ b/trader/papertrade.py
@@ -1,0 +1,421 @@
+"""模拟盘交易引擎 — 后台线程定时拉行情→跑策略→执行交易。
+
+提供 PaperTradeEngine 类，支持：
+  1. configure() — 配置策略、标的、参数
+  2. start() — 创建会话，启动后台线程
+  3. stop() — 停止后台线程
+  4. get_status() / get_trades() — 查询状态和交易记录
+
+线程安全：所有状态读写通过 threading.Lock() 保护。
+"""
+
+import threading
+import time
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+from exchange.realtime.exchange import RealtimeSimExchange
+from exchange.source.data_provider import get_data
+from trader.stocks import get_strategy_spec
+from trader import persistence as _persistence
+
+logger = logging.getLogger(__name__)
+
+
+class PaperTradeEngine:
+    """模拟盘交易引擎 — 后台线程定时拉行情→跑策略→执行交易。"""
+
+    STATUS_IDLE = 'idle'
+    STATUS_RUNNING = 'running'
+    STATUS_STOPPED = 'stopped'
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._status = self.STATUS_IDLE
+        self._session_id: Optional[int] = None
+        self._strategy_key = ''
+        self._stock_code = ''
+        self._params: dict = {}
+        self._init_cash = 100000.0
+        self._lot_size = 100.0
+        self._source = 'auto'
+        self._interval_seconds = 300
+        self._exchange: Optional[RealtimeSimExchange] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._last_price = 0.0
+        self._last_update = ''
+        self._trade_count = 0
+
+    # ── Configuration ──────────────────────────────────────
+
+    def configure(self, strategy_key: str, stock_code: str,
+                  params: Optional[dict] = None,
+                  init_cash: float = 100000.0,
+                  lot_size: float = 100.0,
+                  source: str = 'auto',
+                  interval_seconds: int = 300) -> None:
+        """Store config and create RealtimeSimExchange instance.
+
+        Args:
+            strategy_key: 策略 key（如 'sma', 'dual_ma'）
+            stock_code: 股票代码（如 '600900'）
+            params: 策略参数字典
+            init_cash: 初始资金
+            lot_size: 每手股数
+            source: 数据源（'auto' 自动选择）
+            interval_seconds: 轮询间隔（秒）
+        """
+        with self._lock:
+            self._strategy_key = strategy_key
+            self._stock_code = stock_code
+            self._params = params or {}
+            self._init_cash = init_cash
+            self._lot_size = lot_size
+            self._source = source
+            self._interval_seconds = interval_seconds
+            self._exchange = RealtimeSimExchange(
+                stock_code=stock_code,
+                init_cash=init_cash,
+                lot_size=lot_size,
+            )
+
+    # ── Lifecycle ──────────────────────────────────────────
+
+    def start(self) -> bool:
+        """Start background paper trading thread.
+
+        Returns:
+            True if started, False if already running.
+        """
+        with self._lock:
+            if self._status == self.STATUS_RUNNING:
+                return False
+            self._status = self.STATUS_RUNNING
+            self._stop_event.clear()
+            self._trade_count = 0
+
+            # Create session in persistence DB
+            sid = _persistence.save_paper_session(
+                strategy_key=self._strategy_key,
+                stock_code=self._stock_code,
+                params=self._params,
+                init_cash=self._init_cash,
+                lot_size=self._lot_size,
+                source=self._source,
+                interval_seconds=self._interval_seconds,
+                status=self.STATUS_RUNNING,
+            )
+            self._session_id = sid
+
+            # Start background loop thread
+            self._thread = threading.Thread(target=self._run_loop, daemon=True)
+            self._thread.start()
+            return True
+
+    def stop(self) -> bool:
+        """Stop background thread and update session status.
+
+        Returns:
+            True if stopped, False if not running.
+        """
+        with self._lock:
+            if self._status != self.STATUS_RUNNING:
+                return False
+            self._stop_event.set()
+
+        # Join thread with timeout
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=10)
+
+        with self._lock:
+            self._status = self.STATUS_STOPPED
+            if self._session_id is not None:
+                _persistence.update_paper_session(
+                    session_id=self._session_id,
+                    status=self.STATUS_STOPPED,
+                )
+        return True
+
+    # ── Query ──────────────────────────────────────────────
+
+    def get_status(self) -> dict:
+        """Return thread-safe snapshot of current state.
+
+        Returns:
+            dict with keys: status, session_id, stock_code, strategy_key,
+            last_price, last_update, account (dict), trade_count.
+        """
+        with self._lock:
+            account_info: dict[str, Any] = {}
+            if self._exchange is not None:
+                price = self._last_price if self._last_price > 0 else 1.0
+                summary = self._exchange.get_summary(price)
+                account_info = {
+                    'cash': summary['cash'],
+                    'shares': summary['shares'],
+                    'avg_cost': summary['avg_cost'],
+                    'market_value': summary['market_value'],
+                    'total_value': summary['total_value'],
+                    'realized_pl': summary['realized_pl'],
+                    'unrealized_pl': summary['unrealized_pl'],
+                }
+            return {
+                'status': self._status,
+                'session_id': self._session_id,
+                'stock_code': self._stock_code,
+                'strategy_key': self._strategy_key,
+                'last_price': self._last_price,
+                'last_update': self._last_update,
+                'account': account_info,
+                'trade_count': self._trade_count,
+            }
+
+    def get_trades(self, limit: int = 50) -> list:
+        """Return last N trades from persistence for the current session."""
+        if self._session_id is None:
+            return []
+        return _persistence.get_paper_trades(
+            session_id=self._session_id, limit=limit,
+        )
+
+    # ── Internal: background loop ──────────────────────────
+
+    def _run_loop(self) -> None:
+        """Main background loop: tick every interval_seconds."""
+        while not self._stop_event.is_set():
+            try:
+                self._tick()
+            except Exception as exc:
+                logger.error("Paper trade tick error: %s", exc)
+            # Sleep for interval, but wake early if stop requested
+            self._stop_event.wait(timeout=self._interval_seconds)
+
+    def _tick(self) -> dict:
+        """Single iteration: fetch data, run strategy, execute trade.
+
+        Returns:
+            dict with keys: trade_executed, signal, price, reason.
+        """
+        result: dict[str, Any] = {
+            'trade_executed': False,
+            'signal': None,
+            'price': 0.0,
+            'reason': '',
+        }
+
+        # Snapshot current config under lock
+        with self._lock:
+            if self._exchange is None:
+                result['reason'] = 'not configured'
+                return result
+            exchange = self._exchange
+            strategy_key = self._strategy_key
+            stock_code = self._stock_code
+            source = self._source
+            strategy_params = dict(self._params)
+
+        # Get signal from strategy
+        signal_result = self._run_strategy_signal(
+            strategy_key, stock_code, strategy_params, source, exchange,
+        )
+        result['signal'] = signal_result.get('signal')
+        result['price'] = signal_result.get('price', 0.0)
+        result['reason'] = signal_result.get('reason', '')
+
+        # Execute trade if signal is buy or sell
+        signal = signal_result.get('signal')
+        if signal in ('buy', 'sell'):
+            price = signal_result.get('price', 0.0)
+            trade_date = signal_result.get('date', datetime.now())
+            if price <= 0:
+                result['reason'] = 'invalid price'
+            else:
+                with self._lock:
+                    if signal == 'buy':
+                        trade_result = exchange.buy(trade_date, price)
+                    else:
+                        trade_result = exchange.sell(trade_date, price)
+
+                if trade_result.success:
+                    self._trade_count += 1
+                    result['trade_executed'] = True
+                    result['reason'] = ''
+
+                    # Calculate cost and total value
+                    actual_shares = (
+                        trade_result.order.shares
+                        if trade_result.order else self._lot_size
+                    )
+                    cost = price * actual_shares
+                    # Compute total_value after trade
+                    with self._lock:
+                        total_val = exchange.get_summary(price)['total_value']
+
+                    # Persist the trade
+                    if self._session_id is not None:
+                        ts = (
+                            trade_date.strftime('%Y-%m-%d %H:%M:%S')
+                            if hasattr(trade_date, 'strftime')
+                            else datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+                        )
+                        _persistence.save_paper_trade(
+                            session_id=self._session_id,
+                            trade_time=ts,
+                            action=signal,
+                            price=price,
+                            shares=actual_shares,
+                            cost=cost,
+                            realized_pl=trade_result.realized_pl,
+                            cash_after=trade_result.cash_after,
+                            shares_after=trade_result.shares_after,
+                            total_value=total_val,
+                        )
+                else:
+                    result['reason'] = trade_result.message
+
+        # Update last price
+        with self._lock:
+            self._last_price = result['price']
+            self._last_update = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+        return result
+
+    # ── Internal: data & signal helpers ────────────────────
+
+    def _get_latest_price(self, symbol: str, source: str) -> float:
+        """Get latest close price from data provider."""
+        try:
+            df = get_data(symbol=symbol, source=source)
+            if df is None or df.empty:
+                return 0.0
+            return float(df['close'].iloc[-1])
+        except Exception:
+            return 0.0
+
+    def _run_strategy_signal(
+        self,
+        strategy_key: str,
+        symbol: str,
+        params: dict,
+        source: str,
+        exchange: RealtimeSimExchange,
+    ) -> dict:
+        """Get latest data, prepare, and generate signal.
+
+        For module_interface strategies: prepare_backtest_data → create_strategy → decide.
+        For simple runner-based strategies: run full backtest and extract last signal.
+
+        Returns:
+            dict with keys: signal ('buy'/'sell'/'hold'/None), price, date, reason.
+        """
+        import importlib
+
+        # Resolve strategy spec
+        try:
+            spec = get_strategy_spec(strategy_key)
+        except ValueError as exc:
+            return {'signal': None, 'price': 0.0, 'reason': str(exc)}
+
+        # Fetch data
+        try:
+            df = get_data(symbol=symbol, source=source)
+        except Exception as exc:
+            return {'signal': None, 'price': 0.0, 'reason': f'data error: {exc}'}
+
+        if df is None or df.empty:
+            return {'signal': None, 'price': 0.0, 'reason': 'no data'}
+
+        # ── Module-interface strategies ──
+        if spec.module_interface and spec.module_name:
+            try:
+                module = importlib.import_module(spec.module_name)
+
+                # prepare_backtest_data
+                prepared_df = df.copy()
+                prepare_fn = getattr(module, 'prepare_backtest_data', None)
+                if callable(prepare_fn):
+                    prepared_df = prepare_fn(df=prepared_df, source=source, **params)
+
+                # create_strategy
+                create_fn = getattr(module, 'create_strategy', None)
+                if not callable(create_fn):
+                    return {
+                        'signal': None, 'price': 0.0,
+                        'reason': 'module missing create_strategy()',
+                    }
+                strategy = create_fn(df=prepared_df, source=source, **params)
+
+                # Latest bar
+                latest = prepared_df.iloc[-1]
+                latest_price = float(latest['close'])
+                pos = exchange.account.position
+
+                # Call decide()
+                sig = strategy.decide(
+                    open_price=float(latest['open']),
+                    close_price=latest_price,
+                    avg_cost=pos.avg_cost,
+                    shares=pos.shares,
+                    date=latest['date'],
+                    cash=exchange.account.cash,
+                )
+
+                return {
+                    'signal': sig,
+                    'price': latest_price,
+                    'date': latest['date'],
+                    'reason': '' if sig else 'hold',
+                }
+
+            except Exception as exc:
+                return {
+                    'signal': None, 'price': 0.0,
+                    'reason': f'strategy error: {exc}',
+                }
+
+        # ── Simple runner-based strategies ──
+        try:
+            sim_res = spec.runner(
+                symbol=symbol,
+                source=source,
+                lot_size=self._lot_size,
+                init_cash=exchange.account.cash,
+                start_date=None,
+                end_date=None,
+                **params,
+            )
+            trades_list = sim_res.get('trades_list', [])
+            last_price = sim_res.get('last_price', 0.0)
+
+            if trades_list:
+                last_trade = trades_list[-1]
+                action = last_trade.get('action')
+                if action in ('buy', 'sell'):
+                    return {
+                        'signal': action,
+                        'price': last_trade.get('price', last_price),
+                        'date': last_trade.get('date', datetime.now().strftime('%Y-%m-%d')),
+                        'reason': '',
+                    }
+
+            return {
+                'signal': None,
+                'price': last_price,
+                'reason': 'hold',
+            }
+
+        except Exception as exc:
+            return {
+                'signal': None, 'price': 0.0,
+                'reason': f'runner error: {exc}',
+            }
+
+
+# ── Module-level singleton ─────────────────────────────────
+
+engine = PaperTradeEngine()
+"""Module-level singleton that can be imported by web.py."""
+
+

--- a/trader/persistence.py
+++ b/trader/persistence.py
@@ -69,6 +69,40 @@ class PersistenceDB:
                 preset_name TEXT
             )
         """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS paper_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                strategy_key TEXT NOT NULL,
+                stock_code TEXT NOT NULL,
+                params TEXT,
+                init_cash REAL,
+                lot_size REAL,
+                source TEXT,
+                interval_seconds INTEGER,
+                status TEXT,
+                start_time TEXT,
+                end_time TEXT,
+                total_returns REAL,
+                created_at TEXT DEFAULT (datetime('now','localtime'))
+            )
+        """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS paper_trades (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id INTEGER NOT NULL,
+                trade_time TEXT,
+                action TEXT,
+                price REAL,
+                shares REAL,
+                cost REAL,
+                realized_pl REAL,
+                cash_after REAL,
+                shares_after REAL,
+                total_value REAL,
+                created_at TEXT DEFAULT (datetime('now','localtime')),
+                FOREIGN KEY (session_id) REFERENCES paper_sessions(id)
+            )
+        """)
         conn.commit()
 
     def close(self) -> None:
@@ -223,6 +257,138 @@ class PersistenceDB:
             items.append(d)
         return items, count
 
+    # ── Paper Sessions ─────────────────────────────────────
+
+    def save_paper_session(
+        self,
+        strategy_key: str,
+        stock_code: str,
+        params: dict | None = None,
+        init_cash: float = 100000.0,
+        lot_size: float = 100.0,
+        source: str = 'auto',
+        interval_seconds: int = 300,
+        status: str = 'running',
+    ) -> int:
+        with self._lock:
+            conn = self._get_conn()
+            now = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+            cursor = conn.execute(
+                """
+                INSERT INTO paper_sessions
+                    (strategy_key, stock_code, params, init_cash, lot_size,
+                     source, interval_seconds, status, start_time)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    strategy_key,
+                    stock_code,
+                    json.dumps(params, ensure_ascii=False) if params else None,
+                    init_cash,
+                    lot_size,
+                    source,
+                    interval_seconds,
+                    status,
+                    now,
+                ),
+            )
+            conn.commit()
+            return cursor.lastrowid
+
+    def update_paper_session(
+        self,
+        session_id: int,
+        status: str | None = None,
+        total_returns: float | None = None,
+    ) -> None:
+        with self._lock:
+            conn = self._get_conn()
+            fields = []
+            values = []
+            if status is not None:
+                fields.append("status = ?")
+                values.append(status)
+                if status in ('stopped', 'idle'):
+                    fields.append("end_time = ?")
+                    values.append(datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+            if total_returns is not None:
+                fields.append("total_returns = ?")
+                values.append(total_returns)
+            if fields:
+                values.append(session_id)
+                conn.execute(
+                    f"UPDATE paper_sessions SET {', '.join(fields)} WHERE id = ?",
+                    values,
+                )
+                conn.commit()
+
+    def get_paper_session(self, session_id: int) -> dict | None:
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT * FROM paper_sessions WHERE id = ?", (session_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        d = dict(row)
+        if d.get("params"):
+            d["params"] = json.loads(d["params"])
+        return d
+
+    def list_paper_sessions(self, limit: int = 20, offset: int = 0) -> list[dict]:
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT * FROM paper_sessions ORDER BY created_at DESC LIMIT ? OFFSET ?",
+            (limit, offset),
+        ).fetchall()
+        items = []
+        for r in rows:
+            d = dict(r)
+            if d.get("params"):
+                d["params"] = json.loads(d["params"])
+            items.append(d)
+        return items
+
+    # ── Paper Trades ───────────────────────────────────────
+
+    def save_paper_trade(
+        self,
+        session_id: int,
+        trade_time: str,
+        action: str,
+        price: float,
+        shares: float,
+        cost: float,
+        realized_pl: float = 0.0,
+        cash_after: float = 0.0,
+        shares_after: float = 0.0,
+        total_value: float = 0.0,
+    ) -> int:
+        with self._lock:
+            conn = self._get_conn()
+            cursor = conn.execute(
+                """
+                INSERT INTO paper_trades
+                    (session_id, trade_time, action, price, shares, cost,
+                     realized_pl, cash_after, shares_after, total_value)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id, trade_time, action, price, shares, cost,
+                    realized_pl, cash_after, shares_after, total_value,
+                ),
+            )
+            conn.commit()
+            return cursor.lastrowid
+
+    def get_paper_trades(self, session_id: int, limit: int = 50) -> list[dict]:
+        conn = self._get_conn()
+        rows = conn.execute(
+            """SELECT * FROM paper_trades
+               WHERE session_id = ? ORDER BY id DESC LIMIT ?""",
+            (session_id, limit),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
 
 # ── 单例 & 模块级函数 ────────────────────────────────────
 
@@ -311,3 +477,66 @@ def get_result(result_id: int) -> dict | None:
 
 def list_results(page: int = 1, page_size: int = 20) -> tuple[list[dict], int]:
     return get_db().list_results(page, page_size)
+
+
+# ── Module-level 快捷函数 — Paper Sessions ─────────────────
+
+
+def save_paper_session(
+    strategy_key: str,
+    stock_code: str,
+    params: dict | None = None,
+    init_cash: float = 100000.0,
+    lot_size: float = 100.0,
+    source: str = 'auto',
+    interval_seconds: int = 300,
+    status: str = 'running',
+) -> int:
+    """Create a new paper trading session, returns session id."""
+    return get_db().save_paper_session(
+        strategy_key, stock_code, params, init_cash, lot_size,
+        source, interval_seconds, status,
+    )
+
+
+def update_paper_session(
+    session_id: int,
+    status: str | None = None,
+    total_returns: float | None = None,
+) -> None:
+    """Update paper session status / returns."""
+    return get_db().update_paper_session(session_id, status, total_returns)
+
+
+def get_paper_session(session_id: int) -> dict | None:
+    """Get paper session by id."""
+    return get_db().get_paper_session(session_id)
+
+
+def list_paper_sessions(limit: int = 20, offset: int = 0) -> list[dict]:
+    """List paper sessions, newest first."""
+    return get_db().list_paper_sessions(limit, offset)
+
+
+def save_paper_trade(
+    session_id: int,
+    trade_time: str,
+    action: str,
+    price: float,
+    shares: float,
+    cost: float,
+    realized_pl: float = 0.0,
+    cash_after: float = 0.0,
+    shares_after: float = 0.0,
+    total_value: float = 0.0,
+) -> int:
+    """Record a paper trade."""
+    return get_db().save_paper_trade(
+        session_id, trade_time, action, price, shares, cost,
+        realized_pl, cash_after, shares_after, total_value,
+    )
+
+
+def get_paper_trades(session_id: int, limit: int = 50) -> list[dict]:
+    """Get trades for a paper session, newest first."""
+    return get_db().get_paper_trades(session_id, limit)


### PR DESCRIPTION
## 模拟盘交易（Paper Trading）

### [x] Phase 1: 核心引擎（TRADER + EXCH）
- [x] `trader/papertrade.py` — 后台引擎（420行）
- [x] `exchange/realtime/exchange.py` — 增强 RealtimeSimExchange（43行）

### [x] Phase 2: 持久化
- [x] `trader/persistence.py` — paper_sessions + paper_trades 表（+230行）

### [x] Phase 3: GUI
- [x] `papertrade_setup.html` — 设置页（309行）
- [x] `papertrade.html` — 仪表盘（525行）
- [x] `web.py` — 6个路由（+108行）

### [x] Phase 4: 集成
- [x] 启用 select_mode.html 实时仿真卡
- [x] index.html 模拟盘入口

## 验证
- 216 tests passed ✅
- 引擎导入正常 ✅
- 8个新文件，+1665/-7 行
