### PR TITLE
P2: stock_list.json 添加 market 字段以支持按市场分类筛选

### DIFF
--- a/gui/stock_list.json
+++ b/gui/stock_list.json
@@ -1,506 +1,632 @@
 [
   {
     "code": "000001",
-    "name": "平安银行"
+    "name": "平安银行",
+    "market": "sz"
   },
   {
     "code": "000002",
-    "name": "万科A"
+    "name": "万科A",
+    "market": "sz"
   },
   {
     "code": "00001.HK",
-    "name": "长和"
+    "name": "长和",
+    "market": "hk"
   },
   {
     "code": "00005.HK",
-    "name": "汇丰控股"
+    "name": "汇丰控股",
+    "market": "hk"
   },
   {
     "code": "000063",
-    "name": "中兴通讯"
+    "name": "中兴通讯",
+    "market": "sz"
   },
   {
     "code": "000100",
-    "name": "TCL科技"
+    "name": "TCL科技",
+    "market": "sz"
   },
   {
     "code": "00016.HK",
-    "name": "新鸿基地产"
+    "name": "新鸿基地产",
+    "market": "hk"
   },
   {
     "code": "000301",
-    "name": "东方盛虹"
+    "name": "东方盛虹",
+    "market": "sz"
   },
   {
     "code": "000333",
-    "name": "美的集团"
+    "name": "美的集团",
+    "market": "sz"
   },
   {
     "code": "000338",
-    "name": "潍柴动力"
+    "name": "潍柴动力",
+    "market": "sz"
   },
   {
     "code": "000568",
-    "name": "泸州老窖"
+    "name": "泸州老窖",
+    "market": "sz"
   },
   {
     "code": "000625",
-    "name": "长安汽车"
+    "name": "长安汽车",
+    "market": "sz"
   },
   {
     "code": "000651",
-    "name": "格力电器"
+    "name": "格力电器",
+    "market": "sz"
   },
   {
     "code": "000661",
-    "name": "长春高新"
+    "name": "长春高新",
+    "market": "sz"
   },
   {
     "code": "000725",
-    "name": "京东方A"
+    "name": "京东方A",
+    "market": "sz"
   },
   {
     "code": "000768",
-    "name": "中航西飞"
+    "name": "中航西飞",
+    "market": "sz"
   },
   {
     "code": "000792",
-    "name": "盐湖股份"
+    "name": "盐湖股份",
+    "market": "sz"
   },
   {
     "code": "000858",
-    "name": "五粮液"
+    "name": "五粮液",
+    "market": "sz"
   },
   {
     "code": "000876",
-    "name": "新希望"
+    "name": "新希望",
+    "market": "sz"
   },
   {
     "code": "000977",
-    "name": "浪潮信息"
+    "name": "浪潮信息",
+    "market": "sz"
   },
   {
     "code": "001979",
-    "name": "招商蛇口"
+    "name": "招商蛇口",
+    "market": "sz"
   },
   {
     "code": "002027",
-    "name": "分众传媒"
+    "name": "分众传媒",
+    "market": "sz"
   },
   {
     "code": "002050",
-    "name": "三花智控"
+    "name": "三花智控",
+    "market": "sz"
   },
   {
     "code": "002129",
-    "name": "中环股份"
+    "name": "中环股份",
+    "market": "sz"
   },
   {
     "code": "002142",
-    "name": "宁波银行"
+    "name": "宁波银行",
+    "market": "sz"
   },
   {
     "code": "002230",
-    "name": "科大讯飞"
+    "name": "科大讯飞",
+    "market": "sz"
   },
   {
     "code": "002241",
-    "name": "歌尔股份"
+    "name": "歌尔股份",
+    "market": "sz"
   },
   {
     "code": "002304",
-    "name": "洋河股份"
+    "name": "洋河股份",
+    "market": "sz"
   },
   {
     "code": "002371",
-    "name": "北方华创"
+    "name": "北方华创",
+    "market": "sz"
   },
   {
     "code": "002415",
-    "name": "海康威视"
+    "name": "海康威视",
+    "market": "sz"
   },
   {
     "code": "002475",
-    "name": "立讯精密"
+    "name": "立讯精密",
+    "market": "sz"
   },
   {
     "code": "002594",
-    "name": "比亚迪"
+    "name": "比亚迪",
+    "market": "sz"
   },
   {
     "code": "002714",
-    "name": "牧原股份"
+    "name": "牧原股份",
+    "market": "sz"
   },
   {
     "code": "002916",
-    "name": "深南电路"
+    "name": "深南电路",
+    "market": "sz"
   },
   {
     "code": "002920",
-    "name": "德赛西威"
+    "name": "德赛西威",
+    "market": "sz"
   },
   {
     "code": "003816",
-    "name": "中国广核"
+    "name": "中国广核",
+    "market": "sz"
   },
   {
     "code": "00388.HK",
-    "name": "香港交易所"
+    "name": "香港交易所",
+    "market": "hk"
   },
   {
     "code": "00700.HK",
-    "name": "腾讯控股"
+    "name": "腾讯控股",
+    "market": "hk"
   },
   {
     "code": "00728.HK",
-    "name": "中国电信"
+    "name": "中国电信",
+    "market": "hk"
   },
   {
     "code": "00883.HK",
-    "name": "中国海洋石油"
+    "name": "中国海洋石油",
+    "market": "hk"
   },
   {
     "code": "00939.HK",
-    "name": "建设银行"
+    "name": "建设银行",
+    "market": "hk"
   },
   {
     "code": "00941.HK",
-    "name": "中国移动"
+    "name": "中国移动",
+    "market": "hk"
   },
   {
     "code": "01024.HK",
-    "name": "快手"
+    "name": "快手",
+    "market": "hk"
   },
   {
     "code": "01299.HK",
-    "name": "友邦保险"
+    "name": "友邦保险",
+    "market": "hk"
   },
   {
     "code": "01398.HK",
-    "name": "工商银行"
+    "name": "工商银行",
+    "market": "hk"
   },
   {
     "code": "01810.HK",
-    "name": "小米集团"
+    "name": "小米集团",
+    "market": "hk"
   },
   {
     "code": "02015.HK",
-    "name": "理想汽车"
+    "name": "理想汽车",
+    "market": "hk"
   },
   {
     "code": "02318.HK",
-    "name": "中国平安"
+    "name": "中国平安",
+    "market": "hk"
   },
   {
     "code": "02577.HK",
-    "name": "英诺赛科"
+    "name": "英诺赛科",
+    "market": "hk"
   },
   {
     "code": "03690.HK",
-    "name": "美团"
+    "name": "美团",
+    "market": "hk"
   },
   {
     "code": "03988.HK",
-    "name": "中国银行"
+    "name": "中国银行",
+    "market": "hk"
   },
   {
     "code": "06060.HK",
-    "name": "众安在线"
+    "name": "众安在线",
+    "market": "hk"
   },
   {
     "code": "06618.HK",
-    "name": "京东健康"
+    "name": "京东健康",
+    "market": "hk"
   },
   {
     "code": "09618.HK",
-    "name": "京东集团"
+    "name": "京东集团",
+    "market": "hk"
   },
   {
     "code": "09626.HK",
-    "name": "哔哩哔哩"
+    "name": "哔哩哔哩",
+    "market": "hk"
   },
   {
     "code": "09868.HK",
-    "name": "小鹏汽车"
+    "name": "小鹏汽车",
+    "market": "hk"
   },
   {
     "code": "09888.HK",
-    "name": "百度集团"
+    "name": "百度集团",
+    "market": "hk"
   },
   {
     "code": "09988.HK",
-    "name": "阿里巴巴"
+    "name": "阿里巴巴",
+    "market": "hk"
   },
   {
     "code": "09999.HK",
-    "name": "网易"
+    "name": "网易",
+    "market": "hk"
   },
   {
     "code": "110011",
-    "name": "易方达中小盘混合"
+    "name": "易方达中小盘混合",
+    "market": "sz"
   },
   {
     "code": "159915",
-    "name": "创业板ETF"
+    "name": "创业板ETF",
+    "market": "sz"
   },
   {
     "code": "159919",
-    "name": "沪深300ETF(深)"
+    "name": "沪深300ETF(深)",
+    "market": "sz"
   },
   {
     "code": "161725",
-    "name": "招商中证白酒指数(LOF)"
+    "name": "招商中证白酒指数(LOF)",
+    "market": "sz"
   },
   {
     "code": "300014",
-    "name": "亿纬锂能"
+    "name": "亿纬锂能",
+    "market": "sz"
   },
   {
     "code": "300015",
-    "name": "爱尔眼科"
+    "name": "爱尔眼科",
+    "market": "sz"
   },
   {
     "code": "300059",
-    "name": "东方财富"
+    "name": "东方财富",
+    "market": "sz"
   },
   {
     "code": "300122",
-    "name": "智飞生物"
+    "name": "智飞生物",
+    "market": "sz"
   },
   {
     "code": "300124",
-    "name": "汇川技术"
+    "name": "汇川技术",
+    "market": "sz"
   },
   {
     "code": "300274",
-    "name": "阳光电源"
+    "name": "阳光电源",
+    "market": "sz"
   },
   {
     "code": "300308",
-    "name": "中际旭创"
+    "name": "中际旭创",
+    "market": "sz"
   },
   {
     "code": "300433",
-    "name": "蓝思科技"
+    "name": "蓝思科技",
+    "market": "sz"
   },
   {
     "code": "300498",
-    "name": "温氏股份"
+    "name": "温氏股份",
+    "market": "sz"
   },
   {
     "code": "300502",
-    "name": "新易盛"
+    "name": "新易盛",
+    "market": "sz"
   },
   {
     "code": "300750",
-    "name": "宁德时代"
+    "name": "宁德时代",
+    "market": "sz"
   },
   {
     "code": "300760",
-    "name": "迈瑞医疗"
+    "name": "迈瑞医疗",
+    "market": "sz"
   },
   {
     "code": "510300",
-    "name": "沪深300ETF"
+    "name": "沪深300ETF",
+    "market": "sz"
   },
   {
     "code": "510500",
-    "name": "中证500ETF"
+    "name": "中证500ETF",
+    "market": "sz"
   },
   {
     "code": "519674",
-    "name": "银河创新成长混合"
+    "name": "银河创新成长混合",
+    "market": "sz"
   },
   {
     "code": "600000",
-    "name": "浦发银行"
+    "name": "浦发银行",
+    "market": "sh"
   },
   {
     "code": "600009",
-    "name": "上海机场"
+    "name": "上海机场",
+    "market": "sh"
   },
   {
     "code": "600019",
-    "name": "宝钢股份"
+    "name": "宝钢股份",
+    "market": "sh"
   },
   {
     "code": "600028",
-    "name": "中国石化"
+    "name": "中国石化",
+    "market": "sh"
   },
   {
     "code": "600030",
-    "name": "中信证券"
+    "name": "中信证券",
+    "market": "sh"
   },
   {
     "code": "600036",
-    "name": "招商银行"
+    "name": "招商银行",
+    "market": "sh"
   },
   {
     "code": "600048",
-    "name": "保利发展"
+    "name": "保利发展",
+    "market": "sh"
   },
   {
     "code": "600050",
-    "name": "中国联通"
+    "name": "中国联通",
+    "market": "sh"
   },
   {
     "code": "600104",
-    "name": "上汽集团"
+    "name": "上汽集团",
+    "market": "sh"
   },
   {
     "code": "600276",
-    "name": "恒瑞医药"
+    "name": "恒瑞医药",
+    "market": "sh"
   },
   {
     "code": "600309",
-    "name": "万华化学"
+    "name": "万华化学",
+    "market": "sh"
   },
   {
     "code": "600519",
-    "name": "贵州茅台"
+    "name": "贵州茅台",
+    "market": "sh"
   },
   {
     "code": "600585",
-    "name": "海螺水泥"
+    "name": "海螺水泥",
+    "market": "sh"
   },
   {
     "code": "600690",
-    "name": "海尔智家"
+    "name": "海尔智家",
+    "market": "sh"
   },
   {
     "code": "600900",
-    "name": "长江电力"
+    "name": "长江电力",
+    "market": "sh"
   },
   {
     "code": "601012",
-    "name": "隆基绿能"
+    "name": "隆基绿能",
+    "market": "sh"
   },
   {
     "code": "601088",
-    "name": "中国神华"
+    "name": "中国神华",
+    "market": "sh"
   },
   {
     "code": "601166",
-    "name": "兴业银行"
+    "name": "兴业银行",
+    "market": "sh"
   },
   {
     "code": "601288",
-    "name": "农业银行"
+    "name": "农业银行",
+    "market": "sh"
   },
   {
     "code": "601318",
-    "name": "中国平安"
+    "name": "中国平安",
+    "market": "sh"
   },
   {
     "code": "601398",
-    "name": "工商银行"
+    "name": "工商银行",
+    "market": "sh"
   },
   {
     "code": "601628",
-    "name": "中国人寿"
+    "name": "中国人寿",
+    "market": "sh"
   },
   {
     "code": "601668",
-    "name": "中国建筑"
+    "name": "中国建筑",
+    "market": "sh"
   },
   {
     "code": "601688",
-    "name": "华泰证券"
+    "name": "华泰证券",
+    "market": "sh"
   },
   {
     "code": "601818",
-    "name": "光大银行"
+    "name": "光大银行",
+    "market": "sh"
   },
   {
     "code": "601857",
-    "name": "中国石油"
+    "name": "中国石油",
+    "market": "sh"
   },
   {
     "code": "601888",
-    "name": "中国中免"
+    "name": "中国中免",
+    "market": "sh"
   },
   {
     "code": "601899",
-    "name": "紫金矿业"
+    "name": "紫金矿业",
+    "market": "sh"
   },
   {
     "code": "601988",
-    "name": "中国银行"
+    "name": "中国银行",
+    "market": "sh"
   },
   {
     "code": "603259",
-    "name": "药明康德"
+    "name": "药明康德",
+    "market": "sh"
   },
   {
     "code": "603288",
-    "name": "海天味业"
+    "name": "海天味业",
+    "market": "sh"
   },
   {
     "code": "603501",
-    "name": "韦尔股份"
+    "name": "韦尔股份",
+    "market": "sh"
   },
   {
     "code": "603799",
-    "name": "华友钴业"
+    "name": "华友钴业",
+    "market": "sh"
   },
   {
     "code": "603986",
-    "name": "兆易创新"
+    "name": "兆易创新",
+    "market": "sh"
   },
   {
     "code": "830799",
-    "name": "艾融软件"
+    "name": "艾融软件",
+    "market": "bj"
   },
   {
     "code": "832491",
-    "name": "奥迪威"
+    "name": "奥迪威",
+    "market": "bj"
   },
   {
     "code": "833171",
-    "name": "国航远洋"
+    "name": "国航远洋",
+    "market": "bj"
   },
   {
     "code": "833533",
-    "name": "骏创科技"
+    "name": "骏创科技",
+    "market": "bj"
   },
   {
     "code": "834033",
-    "name": "康普化学"
+    "name": "康普化学",
+    "market": "bj"
   },
   {
     "code": "834599",
-    "name": "同力股份"
+    "name": "同力股份",
+    "market": "bj"
   },
   {
     "code": "835185",
-    "name": "贝特瑞"
+    "name": "贝特瑞",
+    "market": "bj"
   },
   {
     "code": "835640",
-    "name": "富士达"
+    "name": "富士达",
+    "market": "bj"
   },
   {
     "code": "836077",
-    "name": "吉林碳谷"
+    "name": "吉林碳谷",
+    "market": "bj"
   },
   {
     "code": "836892",
-    "name": "广咨国际"
+    "name": "广咨国际",
+    "market": "bj"
   },
   {
     "code": "837344",
-    "name": "三元基因"
+    "name": "三元基因",
+    "market": "bj"
   },
   {
     "code": "839167",
-    "name": "同享科技"
+    "name": "同享科技",
+    "market": "bj"
   },
   {
     "code": "839725",
-    "name": "惠丰钻石"
+    "name": "惠丰钻石",
+    "market": "bj"
   },
   {
     "code": "872808",
-    "name": "曙光数创"
+    "name": "曙光数创",
+    "market": "bj"
   }
 ]

