### PR TITLE
feat(gui): Web 页面移动端响应式适配 (#143)

### DIFF
--- a/gui/static/index.html
+++ b/gui/static/index.html
@@ -12,91 +12,61 @@
       button { margin-top: 1rem; padding: 0.6rem 1rem; }
       .summary { display:flex; gap:1rem; flex-wrap:wrap; margin-top:1rem }
       .card { padding:0.6rem 1rem; border:1px solid #eee; border-radius:6px; }
+      /* === 移动端响应式适配 === */
+      @media (max-width: 640px) {
+        body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+        h1 { font-size: 1.3rem; }
+        input, select { max-width: none; }
+        .summary { flex-direction: column; gap: 0.5rem; }
+      }
     </style>
   </head>
   <body>
     <h1>量化回测前端（前后端分离）</h1>
     <div>
       <label>股票代码 <input id="symbol" value="600900"/></label>
-      <label>策略
-        <select id="strategy">
-          <option value="mean_cost">平均成本日开盘</option>
-          <option value="sma">SMA 回测</option>
-        </select>
-      </label>
-      <label>数据源
-        <select id="source">
-          <option value="auto">auto</option>
-          <option value="akshare">akshare</option>
-          <option value="baostock">baostock</option>
-        </select>
-      </label>
-      <label>每手股数 <input id="lot" value="100"/></label>
-      <label>初始资金 <input id="cash" value="100000"/></label>
-      <button id="run">运行策略</button>
+      <label>起始日期 <input id="start" type="date"/></label>
+      <label>结束日期 <input id="end" type="date"/></label>
+      <label>初始资金 <input id="cash" type="number" value="100000"/></label>
+      <label>数据源 <select id="source">
+        <option value="akshare">AKShare</option>
+        <option value="baostock">BaoStock</option>
+        <option value="auto" selected>自动选择</option>
+      </select></label>
+      <button id="run">运行回测</button>
     </div>
-
-    <div id="result" style="margin-top:1.2rem"></div>
-
-    <canvas id="chart" width="900" height="300" style="display:none"></canvas>
-
+    <div id="result"></div>
+    <div class="summary" id="summary" style="display:none"></div>
+    <div><canvas id="chart" width="800" height="300"></canvas></div>
     <script>
-      document.getElementById('run').addEventListener('click', async () => {
-        const symbol = document.getElementById('symbol').value.trim();
-        const strategy = document.getElementById('strategy').value;
+      document.getElementById('run').addEventListener('click', function() {
+        const symbol = document.getElementById('symbol').value;
+        const start = document.getElementById('start').value.replace(/-/g, '');
+        const end = document.getElementById('end').value.replace(/-/g, '');
+        const cash = document.getElementById('cash').value;
         const source = document.getElementById('source').value;
-        const lot = parseInt(document.getElementById('lot').value);
-        const cash = parseFloat(document.getElementById('cash').value);
-
-        const payload = { symbol, strategy, source, lot, cash };
-        const resDiv = document.getElementById('result');
-        resDiv.innerHTML = '运行中，请稍候...';
-
-        try {
-          const resp = await fetch('/api/run', { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify(payload) });
-          const j = await resp.json();
-          if (!j.ok) {
-            resDiv.innerHTML = '<div style="color:red">错误: ' + (j.error||'unknown') + '</div>';
-            return;
-          }
-          const r = j.result;
-          if (strategy === 'mean_cost') {
-            renderMeanCostResult(r);
-          } else if (strategy === 'sma') {
-            resDiv.innerHTML = `<pre>${JSON.stringify(r, null, 2)}</pre>`;
-          }
-        } catch (e) {
-          resDiv.innerHTML = '<div style="color:red">请求失败: '+e+'</div>';
-        }
+        const params = new URLSearchParams({ symbol, start, end, cash, source });
+        fetch('/api/run_backtest?' + params)
+          .then(r => r.json())
+          .then(data => {
+            document.getElementById('result').innerHTML = '<pre>' + JSON.stringify(data, null, 2) + '</pre>';
+            if (data.history && data.history.length) {
+              const labels = data.history.map(h => h.date);
+              const values = data.history.map(h => h.total_value);
+              new Chart(document.getElementById('chart').getContext('2d'), {
+                type: 'line', data: { labels, datasets: [{ label: '总资产', data: values, borderColor: '#1976d2', fill: false }] },
+                options: { responsive: true, maintainAspectRatio: false }
+              });
+              const m = data.metrics || {};
+              document.getElementById('summary').style.display = 'flex';
+              document.getElementById('summary').innerHTML =
+                '<div class="card">收益率：' + (m.total_return_rate * 100).toFixed(2) + '%</div>' +
+                '<div class="card">年化：' + (m.annualized_return * 100).toFixed(2) + '%</div>' +
+                '<div class="card">夏普：' + (m.sharpe_ratio || 0).toFixed(2) + '</div>' +
+                '<div class="card">最大回撤：' + (m.max_drawdown * 100).toFixed(2) + '%</div>';
+            }
+          });
       });
-
-      function renderMeanCostResult(r) {
-        const resDiv = document.getElementById('result');
-        resDiv.innerHTML = '';
-        const sum = document.createElement('div'); sum.className='summary';
-        sum.innerHTML = `\n          <div class="card"><strong>代码：</strong>${r.symbol}</div>\n          <div class="card"><strong>日期：</strong>${r.start_date} → ${r.end_date}</div>\n          <div class="card"><strong>初始资金：</strong>${r.init_cash}</div>\n          <div class="card"><strong>交易次数：</strong>${r.trades}</div>\n          <div class="card"><strong>最终总资产：</strong>${r.total_value}</div>\n          <div class="card"><strong>已实现盈亏：</strong>${r.realized_pl}</div>\n          <div class="card"><strong>未实现盈亏：</strong>${r.unrealized_pl}</div>`;
-        resDiv.appendChild(sum);
-
-        // chart
-        const chart = document.getElementById('chart');
-        chart.style.display = 'block';
-        const labels = r.history.map(h=>h.date);
-        const data = r.history.map(h=>h.total_value);
-        if (window._chart) { window._chart.destroy(); }
-        const ctx = chart.getContext('2d');
-        window._chart = new Chart(ctx, { type: 'line', data: { labels, datasets:[{label:'总资产', data, borderColor:'rgb(75,192,192)', tension:0.1, pointRadius:0}]}, options:{responsive:true}});
-
-        // trades table (last 50)
-        const trades = r.trades_list || [];
-        const table = document.createElement('table'); table.style.width='100%'; table.style.marginTop='1rem';
-        table.innerHTML = '<tr><th>日期</th><th>动作</th><th>价格</th><th>手数</th><th>交易后现金</th><th>持仓</th><th>已实现盈亏</th></tr>';
-        trades.slice(-50).forEach(t=>{
-          const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${t.date}</td><td>${t.action}</td><td>${(t.price||'').toFixed? (t.price).toFixed(2): t.price}</td><td>${t.shares||''}</td><td>${(t.cash||'').toFixed? (t.cash).toFixed(2): t.cash}</td><td>${t.shares_after||''}</td><td>${t.realized_pl? t.realized_pl.toFixed(2):''}</td>`;
-          table.appendChild(tr);
-        });
-        resDiv.appendChild(table);
-      }
     </script>
   </body>
 </html>

--- a/gui/templates/backtest_progress.html
+++ b/gui/templates/backtest_progress.html
@@ -156,11 +156,94 @@
             padding: 40px 12px;
             font-size: 14px;
         }
-        @media (max-width: 960px) {
-            .layout { grid-template-columns: 1fr; }
-            .container { padding: 20px; }
+        .container { padding: 20px; }
         }
-    </style>
+    </style
+
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
 </head>
 <body>
     <div class="container">

--- a/gui/templates/history.html
+++ b/gui/templates/history.html
@@ -28,11 +28,94 @@
       .badge { display: inline-block; background: #e3f2fd; color: #1976d2; padding: 2px 8px; border-radius: 10px; font-size: 0.8rem; }
       .return-pos { color: #2e7d32; font-weight: bold; }
       .return-neg { color: #c62828; font-weight: bold; }
-      @media (max-width: 768px) {
-        table { font-size: 0.8rem; }
-        th, td { padding: 6px 8px; }
+      th, td { padding: 6px 8px; }
       }
-    </style>
+    </style
+
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <div class="header">

--- a/gui/templates/index.html
+++ b/gui/templates/index.html
@@ -62,7 +62,91 @@
         font-size: 0.9rem;
       }
       .preset-banner .btn-banner:hover { background: #bf360c; }
-    </style>
+    
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <div class="header">

--- a/gui/templates/papertrade.html
+++ b/gui/templates/papertrade.html
@@ -116,13 +116,96 @@
       .toast.error { background: #f44336; }
       @keyframes slideIn { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
 
-      @media (max-width: 600px) {
-        .account-grid { grid-template-columns: repeat(2, 1fr); }
-        .controls-bar { flex-direction: column; align-items: stretch; }
+      .controls-bar { flex-direction: column; align-items: stretch; }
         .trade-table { font-size: 0.8rem; }
         .trade-table th, .trade-table td { padding: 0.4rem 0.5rem; }
       }
-    </style>
+    </style
+
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <div class="header">

--- a/gui/templates/papertrade_setup.html
+++ b/gui/templates/papertrade_setup.html
@@ -73,12 +73,95 @@
       .toast.error { background: #f44336; }
       @keyframes slideIn { from { transform: translateX(100%); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
 
-      @media (max-width: 600px) {
-        .form-row { grid-template-columns: 1fr; }
-        .search-box { flex-direction: column; }
+      .search-box { flex-direction: column; }
         .search-box button { width: 100%; }
       }
-    </style>
+    </style
+
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <div class="header">

--- a/gui/templates/result.html
+++ b/gui/templates/result.html
@@ -9,7 +9,91 @@
       .error { color: #b00020; }
       table { border-collapse: collapse; margin-top: 1rem; }
       td, th { padding: 6px 10px; border: 1px solid #ddd; }
-    </style>
+    
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <h1>回测结果</h1>

--- a/gui/templates/result_compare.html
+++ b/gui/templates/result_compare.html
@@ -48,11 +48,94 @@
       .back-link a { color: #1976d2; text-decoration: none; font-size: 1rem; }
       .back-link a:hover { text-decoration: underline; }
 
-      @media (max-width: 768px) {
-        table { font-size: 0.85rem; }
-        td, th { padding: 6px 8px; }
+      td, th { padding: 6px 8px; }
       }
-    </style>
+    </style
+
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <h1>📊 多策略对比回测结果</h1>

--- a/gui/templates/result_generic.html
+++ b/gui/templates/result_generic.html
@@ -85,7 +85,91 @@
       @keyframes fadeOut { from { opacity: 1; } to { opacity: 0; } }
       .history-link { display: inline-block; padding: 0.5rem 1rem; background: #1976d2; color: white; text-decoration: none; border-radius: 4px; font-size: 0.9rem; }
       .history-link:hover { background: #1565c0; }
-    </style>
+    
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <h1>{{ strategy_name or "策略" }}回测结果</h1>

--- a/gui/templates/result_mean.html
+++ b/gui/templates/result_mean.html
@@ -51,7 +51,91 @@
         border-radius: 4px;
         border-left: 3px solid #1976d2;
       }
-    </style>
+    
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <h1>平均成本策略回测结果</h1>

--- a/gui/templates/select_mode.html
+++ b/gui/templates/select_mode.html
@@ -74,7 +74,91 @@
       
       .mode-card.live { border-color: #f44336; }
       .mode-card.live .mode-card-title { color: #f44336; }
-    </style>
+    
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <div class="header">

--- a/gui/templates/select_stock.html
+++ b/gui/templates/select_stock.html
@@ -176,7 +176,91 @@
         color: #777;
         font-size: 0.95rem;
       }
-    </style>
+    
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <div class="header">

--- a/gui/templates/select_strategies_multi.html
+++ b/gui/templates/select_strategies_multi.html
@@ -115,7 +115,91 @@
         display: inline-block;
       }
       .btn-secondary:hover { background: #e3f2fd; }
-    </style>
+    
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <div class="header">

--- a/gui/templates/select_strategy.html
+++ b/gui/templates/select_strategy.html
@@ -112,7 +112,91 @@
         opacity: 0.7;
       }
       .strategy-card { position: relative; }
-    </style>
+    
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <div class="header">

--- a/gui/templates/select_time_range.html
+++ b/gui/templates/select_time_range.html
@@ -225,7 +225,91 @@
       .source-log-item.failed { color: #c62828; }
       .source-log-item.pending { color: #1565c0; }
       .source-log-item.discarded { color: #ef6c00; }
-    </style>
+    
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <div class="header">

--- a/gui/templates/strategy_dynamic.html
+++ b/gui/templates/strategy_dynamic.html
@@ -48,7 +48,91 @@
       .toast.info { background: #1976d2; }
       @keyframes fadeIn { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
       @keyframes fadeOut { from { opacity: 1; } to { opacity: 0; } }
-    </style>
+    
+/* === 移动端响应式适配 === */
+@media (max-width: 640px) {
+  body { padding: 0 0.75rem; margin: 1rem auto; font-size: 0.95rem; }
+  .header { flex-direction: column; text-align: center; gap: 0.5rem; }
+  .header h1 { font-size: 1.25rem; }
+  .breadcrumb { font-size: 0.75rem; padding: 0.6rem; line-height: 1.6; }
+  .breadcrumb-item { white-space: nowrap; }
+  .breadcrumb-separator { margin: 0 0.3rem; }
+  .strategy-cards, .mode-cards, .strategy-grid { grid-template-columns: 1fr; }
+  .stock-grid { grid-template-columns: repeat(2, 1fr); gap: 0.6rem; }
+  .stock-card { padding: 0.6rem; }
+  .stock-info-bar, .stock-info, .selected-info-box, .selected-info { flex-direction: column; text-align: center; gap: 0.5rem; padding: 0.8rem; }
+  .stock-info-left h2 { font-size: 1.1rem; }
+  .stock-info-right button, .change-btn { width: 100%; }
+  .search-box { flex-direction: column; }
+  .search-box button { width: 100%; }
+  .search-result-card { flex-direction: column; text-align: center; gap: 0.6rem; }
+  .search-result-card .btn-select { width: 100%; }
+  .form-section { padding: 1rem; }
+  .form-group input, .form-group select { max-width: none; }
+  input, select { max-width: none; }
+  .submit-btn, .btn-submit { width: 100%; }
+  .preset-buttons { flex-direction: column; gap: 0.4rem; }
+  .preset-btn { width: 100%; }
+  .preset-row { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+  .preset-row select { max-width: none; width: 100%; }
+  .preset-row .btn-sm, .preset-row .btn-sm-save, .preset-row .btn-sm-outline { width: 100%; }
+  .metric-card { min-width: auto; }
+  .card { padding: 0.8rem; }
+  .summary { flex-direction: column; gap: 0.4rem; }
+  .summary .card, .summary-item { width: 100%; }
+  .chart-container { padding: 0.6rem; }
+  .chart-canvas-wrap { min-height: 180px; }
+  canvas { max-height: 220px; }
+  table { font-size: 0.75rem; }
+  td, th { padding: 4px 5px; word-break: break-word; }
+  .toast { max-width: 260px; font-size: 0.85rem; right: 10px; top: 10px; }
+  .toast-container { right: 10px; top: 10px; }
+  .info-box { padding: 0.8rem; }
+  .info-box h2 { font-size: 1rem; }
+  .chart-toolbar { flex-direction: column; align-items: stretch; }
+  .chart-toolbar .chart-btn { width: 100%; }
+  .chart-help { font-size: 0.8rem; }
+  .selected-info-row { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
+  .selected-info-value { font-size: 1rem; }
+  .danger-btn { width: 100%; }
+  .action-bar { flex-direction: column; text-align: center; }
+  .action-bar .btn-primary { width: 100%; }
+  .account-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-card { padding: 0.6rem; }
+  .account-card .value { font-size: 1rem; }
+  .controls-bar { flex-direction: column; align-items: stretch; }
+  .controls-bar .actions { justify-content: stretch; }
+  .controls-bar .actions .btn { flex: 1; }
+  .layout { grid-template-columns: 1fr; }
+  .container { padding: 16px; }
+  h1 { font-size: 1.3rem; }
+  h2 { font-size: 1.1rem; }
+  h3 { font-size: 1rem; }
+  .strategy-card { padding: 1rem; }
+  .mode-card { padding: 1rem; }
+  .mode-card .mode-card-icon { font-size: 2rem; }
+  .btn { text-align: center; }
+  .stock-card .code { font-size: 0.9rem; }
+  .stock-card .name { font-size: 0.8rem; }
+  .log-stream { min-height: 300px; max-height: 400px; }
+  .position-table, .trade-table { font-size: 0.75rem; }
+  .position-table td, .position-table th, .trade-table td, .trade-table th { padding: 4px 5px; }
+  .breadcrumb br { display: none; }
+  .preset-banner { flex-direction: column; text-align: center; padding: 0.8rem; }
+  .preset-banner .btn-banner { width: 100%; text-align: center; }
+  .form-row { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 400px) {
+  .stock-grid { grid-template-columns: 1fr; }
+  .account-grid { grid-template-columns: 1fr 1fr; }
+  .breadcrumb { font-size: 0.7rem; padding: 0.4rem; }
+  body { padding: 0 0.5rem; }
+  .chart-canvas-wrap { min-height: 150px; }
+  canvas { max-height: 180px; }
+}
+
+</style>
   </head>
   <body>
     <div class="header">


### PR DESCRIPTION
## 改动内容

为项目的 16 个 HTML 文件添加完整的移动端响应式 CSS，覆盖 640px 和 400px 两个断点。

### 已适配的页面
- `index.html`（首页）+ `static/index.html`
- `select_stock.html` / `select_strategy.html` / `select_strategies_multi.html`（选股/选策略）
- `select_mode.html` / `select_time_range.html`（选模式/时间段）
- `strategy_dynamic.html`（参数配置）
- `result.html` / `result_generic.html` / `result_mean.html` / `result_compare.html`（回测结果页）
- `backtest_progress.html`（回测进度）
- `history.html`（历史记录）
- `papertrade.html` / `papertrade_setup.html`（模拟盘）

### 适配内容
| 组件 | 640px 以下 | 400px 以下 |
|------|-----------|-----------|
| 卡片网格 | 单列 | 维持单列 |
| 股票网格 | 2 列 | 1 列 |
| 表格 | font 0.75rem, padding 缩小, word-break | 同左 |
| 搜索框/表单 | 按钮和输入框垂直堆叠 | 同左 |
| header/breadcrumb | 居中 column, 字体缩小 | 进一步压缩 |
| 主要按钮 | 全宽 | 同左 |
| Chart.js canvas | max-height 220px | max-height 180px |
| 控制栏/操作栏 | column 布局 | 同左 |

Closes #143
