### PR TITLE
fix: 移除 backtest_progress.html payload 大小检查，长回测结果可正常查看 (#145)

### DIFF
--- a/gui/templates/backtest_progress.html
+++ b/gui/templates/backtest_progress.html
@@ -480,13 +480,6 @@
             if (!resultData) {
                 return;
             }
-            /* Check payload size before creating the form */
-            var payloadStr = JSON.stringify(resultData);
-            var payloadSize = new Blob([payloadStr]).size;
-            if (payloadSize > 15360) {
-                alert('⚠️ 结果数据过大（' + (payloadSize / 1024).toFixed(1) + ' KB），无法通过隐藏表单传输。\n请先点击下方"保存回测结果"按钮保存到历史记录，再从历史记录页面查看和导出。');
-                return;
-            }
             const form = document.createElement('form');
             form.method = 'POST';
             form.action = resultUrl;


### PR DESCRIPTION
## 问题
PR #140（ff125d01）在 `backtest_progress.html` 的 `viewResult()` 中加了 15KB 的 payload 大小检查，导致长时间跨度回测结果被阻塞，用户无法查看结果页面。

## 修复
移除 `viewResult()` 中的 `checkPayloadSize` 检查，回测结果始终可以查看。HTML hidden form 的 POST 数据没有 15KB 限制（Flask 默认 16MB），这个检查本身就是多余的。

## 改动文件
- `gui/templates/backtest_progress.html`：移除 `viewResult()` 中的 payload 大小检查代码块

Closes #145