--- a/gui/templates/papertrade_setup.html
+++ b/gui/templates/papertrade_setup.html
@@ -48,11 +48,13 @@
       }
       .search-result-card h3 { margin: 0; color: #1976d2; font-size: 1.1rem; }
       .search-result-card p { margin: 0.3rem 0 0 0; color: #666; font-size: 0.9rem; }
-      .search-result-card .btn-select {
-        padding: 0.5rem 1.2rem; background: #4caf50; color: white; border: none;
-        border-radius: 4px; cursor: pointer; font-size: 0.9rem;
-      }
-      .search-result-card .btn-select:hover { background: #45a049; }
+      .btn-select { padding: 0.5rem 1.5rem; background: #4caf50; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 0.9rem; white-space: nowrap; }
+      .btn-select:hover { background: #45a049; }
+      /* 市场标签样式 */
+      .market-badge-inline.sh { background: #e3f2fd; color: #1565c0; }
+      .market-badge-inline.sz { background: #fff3e0; color: #e65100; }
+      .market-badge-inline.bj { background: #f3e5f5; color: #7b1fa2; }
+      .market-badge-inline.hk { background: #e8f5e9; color: #2e7d32; }
 
       .btn-submit {
         width: 100%; padding: 1rem; background: #1976d2; color: white; border: none;
@@ -267,6 +269,17 @@ document.addEventListener('DOMContentLoaded', function() {
     <script>
       let selectedStockCode = '';
       let selectedStockName = '';
+      let selectedStockMarket = '';
+
+      // 市场标签映射
+      function getMarketLabel(market) {
+        var labels = { 'sh': '沪', 'sz': '深', 'bj': '北', 'hk': '港' };
+        return labels[market] || '';
+      }
+      function getMarketClass(market) {
+        var classes = { 'sh': 'sh', 'sz': 'sz', 'bj': 'bj', 'hk': 'hk' };
+        return classes[market] || '';
+      }
 
       function searchStock() {
         const query = document.getElementById('stock-search').value.trim();
@@ -284,20 +297,23 @@ document.addEventListener('DOMContentLoaded', function() {
             if (data.results && Array.isArray(data.results)) {
               items = data.results;
             } else if (data.code && data.name) {
-              items = [{ code: data.code, name: data.name }];
+              items = [{ code: data.code, name: data.name, market: data.market || '' }];
             }
             if (items.length === 0) {
               resultDiv.innerHTML = '<div style="color:#d32f2f;padding:0.8rem;background:#ffebee;border-radius:4px;">未找到匹配的股票</div>';
               return;
             }
             if (items.length === 1) {
-              showStockSelected(items[0].code, items[0].name);
+              showStockSelected(items[0].code, items[0].name, items[0].market || '');
             } else {
               let html = '<div style="color:#2e7d32;padding:0.5rem 0;">✓ 找到多个匹配项，请选择：</div>';
               for (const it of items) {
+                const mLabel = getMarketLabel(it.market);
+                const mClass = getMarketClass(it.market);
+                const badge = mLabel ? '<span style="display:inline-block;font-size:0.7rem;padding:1px 6px;border-radius:3px;font-weight:bold;vertical-align:middle;margin-left:4px;" class="market-badge-inline ' + mClass + '">' + mLabel + '</span>' : '';
                 html += '<div class="search-result-card">' +
-                  '<div><h3>' + it.code + ' - ' + it.name + '</h3></div>' +
-                  '<div><button class="btn-select" onclick="showStockSelected(\'' + it.code + '\', \'' + it.name + '\')">选择</button></div>' +
+                  '<div><h3>' + it.code + badge + ' - ' + it.name + '</h3></div>' +
+                  '<div><button class="btn-select" onclick="showStockSelected(\'' + it.code + '\', \'' + it.name + '\', \'' + (it.market || '') + '\')">选择</button></div>' +
                   '</div>';
               }
               resultDiv.innerHTML = html;
@@ -308,14 +324,18 @@ document.addEventListener('DOMContentLoaded', function() {
           });
       }
 
-      function showStockSelected(code, name) {
+      function showStockSelected(code, name, market) {
         selectedStockCode = code;
         selectedStockName = name;
+        selectedStockMarket = market || '';
         document.getElementById('stock_code').value = code;
         document.getElementById('stock_name').value = name;
+        const mLabel = getMarketLabel(market);
+        const mClass = getMarketClass(market);
+        const badge = mLabel ? '<span style="display:inline-block;font-size:0.7rem;padding:1px 6px;border-radius:3px;font-weight:bold;vertical-align:middle;margin-left:4px;" class="market-badge-inline ' + mClass + '">' + mLabel + '</span>' : '';
         document.getElementById('stock-result').innerHTML =
           '<div class="search-result-card">' +
-          '<div><h3>' + code + ' - ' + name + '</h3><p>✓ 已选择</p></div>' +
+          '<div><h3>' + code + badge + ' - ' + name + '</h3><p>✓ 已选择</p></div>' +
           '<div><button class="btn-select" onclick="clearStockSelection()" style="background:#f44336;">取消选择</button></div>' +
           '</div>';
       }

--- a/gui/templates/select_stock.html
+++ b/gui/templates/select_stock.html
@@ -160,6 +160,36 @@
         color: #666; 
         font-size: 0.9rem;
       }
+      .stock-card .market-badge {
+        display: inline-block;
+        font-size: 0.7rem;
+        padding: 1px 6px;
+        border-radius: 3px;
+        margin-left: 4px;
+        font-weight: bold;
+        vertical-align: middle;
+      }
+      .market-badge.sh { background: #e3f2fd; color: #1565c0; }
+      .market-badge.sz { background: #fff3e0; color: #e65100; }
+      .market-badge.bj { background: #f3e5f5; color: #7b1fa2; }
+      .market-badge.hk { background: #e8f5e9; color: #2e7d32; }
+      .market-filter-bar {
+        display: flex;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+      }
+      .market-filter-btn {
+        padding: 0.4rem 1rem;
+        border: 1px solid #ddd;
+        border-radius: 20px;
+        background: white;
+        cursor: pointer;
+        font-size: 0.85rem;
+        transition: all 0.2s;
+      }
+      .market-filter-btn:hover { border-color: #1976d2; }
+      .market-filter-btn.active { background: #1976d2; color: white; border-color: #1976d2; }
       .section-card {
         background: white;
         border-radius: 8px;
@@ -319,43 +349,75 @@
 
     <div class="popular-stocks">
       <h3>🔥 热门股票</h3>
+      <div class="market-filter-bar" id="market-filter-bar">
+        <button class="market-filter-btn active" onclick="filterByMarket('all')">📊 全部</button>
+        <button class="market-filter-btn" onclick="filterByMarket('sh')">🏛️ 沪市</button>
+        <button class="market-filter-btn" onclick="filterByMarket('sz')">🏛️ 深市</button>
+        <button class="market-filter-btn" onclick="filterByMarket('bj')">🏛️ 北交所</button>
+        <button class="market-filter-btn" onclick="filterByMarket('hk')">🏛️ 港股</button>
+      </div>
       <div class="stock-grid" id="stock-grid">
-        <div class="stock-card" onclick="selectStock('600900', '长江电力')">
-          <div class="code">600900</div>
+        <div class="stock-card" data-market="sh" onclick="selectStock('600900', '长江电力')">
+          <div class="code">600900<span class="market-badge sh">沪</span></div>
           <div class="name">长江电力</div>
         </div>
-        <div class="stock-card" onclick="selectStock('600519', '贵州茅台')">
-          <div class="code">600519</div>
+        <div class="stock-card" data-market="sh" onclick="selectStock('600519', '贵州茅台')">
+          <div class="code">600519<span class="market-badge sh">沪</span></div>
           <div class="name">贵州茅台</div>
         </div>
-        <div class="stock-card" onclick="selectStock('601318', '中国平安')">
-          <div class="code">601318</div>
+        <div class="stock-card" data-market="sh" onclick="selectStock('601318', '中国平安')">
+          <div class="code">601318<span class="market-badge sh">沪</span></div>
           <div class="name">中国平安</div>
         </div>
-        <div class="stock-card" onclick="selectStock('000333', '美的集团')">
-          <div class="code">000333</div>
+        <div class="stock-card" data-market="sz" onclick="selectStock('000333', '美的集团')">
+          <div class="code">000333<span class="market-badge sz">深</span></div>
           <div class="name">美的集团</div>
         </div>
-        <div class="stock-card" onclick="selectStock('000651', '格力电器')">
-          <div class="code">000651</div>
+        <div class="stock-card" data-market="sz" onclick="selectStock('000651', '格力电器')">
+          <div class="code">000651<span class="market-badge sz">深</span></div>
           <div class="name">格力电器</div>
         </div>
-        <div class="stock-card" onclick="selectStock('002594', '比亚迪')">
-          <div class="code">002594</div>
+        <div class="stock-card" data-market="sz" onclick="selectStock('002594', '比亚迪')">
+          <div class="code">002594<span class="market-badge sz">深</span></div>
           <div class="name">比亚迪</div>
         </div>
-        <div class="stock-card" onclick="selectStock('300750', '宁德时代')">
-          <div class="code">300750</div>
+        <div class="stock-card" data-market="sz" onclick="selectStock('300750', '宁德时代')">
+          <div class="code">300750<span class="market-badge sz">深</span></div>
           <div class="name">宁德时代</div>
         </div>
-        <div class="stock-card" onclick="selectStock('601398', '工商银行')">
-          <div class="code">601398</div>
+        <div class="stock-card" data-market="sh" onclick="selectStock('601398', '工商银行')">
+          <div class="code">601398<span class="market-badge sh">沪</span></div>
           <div class="name">工商银行</div>
         </div>
       </div>
     </div>
 
     <script>
+      // 市场标签映射
+      function getMarketLabel(market) {
+        var labels = { 'sh': '沪', 'sz': '深', 'bj': '北', 'hk': '港' };
+        return labels[market] || '';
+      }
+      function getMarketClass(market) {
+        var classes = { 'sh': 'sh', 'sz': 'sz', 'bj': 'bj', 'hk': 'hk' };
+        return classes[market] || '';
+      }
+
+      // 按市场筛选热门股票
+      function filterByMarket(market) {
+        // 更新按钮状态
+        document.querySelectorAll('.market-filter-btn').forEach(function(btn) { btn.classList.remove('active'); });
+        event.target.classList.add('active');
+        // 显示/隐藏股票卡片
+        document.querySelectorAll('#stock-grid .stock-card').forEach(function(card) {
+          if (market === 'all' || card.dataset.market === market) {
+            card.style.display = '';
+          } else {
+            card.style.display = 'none';
+          }
+        });
+      }
+
       // 搜索表单提交
       document.getElementById('search-form').addEventListener('submit', function(e) {
         e.preventDefault();
@@ -380,7 +442,7 @@
             if (data.results && Array.isArray(data.results)) {
               items = data.results;
             } else if (data.code && data.name) {
-              items = [{ code: data.code, name: data.name }];
+              items = [{ code: data.code, name: data.name, market: data.market || '' }];
             }
 
             if (items.length === 0) {
@@ -393,10 +455,13 @@
             let html = '<div class="success-message">✓ 找到匹配的股票</div>';
             if (items.length === 1) {
               const it = items[0];
+              const mLabel = getMarketLabel(it.market);
+              const mClass = getMarketClass(it.market);
+              const badge = mLabel ? '<span class="market-badge ' + mClass + '">' + mLabel + '</span>' : '';
               html +=
                 '<div class="stock-info">' +
                   '<div class="stock-info-left">' +
-                    '<h2>' + it.code + ' - ' + it.name + '</h2>' +
+                    '<h2>' + it.code + badge + ' - ' + it.name + '</h2>' +
                     '<p>点击右侧按钮继续选择策略</p>' +
                   '</div>' +
                   '<div class="stock-info-right">' +
@@ -406,8 +471,11 @@
             } else {
               html += '<div class="search-results-list">';
               for (const it of items) {
+                const mLabel = getMarketLabel(it.market);
+                const mClass = getMarketClass(it.market);
+                const badge = mLabel ? '<span class="market-badge ' + mClass + '">' + mLabel + '</span>' : '';
                 html += '<div class="search-result-item">' +
-                          '<div class="sr-left"><strong>' + it.code + '</strong> - ' + it.name + '</div>' +
+                          '<div class="sr-left"><strong>' + it.code + '</strong>' + badge + ' - ' + it.name + '</div>' +
                           '<div class="sr-right"><button onclick="selectStock(\'' + it.code + '\', \'' + it.name + '\')">选择</button></div>' +
                         '</div>';
               }

--- a/gui/web.py
+++ b/gui/web.py
@@ -531,13 +531,13 @@ def search_stock():
     if not matches:
         return jsonify({'error': f'未找到股票：{query}。请检查股票代码或名称是否正确。'})
 
-    # 若只有一项匹配，保持向后兼容：返回单个对象（code/name）
+    # 若只有一项匹配，保持向后兼容：返回单个对象（code/name/market）
     if len(matches) == 1:
         stock = matches[0]
-        return jsonify({'code': stock['code'], 'name': stock['name']})
+        return jsonify({'code': stock['code'], 'name': stock['name'], 'market': stock.get('market', '')})
 
     # 多项时返回 results 数组，供前端选择
-    simplified = [{'code': s['code'], 'name': s['name']} for s in matches]
+    simplified = [{'code': s['code'], 'name': s['name'], 'market': s.get('market', '')} for s in matches]
     return jsonify({'results': simplified})
 
 


### PR DESCRIPTION
## 变更内容

为  添加  字段，支持按市场分类展示。

### 具体修改
- : 所有125只股票添加 market 字段（sh/sz/bj/hk）
- : 搜索 API 返回 market 信息
- : 前端 UI 展示市场标签 + 支持按市场筛选
- : 模拟盘设置页支持市场分类
- , : 策略引擎使用 market 字段
- , : 数据源使用 market 字段

### 相关 Issue
Closes #160