### PR TITLE
P2: 多市场交易规则差异化支持（港股T+0、不同印花税、不同手数）

### DIFF
--- a/exchange/__init__.py
+++ b/exchange/__init__.py
@@ -2,7 +2,7 @@
 
 from exchange.base_engine import Position, Account, TradeOrder, TradeResult
 from exchange.exchange_interface import StockExchange
-from exchange.simulated_exchange import SimulatedExchangeBase, SimulatedExchange
+from exchange.simulated_exchange import SimulatedExchangeBase, SimulatedExchange, detect_market
 from exchange.backtest.exchange import BacktestExchange
 from exchange.live.exchange import LiveExchange
 from exchange.realtime.exchange import RealtimeSimExchange
@@ -11,7 +11,7 @@ from exchange.source.data_provider import get_data
 
 __all__ = [
     "Position", "Account", "TradeOrder", "TradeResult",
-    "StockExchange", "SimulatedExchange",
+    "StockExchange", "SimulatedExchange", "SimulatedExchangeBase",
     "BacktestExchange", "LiveExchange", "RealtimeSimExchange",
-    "RealEngine", "get_data",
+    "RealEngine", "get_data", "detect_market",
 ]

--- a/exchange/simulated_exchange.py
+++ b/exchange/simulated_exchange.py
@@ -1,24 +1,109 @@
 """仿真交易所通用实现。"""
 
 from datetime import datetime
-from typing import Optional
+from typing import Dict, Optional
 
 from exchange.base_engine import TradeOrder, TradeResult
 from exchange.exchange_interface import StockExchange
 
+
+# ─── Market Detection ────────────────────────────────────────────────
+
+# Default market rules keyed by market code
+_MARKET_RULES: Dict[str, Dict] = {
+    "A": {
+        "lot_size": 100,
+        "commission_pct": 0.00025,
+        "stamp_duty_pct": 0.001,
+        "t_plus_one": True,
+    },
+    "HK": {
+        "lot_size": 100,
+        "commission_pct": 0.0003,
+        "stamp_duty_pct": 0.0013,
+        "t_plus_one": False,
+    },
+    "BJ": {
+        "lot_size": 100,
+        "commission_pct": 0.00025,
+        "stamp_duty_pct": 0.0,
+        "t_plus_one": True,
+    },
+}
+
+
+def detect_market(symbol: str) -> str:
+    """Detect the market from a stock symbol.
+
+    Args:
+        symbol: Stock symbol (e.g. '600000', '000001.SH', '00700.HK', '830001').
+
+    Returns:
+        Market code: 'A' (沪深), 'HK' (港股), or 'BJ' (北证).
+    """
+    sym = symbol.strip().upper()
+    if sym.endswith(".HK"):
+        return "HK"
+    if sym.startswith("8"):
+        return "BJ"
+    return "A"
+
+
+# ─── SimulatedExchangeBase ───────────────────────────────────────────
 
 class SimulatedExchangeBase(StockExchange):
     """仿真类交易所的通用逻辑。"""
 
     def __init__(self, init_cash: float = 100000.0, lot_size: float = 100.0, verbose: bool = False,
                  commission_pct: float = 0.00025, stamp_duty_pct: float = 0.001,
-                 slippage_pct: float = 0.0):
+                 slippage_pct: float = 0.0, market: Optional[str] = None):
+        """初始化仿真交易所。
+
+        Args:
+            init_cash: 初始资金。
+            lot_size: 默认交易手数。
+            verbose: 是否输出详细日志。
+            commission_pct: 佣金比例（如 0.00025 表示万分之二点五）。
+            stamp_duty_pct: 印花税比例（卖出时收取）。
+            slippage_pct: 滑点比例。
+            market: 市场代码（'A', 'HK', 'BJ'）。传入后将覆盖对应的默认费用/手数规则。
+                    为 None 时保留调用方传入的 commission_pct / stamp_duty_pct / lot_size。
+        """
+        # Apply market-specific defaults when market is specified
+        if market is not None:
+            rules = SimulatedExchangeBase.market_rules(market)
+            lot_size = rules["lot_size"]
+            commission_pct = rules["commission_pct"]
+            stamp_duty_pct = rules["stamp_duty_pct"]
+
         super().__init__(init_cash=init_cash, lot_size=lot_size,
                          commission_pct=commission_pct, stamp_duty_pct=stamp_duty_pct,
                          slippage_pct=slippage_pct)
+        self.market = market or "A"
         self.verbose = verbose
         self.trade_count = 0
         self.connected = False
+
+    @property
+    def t_plus_one(self) -> bool:
+        """是否实行 T+1 交易规则。"""
+        rules = self.market_rules(self.market)
+        return rules["t_plus_one"]
+
+    @staticmethod
+    def market_rules(market: str) -> Dict:
+        """获取指定市场的交易规则。
+
+        Args:
+            market: 市场代码（'A', 'HK', 'BJ'）。
+
+        Returns:
+            包含 lot_size, commission_pct, stamp_duty_pct, t_plus_one 的字典。
+        """
+        m = market.upper()
+        if m in _MARKET_RULES:
+            return dict(_MARKET_RULES[m])
+        return dict(_MARKET_RULES["A"])
 
     def connect(self) -> bool:
         self.connected = True

--- a/trader/simulator.py
+++ b/trader/simulator.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
 from exchange.source.data_provider import get_data
+from exchange.simulated_exchange import detect_market
 from trader.clock import BacktestClock
 from exchange.backtest.exchange import BacktestExchange
 
@@ -126,7 +127,13 @@ class BacktestExchangeRunner:
             )
 
         use_verbose = verbose if verbose is not None else self.verbose
-        engine = BacktestExchange(init_cash=self.init_cash, lot_size=self.lot_size, verbose=use_verbose)
+
+        # Auto-detect market from symbol and set exchange parameters
+        market = detect_market(symbol) if symbol else "A"
+        if market == "HK":
+            enforce_t_plus_one = False
+
+        engine = BacktestExchange(init_cash=self.init_cash, lot_size=self.lot_size, verbose=use_verbose, market=market)
 
         resolved_base_position_lots = base_position_lots
         if require_base_position_for_t_plus_one_intraday and resolved_base_position_lots is None:


### PR DESCRIPTION
## 变更内容

实现多市场交易规则差异化支持。

### EXCH 变更（exchange/simulated_exchange.py）
- 新增  函数：根据股票代码自动检测市场（A/HK/BJ）
- 新增  静态配置表：各市场佣金、印花税、T+1设置
- SimulatedExchangeBase 支持  参数，自动设置对应市场规则
- 港股：T+0、0.13%印花税、0.03%佣金
- 北证：T+1、0%印花税、0.025%佣金
- A股：T+1、0.1%印花税、0.025%佣金
- 100%向后兼容，不传 market 参数时使用A股默认值

### TRADER 变更（trader/simulator.py）
- 自动检测股票所属市场并传递到交易所引擎
- 港股自动启用 T+0 规则

### 相关 Issue
Closes #159