### PR TITLE
#175 配置参数页面取消数据源选择功能

### DIFF
--- a/gui/templates/strategy_dynamic.html
+++ b/gui/templates/strategy_dynamic.html
@@ -227,15 +227,6 @@
         <p class="empty-params">该策略无额外参数，使用默认回测参数即可运行。</p>
         {% endif %}
 
-        <label>数据源
-          <select name="source">
-            <option value="auto">自动选择</option>
-            <option value="akshare">AKShare</option>
-            <option value="baostock">Baostock</option>
-          </select>
-          <div class="param-hint">数据源选择，推荐使用"自动选择"</div>
-        </label>
-
         <label>交易单位（股/份）
           <input type="number" name="lot" id="lot-input" value="100" min="0.01" step="0.01" required oninput="updateFundPreview()" />
           <div class="param-hint">股票常用 100；ETF/场外基金可设置为 1 或 0.01</div>
@@ -337,23 +328,19 @@
       function getFormData() {
         const data = {};
         data.strategy = strategyKey;
-        data.source = document.querySelector('select[name="source"]').value;
         data.lot = document.querySelector('input[name="lot"]').value;
         data.cash = document.querySelector('input[name="cash"]').value;
         document.querySelectorAll('input[name^="param_"], input[name^="period_"], input[name^="threshold_"], input[name^="ma_"], input[name^="rsi_"], input[name^="bb_"], input[name^="std_"]').forEach(function(inp) {
           data[inp.name] = inp.value;
         });
         /* Also capture any input that is a strategy parameter (all inputs inside form-section except source/lot/cash) */
-        document.querySelectorAll('.form-section input:not([name="source"]):not([name="lot"]):not([name="cash"])').forEach(function(inp) {
+        document.querySelectorAll('.form-section input:not([name="lot"]):not([name="cash"])').forEach(function(inp) {
           if (inp.name && inp.type !== 'hidden') data[inp.name] = inp.value;
         });
         return data;
       }
 
       function fillForm(data) {
-        /* Fill source */
-        const srcEl = document.querySelector('select[name="source"]');
-        if (srcEl && data.source) srcEl.value = data.source;
         /* Fill lot */
         const lotEl = document.querySelector('input[name="lot"]');
         if (lotEl && data.lot) lotEl.value = data.lot;
@@ -362,7 +349,7 @@
         if (cashEl && data.cash) cashEl.value = data.cash;
         /* Fill all other inputs by name */
         Object.keys(data).forEach(function(key) {
-          if (key === 'strategy' || key === 'source' || key === 'lot' || key === 'cash') return;
+          if (key === 'strategy' || key === 'lot' || key === 'cash') return;
           const el = document.querySelector('[name="' + key + '"]');
           if (el) el.value = data[key];
         });

--- a/gui/web.py
+++ b/gui/web.py
@@ -893,7 +893,7 @@ def run():
     else:
         end = session.get('backtest_end') or None
 
-    source = request.form.get('source', 'auto')
+    source = 'auto'
     strategy = request.form.get('strategy', 'sma')
     lot = float(request.form.get('lot') or 100.0)
     cash = float(request.form.get('cash') or 100000.0)
@@ -1046,7 +1046,7 @@ def run_multi():
     start = form_start if form_start else (session.get('backtest_start') or None)
     end = form_end if form_end else (session.get('backtest_end') or None)
 
-    source = request.form.get('source', 'auto')
+    source = 'auto'
     lot = float(request.form.get('lot') or 100.0)
     cash = float(request.form.get('cash') or 100000.0)
 

--- a/tests/guitests/test_gui_backtest_report_e2e.py
+++ b/tests/guitests/test_gui_backtest_report_e2e.py
@@ -205,14 +205,13 @@ class TestGuiBacktestReportE2E(unittest.TestCase):
                 )
             )
 
-            page.select_option("select[name='source']", "auto")
             page.fill("input[name='lot']", "100")
             page.fill("input[name='cash']", "100000")
             expect(page.locator(".strategy-info")).to_be_visible()
             steps.append(
                 (
                     "配置策略参数",
-                    "使用自动数据源、每手 100 股、初始资金 100000 元，并确认实时计算区域正常显示。",
+                    "设置每手 100 股、初始资金 100000 元，并确认实时计算区域正常显示。",
                     self._screenshot(page, "06_strategy_params.png"),
                 )
             )

--- a/tests/guitests/test_realtime_lot_calculation.py
+++ b/tests/guitests/test_realtime_lot_calculation.py
@@ -111,7 +111,6 @@ class TestRealtimeLotCalculation(unittest.TestCase):
         # 验证基础表单字段
         self.assertIn('name="lot"', html)
         self.assertIn('name="cash"', html)
-        self.assertIn('name="source"', html)
 
     def test_strategy_mean_cost_page_contains_realtime_info(self):
         """测试均值成本策略页面包含动态参数渲染"""
@@ -133,7 +132,6 @@ class TestRealtimeLotCalculation(unittest.TestCase):
         # 验证基础表单字段
         self.assertIn('name="lot"', html)
         self.assertIn('name="cash"', html)
-        self.assertIn('name="source"', html)
         self.assertIn('name="strategy"', html)
 
     def test_strategy_fixed_amount_page_contains_realtime_info(self):


### PR DESCRIPTION
## 改动内容
配置参数页面取消数据源选择功能

### 变更
- 删除数据源下拉框（AKShare/Baostock/自动选择）
- 清理前端 getFormData/fillForm 中的 source 字段
- 后端 web.py 中 source 统一设为 auto

Closes #175