### PR TITLE
[#153] feat(exch): 扩展 BaostockProvider 支持港股和北证多市场

### DIFF
--- a/exchange/source/baostock_provider.py
+++ b/exchange/source/baostock_provider.py
@@ -17,16 +17,44 @@ class BaostockProvider(BaseProvider):
             return value
         return f"{value[:4]}-{value[4:6]}-{value[6:8]}"
 
+    @staticmethod
+    def _resolve_code(symbol: str) -> str:
+        """Map a symbol to baostock's market-prefixed code.
+
+        Baostock uses market prefixes:
+          - Shanghai (6xxxxx)  -> sh.{symbol}
+          - Shenzhen (0xxxxx/3xxxxx) -> sz.{symbol}
+          - Beijing (8xxxxx)   -> bj.{symbol}
+          - Hong Kong (*.HK)   -> hk.{symbol_without_HK}
+        """
+        s = str(symbol).strip()
+
+        # Hong Kong: ends with .HK
+        if s.upper().endswith('.HK'):
+            return f"hk.{s[:-3]}"
+
+        # Beijing: starts with '8'
+        if s.startswith('8'):
+            return f"bj.{s}"
+
+        # Shanghai: starts with '6'
+        if s.startswith('6'):
+            return f"sh.{s}"
+
+        # Shenzhen: starts with '0' or '3' (main board / chiNext)
+        if s.startswith(('0', '3')):
+            return f"sz.{s}"
+
+        # Default to sz for unknown formats (backward compatible)
+        return f"sz.{s}"
+
     def fetch(self, symbol: str, start_date: str, end_date: str) -> pd.DataFrame:
         try:
             import baostock as bs
         except Exception as e:
             raise ImportError("baostock is required for BaostockProvider") from e
 
-        if symbol.startswith("6"):
-            code = f"sh.{symbol}"
-        else:
-            code = f"sz.{symbol}"
+        code = self._resolve_code(symbol)
 
         sd = self._normalize_date(start_date)
         ed = self._normalize_date(end_date)


### PR DESCRIPTION
## 变更内容

修复 BaostockProvider 不支持港股和北证股票的问题。

### 改动
- 新增 `_resolve_code()` 静态方法，按市场映射正确的 baostock 前缀
- 港股 `*.HK` → `hk.{code}`（如 `00700.HK` → `hk.00700`）
- 北证 `8xxxxx` → `bj.{code}`（如 `830799` → `bj.830799`）
- 沪深保持 `sh.{code}` / `sz.{code}` 规则
- 未知格式默认使用 `sz` 前缀（向后兼容）

### 受影响文件
- `exchange/source/baostock_provider.py`

### 测试
- [ ] 北证代码正确生成 bj.xxx 前缀
- [ ] 港股代码正确生成 hk.xxx 前缀
- [ ] 现有沪深 A 股不受影响
- [ ] 可通过单元测试验证多市场前缀映射

Closes #153