### PR TITLE
fix(web): 隐藏表单 result_json 大小检查 — 防止截断 (#139)

### DIFF
--- a/gui/templates/backtest_progress.html
+++ b/gui/templates/backtest_progress.html
@@ -397,6 +397,13 @@
             if (!resultData) {
                 return;
             }
+            /* Check payload size before creating the form */
+            var payloadStr = JSON.stringify(resultData);
+            var payloadSize = new Blob([payloadStr]).size;
+            if (payloadSize > 15360) {
+                alert('⚠️ 结果数据过大（' + (payloadSize / 1024).toFixed(1) + ' KB），无法通过隐藏表单传输。\n请先点击下方"保存回测结果"按钮保存到历史记录，再从历史记录页面查看和导出。');
+                return;
+            }
             const form = document.createElement('form');
             form.method = 'POST';
             form.action = resultUrl;

--- a/gui/templates/result_generic.html
+++ b/gui/templates/result_generic.html
@@ -263,6 +263,19 @@
         });
       }
 
+      /* ── Check hidden form payload size before download ── */
+      function checkFormPayloadSize(form) {
+        var input = form.querySelector('input[name="result_json"]');
+        if (!input) return true;
+        var size = new Blob([input.value]).size;
+        /* 15 KB threshold — Flask/Werkzeug may silently truncate beyond ~16 KB */
+        if (size > 15360) {
+          showToast('⚠️ 结果数据过大（' + (size / 1024).toFixed(1) + ' KB），建议先点击"保存到历史记录"再从历史记录页面导出', 'error');
+          return false;
+        }
+        return true;
+      }
+
       document.addEventListener('DOMContentLoaded', function() {
         /* Auto-save on page load */
         saveToHistory();
@@ -285,6 +298,16 @@
               showToast('✅ 已保存到历史记录', 'success');
             })
             .catch(function() { showToast('保存失败', 'error'); });
+          });
+        }
+
+        /* Intercept download form submits to check payload size */
+        var downloadForms = document.querySelectorAll('form[action*="/download/"]');
+        for (var i = 0; i < downloadForms.length; i++) {
+          downloadForms[i].addEventListener('submit', function(e) {
+            if (!checkFormPayloadSize(this)) {
+              e.preventDefault();
+            }
           });
         }
       });

--- a/gui/templates/result_generic.html
+++ b/gui/templates/result_generic.html
@@ -132,14 +132,14 @@
     {% endif %}
 
     <div style="margin: 1rem 0; display: flex; gap: 0.5rem; flex-wrap: wrap;">
-      <form method="post" action="/download/excel" style="display:inline;">
+      <form method="post" action="/download/excel" style="display:inline;" onsubmit="return checkPayloadSize(this);">
         <input type="hidden" name="result_json" value='{{ result | tojson | forceescape }}'>
         <input type="hidden" name="strategy_name" value="{{ strategy_name }}">
         <button type="submit" style="padding:0.5rem 1rem; background:#2e7d32; color:white; border:none; border-radius:4px; cursor:pointer; font-size:0.9rem;">
           📥 导出 Excel
         </button>
       </form>
-      <form method="post" action="/download/pdf" style="display:inline;">
+      <form method="post" action="/download/pdf" style="display:inline;" onsubmit="return checkPayloadSize(this);">
         <input type="hidden" name="result_json" value='{{ result | tojson | forceescape }}'>
         <input type="hidden" name="strategy_name" value="{{ strategy_name }}">
         <button type="submit" style="padding:0.5rem 1rem; background:#c62828; color:white; border:none; border-radius:4px; cursor:pointer; font-size:0.9rem;">
@@ -151,6 +151,17 @@
       </button>
       <a href="/history" class="history-link">📋 查看历史记录</a>
     </div>
+
+    <script>
+    function checkPayloadSize(form) {
+      var size = new Blob([form.result_json.value]).size;
+      if (size > 15360) {
+        alert('⚠️ 结果数据过大（' + (size / 1024).toFixed(1) + ' KB），隐藏表单无法传输。\n请先点击"保存到历史记录"，再从历史记录页面导出。');
+        return false;
+      }
+      return true;
+    }
+    </script>
 
     <!-- Toast container -->
     <div class="toast-container" id="toast-container"></div>

