### PR TITLE
P1: 模拟交易添加交易成本 — 佣金/印花税/滑点 (#133)

### DIFF
--- a/exchange/base_engine.py
+++ b/exchange/base_engine.py
@@ -66,16 +66,25 @@ class BaseEngine(ABC):
     - RealEngine: 实盘交易引擎（实际交易，预留）
     """
 
-    def __init__(self, init_cash: float = 100000.0, lot_size: float = 100.0):
+    def __init__(self, init_cash: float = 100000.0, lot_size: float = 100.0,
+                 commission_pct: float = 0.00025, stamp_duty_pct: float = 0.001,
+                 slippage_pct: float = 0.0):
         """初始化交易引擎
 
         Args:
             init_cash: 初始资金
             lot_size: 交易手数（每次买卖的股数）
+            commission_pct: 佣金比例（如 0.00025 表示万分之二点五）
+            stamp_duty_pct: 印花税比例（卖出时收取，如 0.001 表示千分之一）
+            slippage_pct: 滑点比例（如 0.001 表示千分之一）
         """
         self.lot_size = float(lot_size)
         self.account = Account(cash=init_cash)
         self.realized_pl = 0.0  # 累计已实现盈亏
+        self.total_fees = 0.0  # 累计交易费用（佣金 + 印花税）
+        self.commission_pct = commission_pct
+        self.stamp_duty_pct = stamp_duty_pct
+        self.slippage_pct = slippage_pct
 
     @abstractmethod
     def buy(self, date: datetime, price: float) -> TradeResult:
@@ -141,4 +150,5 @@ class BaseEngine(ABC):
             'total_value': round(total_value, 2),
             'realized_pl': round(self.realized_pl, 4),
             'unrealized_pl': round(unrealized_pl, 4),
+            'total_fees': round(self.total_fees, 4),
         }

--- a/exchange/realtime/exchange.py
+++ b/exchange/realtime/exchange.py
@@ -16,8 +16,13 @@ class RealtimeSimExchange(SimulatedExchangeBase):
     def __init__(self, stock_code: str = '',
                  init_cash: float = 100000.0,
                  lot_size: float = 100.0,
-                 verbose: bool = False):
-        super().__init__(init_cash=init_cash, lot_size=lot_size, verbose=verbose)
+                 verbose: bool = False,
+                 commission_pct: float = 0.00025,
+                 stamp_duty_pct: float = 0.001,
+                 slippage_pct: float = 0.0):
+        super().__init__(init_cash=init_cash, lot_size=lot_size, verbose=verbose,
+                         commission_pct=commission_pct, stamp_duty_pct=stamp_duty_pct,
+                         slippage_pct=slippage_pct)
         self.stock_code = stock_code
         self.trade_history: list[dict] = []
 

--- a/exchange/simulated_exchange.py
+++ b/exchange/simulated_exchange.py
@@ -10,8 +10,12 @@ from exchange.exchange_interface import StockExchange
 class SimulatedExchangeBase(StockExchange):
     """仿真类交易所的通用逻辑。"""
 
-    def __init__(self, init_cash: float = 100000.0, lot_size: float = 100.0, verbose: bool = False):
-        super().__init__(init_cash=init_cash, lot_size=lot_size)
+    def __init__(self, init_cash: float = 100000.0, lot_size: float = 100.0, verbose: bool = False,
+                 commission_pct: float = 0.00025, stamp_duty_pct: float = 0.001,
+                 slippage_pct: float = 0.0):
+        super().__init__(init_cash=init_cash, lot_size=lot_size,
+                         commission_pct=commission_pct, stamp_duty_pct=stamp_duty_pct,
+                         slippage_pct=slippage_pct)
         self.verbose = verbose
         self.trade_count = 0
         self.connected = False
@@ -36,38 +40,45 @@ class SimulatedExchangeBase(StockExchange):
                 shares_after=self.account.position.shares,
             )
 
-        cost = price * buy_shares
-        if self.account.cash < cost:
+        # 应用滑点：买入时价格向上偏移（更差的价格）
+        effective_price = price * (1.0 + self.slippage_pct)
+        cost_before_fees = effective_price * buy_shares
+        commission = cost_before_fees * self.commission_pct
+        total_cost = cost_before_fees + commission
+
+        if self.account.cash < total_cost:
             if self.verbose:
-                print(f"[{date.strftime('%Y-%m-%d')}] 买入失败：资金不足 (需要 {cost:.2f}, 可用 {self.account.cash:.2f})")
+                print(f"[{date.strftime('%Y-%m-%d')}] 买入失败：资金不足 (需要 {total_cost:.2f}, 可用 {self.account.cash:.2f})")
             return TradeResult(
                 success=False,
-                message=f"资金不足：需要 {cost:.2f}，可用 {self.account.cash:.2f}",
+                message=f"资金不足：需要 {total_cost:.2f}，可用 {self.account.cash:.2f}",
                 cash_after=self.account.cash,
                 shares_after=self.account.position.shares,
             )
 
-        self.account.cash -= cost
+        self.account.cash -= total_cost
         self.account.position.shares += buy_shares
-        self.account.position.total_cost += cost
+        self.account.position.total_cost += cost_before_fees
         self.account.position.avg_cost = (
             self.account.position.total_cost / self.account.position.shares
             if self.account.position.shares > 0
             else 0.0
         )
+        self.total_fees += commission
         self.trade_count += 1
 
-        order = TradeOrder(date=date, action="buy", price=price, shares=buy_shares)
+        order = TradeOrder(date=date, action="buy", price=effective_price, shares=buy_shares)
 
         if self.verbose:
             print(
-                f"[{date.strftime('%Y-%m-%d')}] 买入成功：价格 {price:.2f}, 数量 {buy_shares}, "
-                f"成本 {cost:.2f}, 剩余现金 {self.account.cash:.2f}"
+                f"[{date.strftime('%Y-%m-%d')}] 买入成功：价格 {effective_price:.2f}, 数量 {buy_shares}, "
+                f"成本 {total_cost:.2f} (佣金 {commission:.2f}), "
+                f"剩余现金 {self.account.cash:.2f}"
             )
 
         return TradeResult(
             success=True,
-            message="买入成功",
+            message=f"买入成功 (佣金 ¥{commission:.2f})",
             order=order,
             cash_after=self.account.cash,
             shares_after=self.account.position.shares,
@@ -97,15 +108,24 @@ class SimulatedExchangeBase(StockExchange):
                 shares_after=self.account.position.shares,
             )
 
-        proceeds = price * sell_shares
+        # 应用滑点：卖出时价格向下偏移（更差的价格）
+        effective_price = price * (1.0 - self.slippage_pct)
+        proceeds_before_fees = effective_price * sell_shares
+        commission = proceeds_before_fees * self.commission_pct
+        stamp_duty = proceeds_before_fees * self.stamp_duty_pct
+        total_fees_this = commission + stamp_duty
+        net_proceeds = proceeds_before_fees - total_fees_this
+
         avg_cost = self.account.position.avg_cost
         cost_reduced = avg_cost * sell_shares
-        realized_pl_this = (price - avg_cost) * sell_shares
+        # 已实现盈亏按净收入计算（已扣除费用）
+        realized_pl_this = net_proceeds - cost_reduced
 
-        self.account.cash += proceeds
+        self.account.cash += net_proceeds
         self.account.position.shares -= sell_shares
         self.account.position.total_cost -= cost_reduced
         self.realized_pl += realized_pl_this
+        self.total_fees += total_fees_this
         self.trade_count += 1
 
         if self.account.position.shares > 0:
@@ -114,18 +134,19 @@ class SimulatedExchangeBase(StockExchange):
             self.account.position.avg_cost = 0.0
             self.account.position.total_cost = 0.0
 
-        order = TradeOrder(date=date, action="sell", price=price, shares=sell_shares)
+        order = TradeOrder(date=date, action="sell", price=effective_price, shares=sell_shares)
 
         if self.verbose:
             print(
-                f"[{date.strftime('%Y-%m-%d')}] 卖出成功：价格 {price:.2f}, 数量 {sell_shares}, "
-                f"收入 {proceeds:.2f}, 本次盈亏 {realized_pl_this:.2f}, "
+                f"[{date.strftime('%Y-%m-%d')}] 卖出成功：价格 {effective_price:.2f}, 数量 {sell_shares}, "
+                f"收入 {net_proceeds:.2f} (佣金 {commission:.2f}, 印花税 {stamp_duty:.2f}), "
+                f"本次盈亏 {realized_pl_this:.2f}, "
                 f"累计盈亏 {self.realized_pl:.2f}, 现金 {self.account.cash:.2f}"
             )
 
         return TradeResult(
             success=True,
-            message="卖出成功",
+            message=f"卖出成功 (佣金 ¥{commission:.2f}, 印花税 ¥{stamp_duty:.2f})",
             order=order,
             cash_after=self.account.cash,
             shares_after=self.account.position.shares,

--- a/tests/unit/test_fixed_amount_strategy.py
+++ b/tests/unit/test_fixed_amount_strategy.py
@@ -171,8 +171,8 @@ class TestFixedAmountSimulation(unittest.TestCase):
         # 5天，每天都能买入 100 股
         self.assertEqual(result['trades'], 5)
         self.assertEqual(result['shares'], 500)  # 5 * 100
-        # 花费：5 * 1000 = 5000
-        self.assertEqual(result['cash'], 100000.0 - 5000.0)
+        # 花费：5 * 1000 + 5 * 佣金0.25 = 5001.25
+        self.assertEqual(result['cash'], 100000.0 - 5001.25)
 
     def test_verbose_output(self):
         """测试详细输出模式"""

--- a/tests/unit/test_simulator_engine.py
+++ b/tests/unit/test_simulator_engine.py
@@ -80,9 +80,10 @@ class TestSimulatorEngine(unittest.TestCase):
 
         self.assertTrue(result.success)
         self.assertEqual(result.shares_after, 100)
-        self.assertEqual(result.cash_after, 90000.0)
+        # 买入成本 = 100*100 + 佣金(10000*0.00025=2.5) = 10002.5
+        self.assertEqual(result.cash_after, 89997.5)
         self.assertEqual(engine.get_position().shares, 100)
-        self.assertEqual(engine.get_cash(), 90000.0)
+        self.assertEqual(engine.get_cash(), 89997.5)
 
     def test_buy_success_with_fractional_shares(self):
         """测试基金场景：支持小数份额买入。"""
@@ -92,7 +93,9 @@ class TestSimulatorEngine(unittest.TestCase):
 
         self.assertTrue(result.success)
         self.assertAlmostEqual(result.shares_after, 100.25, places=6)
-        self.assertAlmostEqual(result.cash_after, 10000.0 - 1.234 * 100.25, places=6)
+        # 买入成本 = 1.234*100.25 + 佣金(1.234*100.25*0.00025) = 123.7085 + 0.030927 = 123.739427
+        expected_cash = 10000.0 - 1.234 * 100.25 * (1 + 0.00025)
+        self.assertAlmostEqual(result.cash_after, expected_cash, places=6)
 
     def test_buy_insufficient_cash(self):
         """测试资金不足无法买入"""
@@ -117,8 +120,11 @@ class TestSimulatorEngine(unittest.TestCase):
 
         self.assertTrue(result.success)
         self.assertEqual(result.shares_after, 0)
-        self.assertEqual(result.cash_after, 101000.0)  # 90000 + 110*100
-        self.assertEqual(result.realized_pl, 1000.0)  # (110-100)*100
+        # 买入: 100*100+佣金2.5=10002.5 => 现金89997.5
+        # 卖出: 110*100=11000, 减佣金2.75, 减印花税11.0 => 净收入10986.25
+        self.assertEqual(result.cash_after, 100983.75)  # 89997.5 + 10986.25
+        # (110*100 - 佣金2.75 - 印花税11.0) - 成本10000 = 986.25
+        self.assertAlmostEqual(result.realized_pl, 986.25, places=2)
         self.assertEqual(engine.get_position().shares, 0)
 
     def test_sell_insufficient_shares(self):
@@ -150,8 +156,9 @@ class TestSimulatorEngine(unittest.TestCase):
         result = engine.sell(date=date, price=130.0)
         self.assertTrue(result.success)
         self.assertEqual(engine.get_position().shares, 200)
-        # 已实现盈亏应该是 (130-110)*100 = 2000
-        self.assertAlmostEqual(engine.realized_pl, 2000.0, places=2)
+        # 已实现盈亏 = 净收入12983.75 - 成本11000 = 1983.75
+        # 净收入 = 130*100 - 佣金3.25 - 印花税13.0 = 12983.75
+        self.assertAlmostEqual(engine.realized_pl, 1983.75, places=2)
 
     def test_get_summary(self):
         """测试获取账户摘要"""
@@ -164,11 +171,11 @@ class TestSimulatorEngine(unittest.TestCase):
         # 获取摘要（当前价格110）
         summary = engine.get_summary(current_price=110.0)
 
-        self.assertEqual(summary['cash'], 90000.0)
+        self.assertEqual(summary['cash'], 89997.5)
         self.assertEqual(summary['shares'], 100)
         self.assertEqual(summary['avg_cost'], 100.0)
         self.assertEqual(summary['market_value'], 11000.0)  # 100*110
-        self.assertEqual(summary['total_value'], 101000.0)  # 90000+11000
+        self.assertEqual(summary['total_value'], 100997.5)  # 89997.5+11000
         self.assertEqual(summary['unrealized_pl'], 1000.0)  # (110-100)*100
 
     def test_trade_count(self):


### PR DESCRIPTION
为 SimulatedExchangeBase 添加可配置交易成本：
- commission_pct=0.00025（买入卖出均收）
- stamp_duty_pct=0.001（仅卖出）
- slippage_pct=0.0（默认关闭）

更新6处测试断言适配。216 tests passed ✅