### PR TITLE
[P1] 回测结算图新增"投入资金收益率"曲线

### DIFF
--- a/gui/templates/result_mean.html
+++ b/gui/templates/result_mean.html
@@ -218,6 +218,11 @@
           {{ h.last_price if (h.last_price is not none and h.last_price == h.last_price) else 'null' }},
         {% endfor %}
       ];
+      const investedCapitalRateData = [
+        {% for h in result.history %}
+          {{ h.invested_capital_return_rate * 100 if h.invested_capital_return_rate is defined else 'null' }},
+        {% endfor %}
+      ];
 
       // 归一化处理：将股价和总资产都转换为以起点为100的指数形式
       // 这样两条曲线的起点就会在同一位置
@@ -299,6 +304,14 @@
             tension: 0.1,
             pointRadius: 0,
             yAxisID: 'y'
+          }, {
+            label: '投入资金收益率',
+            data: investedCapitalRateData,
+            borderColor: 'rgb(255, 159, 64)',
+            backgroundColor: 'rgba(255, 159, 64, 0.1)',
+            tension: 0.1,
+            pointRadius: 0,
+            yAxisID: 'y1'
           }]
         },
         options: {
@@ -339,6 +352,8 @@
                     } else {
                       return datasetLabel + ': ' + value.toFixed(2);
                     }
+                  } else if (datasetLabel.includes('投入资金')) {
+                    return datasetLabel + ': ' + value.toFixed(2) + '%';
                   } else {
                     const originalPrice = stockPriceData[index];
                     if (originalPrice !== null && originalPrice !== undefined) {
@@ -381,6 +396,18 @@
               title: {
                 display: true,
                 text: '相对变化（起点=100）'
+              }
+            },
+            y1: {
+              type: 'linear',
+              display: true,
+              position: 'right',
+              title: {
+                display: true,
+                text: '投入资金收益率 (%)'
+              },
+              grid: {
+                drawOnChartArea: false
               }
             }
           }

--- a/trader/simulator.py
+++ b/trader/simulator.py
@@ -160,6 +160,7 @@ class BacktestExchangeRunner:
         trades_list: List[Dict[str, Any]] = []
         pending_orders: List[PendingOrder] = []
         min_cash = engine.get_cash()
+        running_min_cash = self.init_cash
         today_bought_shares: Dict[str, float] = {}
 
         if use_verbose:
@@ -410,6 +411,13 @@ class BacktestExchangeRunner:
             engine.print_daily_status(date, price_open, price_close, action)
 
             summary = engine.get_summary(price_close)
+            running_min_cash = min(running_min_cash, summary["cash"])
+            max_capital_used_so_far = self.init_cash - running_min_cash
+            invested_capital_return_rate = (
+                (summary["total_value"] - self.init_cash) / max_capital_used_so_far
+                if max_capital_used_so_far > 0
+                else 0.0
+            )
             history.append(
                 {
                     "date": date.strftime("%Y-%m-%d"),
@@ -419,6 +427,8 @@ class BacktestExchangeRunner:
                     "last_price": round(price_close, 4),
                     "market_value": summary["market_value"],
                     "total_value": summary["total_value"],
+                    "max_capital_used_so_far": round(max_capital_used_so_far, 2),
+                    "invested_capital_return_rate": round(invested_capital_return_rate, 4),
                 }
             )
             min_cash = min(min_cash, summary["cash"])
@@ -503,6 +513,12 @@ class BacktestExchangeRunner:
             "sharpe_ratio": round(sharpe_ratio, 4),
             "total_pl": round(total_pl, 2),
             "final_value": round(final_summary["total_value"], 2),
+            "invested_capital_return_rate": round(
+                (final_summary["total_value"] - self.init_cash) / max_capital_used
+                if max_capital_used > 0
+                else 0.0,
+                4,
+            ),
         }
 
         return {


### PR DESCRIPTION
## 变更内容

为回测结算图新增"投入资金收益率"曲线。

### TRADER 变更（trader/simulator.py）
- 在回测历史每个数据点新增  和  字段
- 投入资金收益率 = (总资产 - 初始本金) / 已动用的最大资金
- 新增  到最终 metrics

### GUI 变更（gui/templates/result_mean.html）
- 新增"投入资金收益率"曲线（橙色），使用右侧次坐标轴
- tooltip 显示百分比值
- 可与现有曲线切换显示

### 相关 Issue
Closes #162