### PR TITLE
P0: pip.conf 源顺序修复 — 清华源优先 (#126)

### DIFF
--- a/pip.conf
+++ b/pip.conf
@@ -1,6 +1,6 @@
 [global]
-index-url = https://pypi.org/simple
-extra-index-url = https://pypi.tuna.tsinghua.edu.cn/simple
+index-url = https://pypi.tuna.tsinghua.edu.cn/simple
+extra-index-url = https://pypi.org/simple
 trusted-host = pypi.tuna.tsinghua.edu.cn
 
 [install]


### PR DESCRIPTION
交换 index-url / extra-index-url，使清华源为首选，pypi.org 为备用。