--- a/gui/templates/result_mean.html
+++ b/gui/templates/result_mean.html
@@ -316,6 +316,29 @@
         link.href = url;
         link.click();
       }
+
+      /* ── Check hidden form payload size before download ── */
+      function checkFormPayloadSize(form) {
+        var input = form.querySelector('input[name="result_json"]');
+        if (!input) return true;
+        var size = new Blob([input.value]).size;
+        if (size > 15360) {
+          alert('⚠️ 结果数据过大（' + (size / 1024).toFixed(1) + ' KB），请先点击"保存到历史记录"再从历史记录页面导出');
+          return false;
+        }
+        return true;
+      }
+
+      document.addEventListener('DOMContentLoaded', function() {
+        var downloadForms = document.querySelectorAll('form[action*="/download/"]');
+        for (var i = 0; i < downloadForms.length; i++) {
+          downloadForms[i].addEventListener('submit', function(e) {
+            if (!checkFormPayloadSize(this)) {
+              e.preventDefault();
+            }
+          });
+        }
+      });
     </script>
   </body>
 </html>

--- a/gui/web.py
+++ b/gui/web.py
@@ -1149,10 +1149,14 @@ def download_excel():
     if not result_json:
         return jsonify({'error': '无法获取回测结果'}), 400
 
+    # Detect potential truncation: warn if unusually large data was sent
+    if len(result_json) > 15000:
+        pass  # Likely truncated — let JSON decode catch it below
+
     try:
         res = json.loads(result_json)
     except json.JSONDecodeError:
-        return jsonify({'error': '结果数据格式错误'}), 400
+        return jsonify({'error': '结果数据格式错误 — 可能是回测结果太大，表单传输中被截断。请先保存到历史记录（点击"保存到历史记录"按钮），再从历史记录页面导出。'}), 400
 
     if not isinstance(res, dict):
         return jsonify({'error': '结果数据格式错误'}), 400
@@ -1196,7 +1200,7 @@ def download_pdf():
     try:
         res = json.loads(result_json)
     except json.JSONDecodeError:
-        return jsonify({'error': '结果数据格式错误'}), 400
+        return jsonify({'error': '结果数据格式错误 — 可能是回测结果太大，表单传输中被截断。请先保存到历史记录，再从历史记录页面导出。'}), 400
 
     if not isinstance(res, dict):
         return jsonify({'error': '结果数据格式错误'}), 400


### PR DESCRIPTION
## 修复：隐藏表单 result_json 可被静默截断

### 问题
`result_generic.html` 和 `result_mean.html` 将整个回测结果（含数千行交易数据）序列化为 JSON 放入 `<input type="hidden" name="result_json">`。超过表单缓冲区限制时数据被静默截断，导致导出 Excel/PDF 失败或输出错误数据。

### 改动范围

#### 1. `gui/templates/result_generic.html`
- 新增 `checkFormPayloadSize()` — 提交前检查 JSON 大小，超 15KB 时弹 toast 警告并阻止提交
- 新增 DOMContentLoaded 监听 — 拦截所有 `/download/` 表单提交做大小检查

#### 2. `gui/templates/result_mean.html`
- 同上的 `checkFormPayloadSize()` + 表单拦截（使用 `alert()` 代替 toast，该页面无 toast 容器）

#### 3. `gui/templates/backtest_progress.html`
- `viewResult()` 中 `JSON.stringify(resultData)` 前做大小检查，超 15KB 时 alert 提示并阻止跳转

#### 4. `gui/web.py`
- `/download/excel` — JSONDecodeError 错误消息增加截断提示
- `/download/pdf` — 同上

### 验收标准
- [x] WEB: 前端 JS 大小检查（3 个模板）
- [x] WEB: 服务端错误提示优化（2 个下载路由）

Closes #139