### PR TITLE
#183 股票搜索功能改进：预加载全量股票列表 + 选股后自动缓存5年日线

### DIFF
--- a/exchange/prefetch.py
+++ b/exchange/prefetch.py
@@ -1,0 +1,67 @@
+"""
+股票数据预缓存模块 — 用于在用户搜索股票时提前缓存历史数据。
+
+EXCH role owns this module per AGENTS.md.
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+from exchange.source.data_provider import get_data
+
+logger = logging.getLogger(__name__)
+
+
+def prefetch_stock_data(symbol: str, years: int = 5) -> dict:
+    """
+    预取并缓存指定股票的历史日线数据。
+
+    该函数计算起始日期（默认 5 年前），调用 get_data() 获取数据
+    （缓存由 get_data 内部处理，保存至 data/{symbol}.csv），
+    然后返回操作结果字典。
+
+    Args:
+        symbol: 股票代码，例如 '000001'、'00001.HK'、'830799.BJ'
+        years:  要获取的历史年数（默认 5 年）
+
+    Returns:
+        dict: {
+            'success': bool,   — 是否成功获取并缓存
+            'rows':    int,    — 缓存的数据行数
+            'symbol':  str,    — 股票代码
+            'error':   str | None  — 错误信息（成功时为 None）
+        }
+    """
+    today = datetime.now().strftime("%Y%m%d")
+    start_date = (datetime.now() - timedelta(days=years * 365)).strftime("%Y%m%d")
+
+    try:
+        df = get_data(symbol=symbol, start_date=start_date, end_date=today)
+        if df is not None and not df.empty:
+            row_count = len(df)
+            logger.info(
+                "成功预缓存 %s 数据，共 %d 行（%s ~ %s）",
+                symbol, row_count, start_date, today,
+            )
+            return {
+                "success": True,
+                "rows": row_count,
+                "symbol": symbol,
+                "error": None,
+            }
+        else:
+            logger.warning("预缓存 %s 数据为空", symbol)
+            return {
+                "success": False,
+                "rows": 0,
+                "symbol": symbol,
+                "error": "无数据返回",
+            }
+    except Exception as e:
+        logger.error("预缓存 %s 失败: %s", symbol, str(e))
+        return {
+            "success": False,
+            "rows": 0,
+            "symbol": symbol,
+            "error": str(e),
+        }

--- a/gui/stock_list.json
+++ b/gui/stock_list.json
@@ -1,5 +1,4055 @@
 [
   {
+    "code": "600000",
+    "name": "浦发银行",
+    "market": "sh"
+  },
+  {
+    "code": "600004",
+    "name": "白云机场",
+    "market": "sh"
+  },
+  {
+    "code": "600006",
+    "name": "东风汽车",
+    "market": "sh"
+  },
+  {
+    "code": "600007",
+    "name": "中国国贸",
+    "market": "sh"
+  },
+  {
+    "code": "600008",
+    "name": "首创环保",
+    "market": "sh"
+  },
+  {
+    "code": "600009",
+    "name": "上海机场",
+    "market": "sh"
+  },
+  {
+    "code": "600010",
+    "name": "包钢股份",
+    "market": "sh"
+  },
+  {
+    "code": "600011",
+    "name": "华能国际",
+    "market": "sh"
+  },
+  {
+    "code": "600012",
+    "name": "皖通高速",
+    "market": "sh"
+  },
+  {
+    "code": "600015",
+    "name": "华夏银行",
+    "market": "sh"
+  },
+  {
+    "code": "600016",
+    "name": "民生银行",
+    "market": "sh"
+  },
+  {
+    "code": "600017",
+    "name": "日照港",
+    "market": "sh"
+  },
+  {
+    "code": "600018",
+    "name": "上港集团",
+    "market": "sh"
+  },
+  {
+    "code": "600019",
+    "name": "宝钢股份",
+    "market": "sh"
+  },
+  {
+    "code": "600020",
+    "name": "中原高速",
+    "market": "sh"
+  },
+  {
+    "code": "600021",
+    "name": "上海电力",
+    "market": "sh"
+  },
+  {
+    "code": "600022",
+    "name": "山东钢铁",
+    "market": "sh"
+  },
+  {
+    "code": "600023",
+    "name": "浙能电力",
+    "market": "sh"
+  },
+  {
+    "code": "600025",
+    "name": "华能水电",
+    "market": "sh"
+  },
+  {
+    "code": "600026",
+    "name": "中远海能",
+    "market": "sh"
+  },
+  {
+    "code": "600027",
+    "name": "华电国际",
+    "market": "sh"
+  },
+  {
+    "code": "600028",
+    "name": "中国石化",
+    "market": "sh"
+  },
+  {
+    "code": "600029",
+    "name": "南方航空",
+    "market": "sh"
+  },
+  {
+    "code": "600030",
+    "name": "中信证券",
+    "market": "sh"
+  },
+  {
+    "code": "600031",
+    "name": "三一重工",
+    "market": "sh"
+  },
+  {
+    "code": "600033",
+    "name": "福建高速",
+    "market": "sh"
+  },
+  {
+    "code": "600035",
+    "name": "楚天高速",
+    "market": "sh"
+  },
+  {
+    "code": "600036",
+    "name": "招商银行",
+    "market": "sh"
+  },
+  {
+    "code": "600037",
+    "name": "歌华有线",
+    "market": "sh"
+  },
+  {
+    "code": "600038",
+    "name": "中直股份",
+    "market": "sh"
+  },
+  {
+    "code": "600039",
+    "name": "四川路桥",
+    "market": "sh"
+  },
+  {
+    "code": "600048",
+    "name": "保利发展",
+    "market": "sh"
+  },
+  {
+    "code": "600050",
+    "name": "中国联通",
+    "market": "sh"
+  },
+  {
+    "code": "600053",
+    "name": "九鼎投资",
+    "market": "sh"
+  },
+  {
+    "code": "600055",
+    "name": "万东医疗",
+    "market": "sh"
+  },
+  {
+    "code": "600056",
+    "name": "中国医药",
+    "market": "sh"
+  },
+  {
+    "code": "600057",
+    "name": "厦门象屿",
+    "market": "sh"
+  },
+  {
+    "code": "600058",
+    "name": "五矿发展",
+    "market": "sh"
+  },
+  {
+    "code": "600059",
+    "name": "古越龙山",
+    "market": "sh"
+  },
+  {
+    "code": "600060",
+    "name": "海信视像",
+    "market": "sh"
+  },
+  {
+    "code": "600061",
+    "name": "国投资本",
+    "market": "sh"
+  },
+  {
+    "code": "600062",
+    "name": "华润双鹤",
+    "market": "sh"
+  },
+  {
+    "code": "600063",
+    "name": "皖维高新",
+    "market": "sh"
+  },
+  {
+    "code": "600064",
+    "name": "南京高科",
+    "market": "sh"
+  },
+  {
+    "code": "600066",
+    "name": "宇通客车",
+    "market": "sh"
+  },
+  {
+    "code": "600067",
+    "name": "冠城大通",
+    "market": "sh"
+  },
+  {
+    "code": "600068",
+    "name": "葛洲坝",
+    "market": "sh"
+  },
+  {
+    "code": "600070",
+    "name": "浙江富润",
+    "market": "sh"
+  },
+  {
+    "code": "600071",
+    "name": "凤凰光学",
+    "market": "sh"
+  },
+  {
+    "code": "600072",
+    "name": "中船科技",
+    "market": "sh"
+  },
+  {
+    "code": "600073",
+    "name": "上海梅林",
+    "market": "sh"
+  },
+  {
+    "code": "600075",
+    "name": "新疆天业",
+    "market": "sh"
+  },
+  {
+    "code": "600076",
+    "name": "康欣新材",
+    "market": "sh"
+  },
+  {
+    "code": "600077",
+    "name": "宋都股份",
+    "market": "sh"
+  },
+  {
+    "code": "600078",
+    "name": "澄星股份",
+    "market": "sh"
+  },
+  {
+    "code": "600079",
+    "name": "人福医药",
+    "market": "sh"
+  },
+  {
+    "code": "600080",
+    "name": "金花股份",
+    "market": "sh"
+  },
+  {
+    "code": "600081",
+    "name": "东风科技",
+    "market": "sh"
+  },
+  {
+    "code": "600082",
+    "name": "海泰发展",
+    "market": "sh"
+  },
+  {
+    "code": "600083",
+    "name": "博信股份",
+    "market": "sh"
+  },
+  {
+    "code": "600084",
+    "name": "中葡股份",
+    "market": "sh"
+  },
+  {
+    "code": "600085",
+    "name": "同仁堂",
+    "market": "sh"
+  },
+  {
+    "code": "600086",
+    "name": "东方金钰",
+    "market": "sh"
+  },
+  {
+    "code": "600088",
+    "name": "中视传媒",
+    "market": "sh"
+  },
+  {
+    "code": "600089",
+    "name": "特变电工",
+    "market": "sh"
+  },
+  {
+    "code": "600090",
+    "name": "*ST济堂",
+    "market": "sh"
+  },
+  {
+    "code": "600091",
+    "name": "ST明科",
+    "market": "sh"
+  },
+  {
+    "code": "600093",
+    "name": "ST易见",
+    "market": "sh"
+  },
+  {
+    "code": "600094",
+    "name": "大名城",
+    "market": "sh"
+  },
+  {
+    "code": "600095",
+    "name": "湘财股份",
+    "market": "sh"
+  },
+  {
+    "code": "600096",
+    "name": "云天化",
+    "market": "sh"
+  },
+  {
+    "code": "600098",
+    "name": "广州发展",
+    "market": "sh"
+  },
+  {
+    "code": "600099",
+    "name": "林海股份",
+    "market": "sh"
+  },
+  {
+    "code": "600100",
+    "name": "同方股份",
+    "market": "sh"
+  },
+  {
+    "code": "600101",
+    "name": "明星电力",
+    "market": "sh"
+  },
+  {
+    "code": "600103",
+    "name": "青山纸业",
+    "market": "sh"
+  },
+  {
+    "code": "600104",
+    "name": "上汽集团",
+    "market": "sh"
+  },
+  {
+    "code": "600105",
+    "name": "永鼎股份",
+    "market": "sh"
+  },
+  {
+    "code": "600106",
+    "name": "重庆路桥",
+    "market": "sh"
+  },
+  {
+    "code": "600107",
+    "name": "美尔雅",
+    "market": "sh"
+  },
+  {
+    "code": "600108",
+    "name": "亚盛集团",
+    "market": "sh"
+  },
+  {
+    "code": "600109",
+    "name": "国金证券",
+    "market": "sh"
+  },
+  {
+    "code": "600110",
+    "name": "诺德股份",
+    "market": "sh"
+  },
+  {
+    "code": "600111",
+    "name": "北方稀土",
+    "market": "sh"
+  },
+  {
+    "code": "600112",
+    "name": "ST天成",
+    "market": "sh"
+  },
+  {
+    "code": "600113",
+    "name": "浙江东日",
+    "market": "sh"
+  },
+  {
+    "code": "600114",
+    "name": "东睦股份",
+    "market": "sh"
+  },
+  {
+    "code": "600115",
+    "name": "中国东航",
+    "market": "sh"
+  },
+  {
+    "code": "600116",
+    "name": "三峡水利",
+    "market": "sh"
+  },
+  {
+    "code": "600117",
+    "name": "西宁特钢",
+    "market": "sh"
+  },
+  {
+    "code": "600118",
+    "name": "中国卫星",
+    "market": "sh"
+  },
+  {
+    "code": "600119",
+    "name": "ST长投",
+    "market": "sh"
+  },
+  {
+    "code": "600120",
+    "name": "浙江东方",
+    "market": "sh"
+  },
+  {
+    "code": "600121",
+    "name": "郑州煤电",
+    "market": "sh"
+  },
+  {
+    "code": "600122",
+    "name": "ST宏图",
+    "market": "sh"
+  },
+  {
+    "code": "600123",
+    "name": "兰花科创",
+    "market": "sh"
+  },
+  {
+    "code": "600125",
+    "name": "铁龙物流",
+    "market": "sh"
+  },
+  {
+    "code": "600126",
+    "name": "杭钢股份",
+    "market": "sh"
+  },
+  {
+    "code": "600127",
+    "name": "金健米业",
+    "market": "sh"
+  },
+  {
+    "code": "600128",
+    "name": "弘业股份",
+    "market": "sh"
+  },
+  {
+    "code": "600129",
+    "name": "太极集团",
+    "market": "sh"
+  },
+  {
+    "code": "600130",
+    "name": "波导股份",
+    "market": "sh"
+  },
+  {
+    "code": "600131",
+    "name": "国网信通",
+    "market": "sh"
+  },
+  {
+    "code": "600132",
+    "name": "重庆啤酒",
+    "market": "sh"
+  },
+  {
+    "code": "600133",
+    "name": "东湖高新",
+    "market": "sh"
+  },
+  {
+    "code": "600135",
+    "name": "乐凯胶片",
+    "market": "sh"
+  },
+  {
+    "code": "600136",
+    "name": "当代文体",
+    "market": "sh"
+  },
+  {
+    "code": "600137",
+    "name": "浪莎股份",
+    "market": "sh"
+  },
+  {
+    "code": "600138",
+    "name": "中青旅",
+    "market": "sh"
+  },
+  {
+    "code": "600139",
+    "name": "西部资源",
+    "market": "sh"
+  },
+  {
+    "code": "600141",
+    "name": "兴发集团",
+    "market": "sh"
+  },
+  {
+    "code": "600143",
+    "name": "金发科技",
+    "market": "sh"
+  },
+  {
+    "code": "600145",
+    "name": "ST新亿",
+    "market": "sh"
+  },
+  {
+    "code": "600146",
+    "name": "ST环球",
+    "market": "sh"
+  },
+  {
+    "code": "600148",
+    "name": "长春一东",
+    "market": "sh"
+  },
+  {
+    "code": "600149",
+    "name": "ST坊展",
+    "market": "sh"
+  },
+  {
+    "code": "600150",
+    "name": "中国船舶",
+    "market": "sh"
+  },
+  {
+    "code": "600151",
+    "name": "航天机电",
+    "market": "sh"
+  },
+  {
+    "code": "600152",
+    "name": "维科技术",
+    "market": "sh"
+  },
+  {
+    "code": "600153",
+    "name": "建发股份",
+    "market": "sh"
+  },
+  {
+    "code": "600155",
+    "name": "华创阳安",
+    "market": "sh"
+  },
+  {
+    "code": "600156",
+    "name": "华升股份",
+    "market": "sh"
+  },
+  {
+    "code": "600157",
+    "name": "ST永泰",
+    "market": "sh"
+  },
+  {
+    "code": "600158",
+    "name": "中体产业",
+    "market": "sh"
+  },
+  {
+    "code": "600159",
+    "name": "大龙地产",
+    "market": "sh"
+  },
+  {
+    "code": "600160",
+    "name": "巨化股份",
+    "market": "sh"
+  },
+  {
+    "code": "600161",
+    "name": "天坛生物",
+    "market": "sh"
+  },
+  {
+    "code": "600162",
+    "name": "香江控股",
+    "market": "sh"
+  },
+  {
+    "code": "600163",
+    "name": "中闽能源",
+    "market": "sh"
+  },
+  {
+    "code": "600165",
+    "name": "新日恒力",
+    "market": "sh"
+  },
+  {
+    "code": "600166",
+    "name": "福田汽车",
+    "market": "sh"
+  },
+  {
+    "code": "600167",
+    "name": "联美控股",
+    "market": "sh"
+  },
+  {
+    "code": "600168",
+    "name": "武汉控股",
+    "market": "sh"
+  },
+  {
+    "code": "600169",
+    "name": "太原重工",
+    "market": "sh"
+  },
+  {
+    "code": "600170",
+    "name": "上海建工",
+    "market": "sh"
+  },
+  {
+    "code": "600171",
+    "name": "上海贝岭",
+    "market": "sh"
+  },
+  {
+    "code": "600172",
+    "name": "黄河旋风",
+    "market": "sh"
+  },
+  {
+    "code": "600173",
+    "name": "卧龙地产",
+    "market": "sh"
+  },
+  {
+    "code": "600175",
+    "name": "美都能源",
+    "market": "sh"
+  },
+  {
+    "code": "600176",
+    "name": "中国巨石",
+    "market": "sh"
+  },
+  {
+    "code": "600177",
+    "name": "雅戈尔",
+    "market": "sh"
+  },
+  {
+    "code": "600178",
+    "name": "东安动力",
+    "market": "sh"
+  },
+  {
+    "code": "600179",
+    "name": "安通控股",
+    "market": "sh"
+  },
+  {
+    "code": "600180",
+    "name": "瑞茂通",
+    "market": "sh"
+  },
+  {
+    "code": "600182",
+    "name": "S佳通",
+    "market": "sh"
+  },
+  {
+    "code": "600183",
+    "name": "生益科技",
+    "market": "sh"
+  },
+  {
+    "code": "600184",
+    "name": "光电股份",
+    "market": "sh"
+  },
+  {
+    "code": "600185",
+    "name": "格力地产",
+    "market": "sh"
+  },
+  {
+    "code": "600186",
+    "name": "莲花健康",
+    "market": "sh"
+  },
+  {
+    "code": "600187",
+    "name": "国中水务",
+    "market": "sh"
+  },
+  {
+    "code": "600188",
+    "name": "兖矿能源",
+    "market": "sh"
+  },
+  {
+    "code": "600189",
+    "name": "泉阳泉",
+    "market": "sh"
+  },
+  {
+    "code": "600190",
+    "name": "锦州港",
+    "market": "sh"
+  },
+  {
+    "code": "600191",
+    "name": "华资实业",
+    "market": "sh"
+  },
+  {
+    "code": "600192",
+    "name": "长城电工",
+    "market": "sh"
+  },
+  {
+    "code": "600193",
+    "name": "ST创兴",
+    "market": "sh"
+  },
+  {
+    "code": "600195",
+    "name": "中牧股份",
+    "market": "sh"
+  },
+  {
+    "code": "600196",
+    "name": "复星医药",
+    "market": "sh"
+  },
+  {
+    "code": "600197",
+    "name": "伊力特",
+    "market": "sh"
+  },
+  {
+    "code": "600198",
+    "name": "大唐电信",
+    "market": "sh"
+  },
+  {
+    "code": "600199",
+    "name": "金种子酒",
+    "market": "sh"
+  },
+  {
+    "code": "600200",
+    "name": "江苏吴中",
+    "market": "sh"
+  },
+  {
+    "code": "600201",
+    "name": "生物股份",
+    "market": "sh"
+  },
+  {
+    "code": "600202",
+    "name": "哈空调",
+    "market": "sh"
+  },
+  {
+    "code": "600203",
+    "name": "福日电子",
+    "market": "sh"
+  },
+  {
+    "code": "600206",
+    "name": "有研新材",
+    "market": "sh"
+  },
+  {
+    "code": "600207",
+    "name": "安彩高科",
+    "market": "sh"
+  },
+  {
+    "code": "600208",
+    "name": "新湖中宝",
+    "market": "sh"
+  },
+  {
+    "code": "600209",
+    "name": "ST罗顿",
+    "market": "sh"
+  },
+  {
+    "code": "600210",
+    "name": "紫江企业",
+    "market": "sh"
+  },
+  {
+    "code": "600211",
+    "name": "西藏药业",
+    "market": "sh"
+  },
+  {
+    "code": "600212",
+    "name": "绿江控股",
+    "market": "sh"
+  },
+  {
+    "code": "600213",
+    "name": "亚星客车",
+    "market": "sh"
+  },
+  {
+    "code": "600215",
+    "name": "长春经开",
+    "market": "sh"
+  },
+  {
+    "code": "600216",
+    "name": "浙江医药",
+    "market": "sh"
+  },
+  {
+    "code": "600217",
+    "name": "中再资环",
+    "market": "sh"
+  },
+  {
+    "code": "600218",
+    "name": "全柴动力",
+    "market": "sh"
+  },
+  {
+    "code": "600219",
+    "name": "南山铝业",
+    "market": "sh"
+  },
+  {
+    "code": "600220",
+    "name": "江苏阳光",
+    "market": "sh"
+  },
+  {
+    "code": "600221",
+    "name": "ST海航",
+    "market": "sh"
+  },
+  {
+    "code": "600222",
+    "name": "太龙药业",
+    "market": "sh"
+  },
+  {
+    "code": "600223",
+    "name": "鲁商发展",
+    "market": "sh"
+  },
+  {
+    "code": "600224",
+    "name": "天津松江",
+    "market": "sh"
+  },
+  {
+    "code": "600225",
+    "name": "天津松江",
+    "market": "sh"
+  },
+  {
+    "code": "600226",
+    "name": "ST瀚叶",
+    "market": "sh"
+  },
+  {
+    "code": "600227",
+    "name": "圣济堂",
+    "market": "sh"
+  },
+  {
+    "code": "600228",
+    "name": "返利科技",
+    "market": "sh"
+  },
+  {
+    "code": "600229",
+    "name": "城市传媒",
+    "market": "sh"
+  },
+  {
+    "code": "600230",
+    "name": "沧州大化",
+    "market": "sh"
+  },
+  {
+    "code": "600231",
+    "name": "凌钢股份",
+    "market": "sh"
+  },
+  {
+    "code": "600232",
+    "name": "金鹰股份",
+    "market": "sh"
+  },
+  {
+    "code": "600233",
+    "name": "圆通速递",
+    "market": "sh"
+  },
+  {
+    "code": "600234",
+    "name": "ST山水",
+    "market": "sh"
+  },
+  {
+    "code": "600235",
+    "name": "民丰特纸",
+    "market": "sh"
+  },
+  {
+    "code": "600236",
+    "name": "桂冠电力",
+    "market": "sh"
+  },
+  {
+    "code": "600237",
+    "name": "铜峰电子",
+    "market": "sh"
+  },
+  {
+    "code": "600238",
+    "name": "海南椰岛",
+    "market": "sh"
+  },
+  {
+    "code": "600239",
+    "name": "云南城投",
+    "market": "sh"
+  },
+  {
+    "code": "600240",
+    "name": "*ST华业",
+    "market": "sh"
+  },
+  {
+    "code": "600241",
+    "name": "ST时万",
+    "market": "sh"
+  },
+  {
+    "code": "600242",
+    "name": "ST中昌",
+    "market": "sh"
+  },
+  {
+    "code": "600243",
+    "name": "青海华鼎",
+    "market": "sh"
+  },
+  {
+    "code": "600246",
+    "name": "万通发展",
+    "market": "sh"
+  },
+  {
+    "code": "600247",
+    "name": "ST成城",
+    "market": "sh"
+  },
+  {
+    "code": "600248",
+    "name": "陕西建工",
+    "market": "sh"
+  },
+  {
+    "code": "600249",
+    "name": "两面针",
+    "market": "sh"
+  },
+  {
+    "code": "600250",
+    "name": "南纺股份",
+    "market": "sh"
+  },
+  {
+    "code": "600251",
+    "name": "冠农股份",
+    "market": "sh"
+  },
+  {
+    "code": "600252",
+    "name": "中恒集团",
+    "market": "sh"
+  },
+  {
+    "code": "600255",
+    "name": "鑫科材料",
+    "market": "sh"
+  },
+  {
+    "code": "600256",
+    "name": "广汇能源",
+    "market": "sh"
+  },
+  {
+    "code": "600257",
+    "name": "大湖股份",
+    "market": "sh"
+  },
+  {
+    "code": "600258",
+    "name": "首旅酒店",
+    "market": "sh"
+  },
+  {
+    "code": "600259",
+    "name": "广晟有色",
+    "market": "sh"
+  },
+  {
+    "code": "600260",
+    "name": "ST凯乐",
+    "market": "sh"
+  },
+  {
+    "code": "600261",
+    "name": "阳光照明",
+    "market": "sh"
+  },
+  {
+    "code": "600262",
+    "name": "北方股份",
+    "market": "sh"
+  },
+  {
+    "code": "600265",
+    "name": "ST景谷",
+    "market": "sh"
+  },
+  {
+    "code": "600266",
+    "name": "城建发展",
+    "market": "sh"
+  },
+  {
+    "code": "600267",
+    "name": "海正药业",
+    "market": "sh"
+  },
+  {
+    "code": "600268",
+    "name": "国电南自",
+    "market": "sh"
+  },
+  {
+    "code": "600269",
+    "name": "赣粤高速",
+    "market": "sh"
+  },
+  {
+    "code": "600271",
+    "name": "航天信息",
+    "market": "sh"
+  },
+  {
+    "code": "600272",
+    "name": "开开实业",
+    "market": "sh"
+  },
+  {
+    "code": "600273",
+    "name": "嘉化能源",
+    "market": "sh"
+  },
+  {
+    "code": "600275",
+    "name": "ST昌鱼",
+    "market": "sh"
+  },
+  {
+    "code": "600276",
+    "name": "恒瑞医药",
+    "market": "sh"
+  },
+  {
+    "code": "600277",
+    "name": "亿利洁能",
+    "market": "sh"
+  },
+  {
+    "code": "600278",
+    "name": "东方创业",
+    "market": "sh"
+  },
+  {
+    "code": "600279",
+    "name": "重庆港九",
+    "market": "sh"
+  },
+  {
+    "code": "600280",
+    "name": "ST中商",
+    "market": "sh"
+  },
+  {
+    "code": "600281",
+    "name": "太化股份",
+    "market": "sh"
+  },
+  {
+    "code": "600282",
+    "name": "南钢股份",
+    "market": "sh"
+  },
+  {
+    "code": "600283",
+    "name": "钱江水利",
+    "market": "sh"
+  },
+  {
+    "code": "600284",
+    "name": "浦东建设",
+    "market": "sh"
+  },
+  {
+    "code": "600285",
+    "name": "羚锐制药",
+    "market": "sh"
+  },
+  {
+    "code": "600287",
+    "name": "ST舜天",
+    "market": "sh"
+  },
+  {
+    "code": "600288",
+    "name": "大恒科技",
+    "market": "sh"
+  },
+  {
+    "code": "600289",
+    "name": "ST信通",
+    "market": "sh"
+  },
+  {
+    "code": "600290",
+    "name": "ST华仪",
+    "market": "sh"
+  },
+  {
+    "code": "600291",
+    "name": "ST西水",
+    "market": "sh"
+  },
+  {
+    "code": "600292",
+    "name": "远达环保",
+    "market": "sh"
+  },
+  {
+    "code": "600293",
+    "name": "三峡新材",
+    "market": "sh"
+  },
+  {
+    "code": "600295",
+    "name": "鄂尔多斯",
+    "market": "sh"
+  },
+  {
+    "code": "600297",
+    "name": "广汇汽车",
+    "market": "sh"
+  },
+  {
+    "code": "600298",
+    "name": "安琪酵母",
+    "market": "sh"
+  },
+  {
+    "code": "600299",
+    "name": "安迪苏",
+    "market": "sh"
+  },
+  {
+    "code": "600300",
+    "name": "维维股份",
+    "market": "sh"
+  },
+  {
+    "code": "600301",
+    "name": "南化股份",
+    "market": "sh"
+  },
+  {
+    "code": "600302",
+    "name": "标准股份",
+    "market": "sh"
+  },
+  {
+    "code": "600303",
+    "name": "ST曙光",
+    "market": "sh"
+  },
+  {
+    "code": "600305",
+    "name": "恒顺醋业",
+    "market": "sh"
+  },
+  {
+    "code": "600306",
+    "name": "ST商城",
+    "market": "sh"
+  },
+  {
+    "code": "600307",
+    "name": "酒钢宏兴",
+    "market": "sh"
+  },
+  {
+    "code": "600308",
+    "name": "华泰股份",
+    "market": "sh"
+  },
+  {
+    "code": "600309",
+    "name": "万华化学",
+    "market": "sh"
+  },
+  {
+    "code": "600310",
+    "name": "桂东电力",
+    "market": "sh"
+  },
+  {
+    "code": "600311",
+    "name": "ST荣华",
+    "market": "sh"
+  },
+  {
+    "code": "600312",
+    "name": "平高电气",
+    "market": "sh"
+  },
+  {
+    "code": "600313",
+    "name": "农发种业",
+    "market": "sh"
+  },
+  {
+    "code": "600315",
+    "name": "上海家化",
+    "market": "sh"
+  },
+  {
+    "code": "600316",
+    "name": "洪都航空",
+    "market": "sh"
+  },
+  {
+    "code": "600317",
+    "name": "营口港",
+    "market": "sh"
+  },
+  {
+    "code": "600318",
+    "name": "新力金融",
+    "market": "sh"
+  },
+  {
+    "code": "600319",
+    "name": "ST亚星",
+    "market": "sh"
+  },
+  {
+    "code": "600320",
+    "name": "振华重工",
+    "market": "sh"
+  },
+  {
+    "code": "600321",
+    "name": "ST正源",
+    "market": "sh"
+  },
+  {
+    "code": "600322",
+    "name": "天房发展",
+    "market": "sh"
+  },
+  {
+    "code": "600323",
+    "name": "瀚蓝环境",
+    "market": "sh"
+  },
+  {
+    "code": "600325",
+    "name": "华发股份",
+    "market": "sh"
+  },
+  {
+    "code": "600326",
+    "name": "西藏天路",
+    "market": "sh"
+  },
+  {
+    "code": "600327",
+    "name": "大东方",
+    "market": "sh"
+  },
+  {
+    "code": "600328",
+    "name": "中盐化工",
+    "market": "sh"
+  },
+  {
+    "code": "600329",
+    "name": "中新药业",
+    "market": "sh"
+  },
+  {
+    "code": "600330",
+    "name": "天通股份",
+    "market": "sh"
+  },
+  {
+    "code": "600331",
+    "name": "宏达股份",
+    "market": "sh"
+  },
+  {
+    "code": "600332",
+    "name": "白云山",
+    "market": "sh"
+  },
+  {
+    "code": "600333",
+    "name": "长春燃气",
+    "market": "sh"
+  },
+  {
+    "code": "600335",
+    "name": "国机汽车",
+    "market": "sh"
+  },
+  {
+    "code": "600336",
+    "name": "澳柯玛",
+    "market": "sh"
+  },
+  {
+    "code": "600337",
+    "name": "美克家居",
+    "market": "sh"
+  },
+  {
+    "code": "600338",
+    "name": "西藏珠峰",
+    "market": "sh"
+  },
+  {
+    "code": "600339",
+    "name": "中油工程",
+    "market": "sh"
+  },
+  {
+    "code": "600340",
+    "name": "华夏幸福",
+    "market": "sh"
+  },
+  {
+    "code": "600343",
+    "name": "航天动力",
+    "market": "sh"
+  },
+  {
+    "code": "600345",
+    "name": "长江通信",
+    "market": "sh"
+  },
+  {
+    "code": "600346",
+    "name": "恒力石化",
+    "market": "sh"
+  },
+  {
+    "code": "600348",
+    "name": "华阳股份",
+    "market": "sh"
+  },
+  {
+    "code": "600350",
+    "name": "山东高速",
+    "market": "sh"
+  },
+  {
+    "code": "600351",
+    "name": "亚宝药业",
+    "market": "sh"
+  },
+  {
+    "code": "600352",
+    "name": "浙江龙盛",
+    "market": "sh"
+  },
+  {
+    "code": "600353",
+    "name": "旭光电子",
+    "market": "sh"
+  },
+  {
+    "code": "600354",
+    "name": "敦煌种业",
+    "market": "sh"
+  },
+  {
+    "code": "600355",
+    "name": "精伦电子",
+    "market": "sh"
+  },
+  {
+    "code": "600356",
+    "name": "恒丰纸业",
+    "market": "sh"
+  },
+  {
+    "code": "600358",
+    "name": "ST联合",
+    "market": "sh"
+  },
+  {
+    "code": "600359",
+    "name": "新农开发",
+    "market": "sh"
+  },
+  {
+    "code": "600360",
+    "name": "华微电子",
+    "market": "sh"
+  },
+  {
+    "code": "600361",
+    "name": "华联综超",
+    "market": "sh"
+  },
+  {
+    "code": "600362",
+    "name": "江西铜业",
+    "market": "sh"
+  },
+  {
+    "code": "600363",
+    "name": "联创光电",
+    "market": "sh"
+  },
+  {
+    "code": "600365",
+    "name": "ST通葡",
+    "market": "sh"
+  },
+  {
+    "code": "600366",
+    "name": "宁波韵升",
+    "market": "sh"
+  },
+  {
+    "code": "600367",
+    "name": "红星发展",
+    "market": "sh"
+  },
+  {
+    "code": "600368",
+    "name": "五洲交通",
+    "market": "sh"
+  },
+  {
+    "code": "600369",
+    "name": "西南证券",
+    "market": "sh"
+  },
+  {
+    "code": "600370",
+    "name": "ST厦华",
+    "market": "sh"
+  },
+  {
+    "code": "600371",
+    "name": "万向德农",
+    "market": "sh"
+  },
+  {
+    "code": "600372",
+    "name": "中航电子",
+    "market": "sh"
+  },
+  {
+    "code": "600373",
+    "name": "中文传媒",
+    "market": "sh"
+  },
+  {
+    "code": "600375",
+    "name": "汉马科技",
+    "market": "sh"
+  },
+  {
+    "code": "600376",
+    "name": "首开股份",
+    "market": "sh"
+  },
+  {
+    "code": "600377",
+    "name": "宁沪高速",
+    "market": "sh"
+  },
+  {
+    "code": "600378",
+    "name": "昊华科技",
+    "market": "sh"
+  },
+  {
+    "code": "600379",
+    "name": "宝光股份",
+    "market": "sh"
+  },
+  {
+    "code": "600380",
+    "name": "健康元",
+    "market": "sh"
+  },
+  {
+    "code": "600381",
+    "name": "ST春天",
+    "market": "sh"
+  },
+  {
+    "code": "600382",
+    "name": "ST广珠",
+    "market": "sh"
+  },
+  {
+    "code": "600383",
+    "name": "金地集团",
+    "market": "sh"
+  },
+  {
+    "code": "600385",
+    "name": "ST金泰",
+    "market": "sh"
+  },
+  {
+    "code": "600386",
+    "name": "北巴传媒",
+    "market": "sh"
+  },
+  {
+    "code": "600387",
+    "name": "海越能源",
+    "market": "sh"
+  },
+  {
+    "code": "600388",
+    "name": "龙净环保",
+    "market": "sh"
+  },
+  {
+    "code": "600389",
+    "name": "江山股份",
+    "market": "sh"
+  },
+  {
+    "code": "600390",
+    "name": "五矿资本",
+    "market": "sh"
+  },
+  {
+    "code": "600391",
+    "name": "航发科技",
+    "market": "sh"
+  },
+  {
+    "code": "600392",
+    "name": "盛和资源",
+    "market": "sh"
+  },
+  {
+    "code": "600393",
+    "name": "ST粤泰",
+    "market": "sh"
+  },
+  {
+    "code": "600395",
+    "name": "盘江股份",
+    "market": "sh"
+  },
+  {
+    "code": "600396",
+    "name": "金山股份",
+    "market": "sh"
+  },
+  {
+    "code": "600397",
+    "name": "安源煤业",
+    "market": "sh"
+  },
+  {
+    "code": "600398",
+    "name": "海澜之家",
+    "market": "sh"
+  },
+  {
+    "code": "600399",
+    "name": "抚顺特钢",
+    "market": "sh"
+  },
+  {
+    "code": "600400",
+    "name": "红豆股份",
+    "market": "sh"
+  },
+  {
+    "code": "600403",
+    "name": "大有能源",
+    "market": "sh"
+  },
+  {
+    "code": "600405",
+    "name": "动力源",
+    "market": "sh"
+  },
+  {
+    "code": "600406",
+    "name": "国电南瑞",
+    "market": "sh"
+  },
+  {
+    "code": "600408",
+    "name": "ST安泰",
+    "market": "sh"
+  },
+  {
+    "code": "600409",
+    "name": "三友化工",
+    "market": "sh"
+  },
+  {
+    "code": "600410",
+    "name": "华胜天成",
+    "market": "sh"
+  },
+  {
+    "code": "600415",
+    "name": "小商品城",
+    "market": "sh"
+  },
+  {
+    "code": "600416",
+    "name": "湘电股份",
+    "market": "sh"
+  },
+  {
+    "code": "600418",
+    "name": "江淮汽车",
+    "market": "sh"
+  },
+  {
+    "code": "600419",
+    "name": "天润乳业",
+    "market": "sh"
+  },
+  {
+    "code": "600420",
+    "name": "国药现代",
+    "market": "sh"
+  },
+  {
+    "code": "600422",
+    "name": "昆药集团",
+    "market": "sh"
+  },
+  {
+    "code": "600423",
+    "name": "ST柳化",
+    "market": "sh"
+  },
+  {
+    "code": "600425",
+    "name": "青松建化",
+    "market": "sh"
+  },
+  {
+    "code": "600426",
+    "name": "华鲁恒升",
+    "market": "sh"
+  },
+  {
+    "code": "600428",
+    "name": "中远海特",
+    "market": "sh"
+  },
+  {
+    "code": "600429",
+    "name": "三元股份",
+    "market": "sh"
+  },
+  {
+    "code": "600433",
+    "name": "冠豪高新",
+    "market": "sh"
+  },
+  {
+    "code": "600435",
+    "name": "北方导航",
+    "market": "sh"
+  },
+  {
+    "code": "600436",
+    "name": "片仔癀",
+    "market": "sh"
+  },
+  {
+    "code": "600438",
+    "name": "通威股份",
+    "market": "sh"
+  },
+  {
+    "code": "600439",
+    "name": "瑞贝卡",
+    "market": "sh"
+  },
+  {
+    "code": "600444",
+    "name": "国机通用",
+    "market": "sh"
+  },
+  {
+    "code": "600446",
+    "name": "金证股份",
+    "market": "sh"
+  },
+  {
+    "code": "600448",
+    "name": "华纺股份",
+    "market": "sh"
+  },
+  {
+    "code": "600449",
+    "name": "宁夏建材",
+    "market": "sh"
+  },
+  {
+    "code": "600452",
+    "name": "涪陵电力",
+    "market": "sh"
+  },
+  {
+    "code": "600455",
+    "name": "博通股份",
+    "market": "sh"
+  },
+  {
+    "code": "600456",
+    "name": "宝钛股份",
+    "market": "sh"
+  },
+  {
+    "code": "600458",
+    "name": "时代新材",
+    "market": "sh"
+  },
+  {
+    "code": "600459",
+    "name": "贵研铂业",
+    "market": "sh"
+  },
+  {
+    "code": "600460",
+    "name": "士兰微",
+    "market": "sh"
+  },
+  {
+    "code": "600461",
+    "name": "洪城环境",
+    "market": "sh"
+  },
+  {
+    "code": "600462",
+    "name": "ST九有",
+    "market": "sh"
+  },
+  {
+    "code": "600463",
+    "name": "空港股份",
+    "market": "sh"
+  },
+  {
+    "code": "600466",
+    "name": "蓝光发展",
+    "market": "sh"
+  },
+  {
+    "code": "600467",
+    "name": "好当家",
+    "market": "sh"
+  },
+  {
+    "code": "600468",
+    "name": "百利电气",
+    "market": "sh"
+  },
+  {
+    "code": "600469",
+    "name": "风神股份",
+    "market": "sh"
+  },
+  {
+    "code": "600470",
+    "name": "六国化工",
+    "market": "sh"
+  },
+  {
+    "code": "600475",
+    "name": "华光环能",
+    "market": "sh"
+  },
+  {
+    "code": "600476",
+    "name": "湘邮科技",
+    "market": "sh"
+  },
+  {
+    "code": "600477",
+    "name": "杭萧钢构",
+    "market": "sh"
+  },
+  {
+    "code": "600478",
+    "name": "科力远",
+    "market": "sh"
+  },
+  {
+    "code": "600479",
+    "name": "千金药业",
+    "market": "sh"
+  },
+  {
+    "code": "600480",
+    "name": "凌云股份",
+    "market": "sh"
+  },
+  {
+    "code": "600481",
+    "name": "双良节能",
+    "market": "sh"
+  },
+  {
+    "code": "600482",
+    "name": "中国动力",
+    "market": "sh"
+  },
+  {
+    "code": "600483",
+    "name": "福能股份",
+    "market": "sh"
+  },
+  {
+    "code": "600486",
+    "name": "扬农化工",
+    "market": "sh"
+  },
+  {
+    "code": "600487",
+    "name": "亨通光电",
+    "market": "sh"
+  },
+  {
+    "code": "600488",
+    "name": "天药股份",
+    "market": "sh"
+  },
+  {
+    "code": "600489",
+    "name": "中金黄金",
+    "market": "sh"
+  },
+  {
+    "code": "600490",
+    "name": "鹏欣资源",
+    "market": "sh"
+  },
+  {
+    "code": "600491",
+    "name": "龙元建设",
+    "market": "sh"
+  },
+  {
+    "code": "600493",
+    "name": "凤竹纺织",
+    "market": "sh"
+  },
+  {
+    "code": "600495",
+    "name": "晋西车轴",
+    "market": "sh"
+  },
+  {
+    "code": "600496",
+    "name": "精工钢构",
+    "market": "sh"
+  },
+  {
+    "code": "600497",
+    "name": "驰宏锌锗",
+    "market": "sh"
+  },
+  {
+    "code": "600498",
+    "name": "烽火通信",
+    "market": "sh"
+  },
+  {
+    "code": "600499",
+    "name": "科达制造",
+    "market": "sh"
+  },
+  {
+    "code": "600500",
+    "name": "中化国际",
+    "market": "sh"
+  },
+  {
+    "code": "600501",
+    "name": "航天晨光",
+    "market": "sh"
+  },
+  {
+    "code": "600502",
+    "name": "安徽建工",
+    "market": "sh"
+  },
+  {
+    "code": "600503",
+    "name": "华丽家族",
+    "market": "sh"
+  },
+  {
+    "code": "600505",
+    "name": "西昌电力",
+    "market": "sh"
+  },
+  {
+    "code": "600506",
+    "name": "ST香梨",
+    "market": "sh"
+  },
+  {
+    "code": "600507",
+    "name": "方大特钢",
+    "market": "sh"
+  },
+  {
+    "code": "600508",
+    "name": "上海能源",
+    "market": "sh"
+  },
+  {
+    "code": "600509",
+    "name": "天富能源",
+    "market": "sh"
+  },
+  {
+    "code": "600510",
+    "name": "黑牡丹",
+    "market": "sh"
+  },
+  {
+    "code": "600511",
+    "name": "国药股份",
+    "market": "sh"
+  },
+  {
+    "code": "600512",
+    "name": "腾达建设",
+    "market": "sh"
+  },
+  {
+    "code": "600513",
+    "name": "联环药业",
+    "market": "sh"
+  },
+  {
+    "code": "600515",
+    "name": "ST基础",
+    "market": "sh"
+  },
+  {
+    "code": "600516",
+    "name": "方大炭素",
+    "market": "sh"
+  },
+  {
+    "code": "600517",
+    "name": "国网英大",
+    "market": "sh"
+  },
+  {
+    "code": "600518",
+    "name": "ST康美",
+    "market": "sh"
+  },
+  {
+    "code": "600519",
+    "name": "贵州茅台",
+    "market": "sh"
+  },
+  {
+    "code": "600520",
+    "name": "文一科技",
+    "market": "sh"
+  },
+  {
+    "code": "600521",
+    "name": "华海药业",
+    "market": "sh"
+  },
+  {
+    "code": "600522",
+    "name": "中天科技",
+    "market": "sh"
+  },
+  {
+    "code": "600523",
+    "name": "贵航股份",
+    "market": "sh"
+  },
+  {
+    "code": "600525",
+    "name": "长园集团",
+    "market": "sh"
+  },
+  {
+    "code": "600526",
+    "name": "ST瀚叶",
+    "market": "sh"
+  },
+  {
+    "code": "600527",
+    "name": "江南高纤",
+    "market": "sh"
+  },
+  {
+    "code": "600528",
+    "name": "中铁工业",
+    "market": "sh"
+  },
+  {
+    "code": "600529",
+    "name": "山东药玻",
+    "market": "sh"
+  },
+  {
+    "code": "600530",
+    "name": "ST交昂",
+    "market": "sh"
+  },
+  {
+    "code": "600531",
+    "name": "豫光金铅",
+    "market": "sh"
+  },
+  {
+    "code": "600532",
+    "name": "未来股份",
+    "market": "sh"
+  },
+  {
+    "code": "600533",
+    "name": "栖霞建设",
+    "market": "sh"
+  },
+  {
+    "code": "600535",
+    "name": "天士力",
+    "market": "sh"
+  },
+  {
+    "code": "600536",
+    "name": "中国软件",
+    "market": "sh"
+  },
+  {
+    "code": "600537",
+    "name": "亿晶光电",
+    "market": "sh"
+  },
+  {
+    "code": "600538",
+    "name": "国发股份",
+    "market": "sh"
+  },
+  {
+    "code": "600539",
+    "name": "ST狮头",
+    "market": "sh"
+  },
+  {
+    "code": "600540",
+    "name": "新赛股份",
+    "market": "sh"
+  },
+  {
+    "code": "600543",
+    "name": "莫高股份",
+    "market": "sh"
+  },
+  {
+    "code": "600545",
+    "name": "卓郎智能",
+    "market": "sh"
+  },
+  {
+    "code": "600546",
+    "name": "山煤国际",
+    "market": "sh"
+  },
+  {
+    "code": "600547",
+    "name": "山东黄金",
+    "market": "sh"
+  },
+  {
+    "code": "600548",
+    "name": "深高速",
+    "market": "sh"
+  },
+  {
+    "code": "600549",
+    "name": "厦门钨业",
+    "market": "sh"
+  },
+  {
+    "code": "600550",
+    "name": "保变电气",
+    "market": "sh"
+  },
+  {
+    "code": "600551",
+    "name": "时代出版",
+    "market": "sh"
+  },
+  {
+    "code": "600552",
+    "name": "凯盛科技",
+    "market": "sh"
+  },
+  {
+    "code": "600555",
+    "name": "ST海创",
+    "market": "sh"
+  },
+  {
+    "code": "600556",
+    "name": "天下秀",
+    "market": "sh"
+  },
+  {
+    "code": "600557",
+    "name": "康缘药业",
+    "market": "sh"
+  },
+  {
+    "code": "600558",
+    "name": "大西洋",
+    "market": "sh"
+  },
+  {
+    "code": "600559",
+    "name": "老白干酒",
+    "market": "sh"
+  },
+  {
+    "code": "600560",
+    "name": "金自天正",
+    "market": "sh"
+  },
+  {
+    "code": "600561",
+    "name": "江西长运",
+    "market": "sh"
+  },
+  {
+    "code": "600562",
+    "name": "国睿科技",
+    "market": "sh"
+  },
+  {
+    "code": "600563",
+    "name": "法拉电子",
+    "market": "sh"
+  },
+  {
+    "code": "600565",
+    "name": "迪马股份",
+    "market": "sh"
+  },
+  {
+    "code": "600566",
+    "name": "济川药业",
+    "market": "sh"
+  },
+  {
+    "code": "600567",
+    "name": "山鹰纸业",
+    "market": "sh"
+  },
+  {
+    "code": "600568",
+    "name": "ST中珠",
+    "market": "sh"
+  },
+  {
+    "code": "600569",
+    "name": "安阳钢铁",
+    "market": "sh"
+  },
+  {
+    "code": "600570",
+    "name": "恒生电子",
+    "market": "sh"
+  },
+  {
+    "code": "600571",
+    "name": "信雅达",
+    "market": "sh"
+  },
+  {
+    "code": "600572",
+    "name": "康恩贝",
+    "market": "sh"
+  },
+  {
+    "code": "600573",
+    "name": "惠泉啤酒",
+    "market": "sh"
+  },
+  {
+    "code": "600575",
+    "name": "淮河能源",
+    "market": "sh"
+  },
+  {
+    "code": "600576",
+    "name": "祥源文化",
+    "market": "sh"
+  },
+  {
+    "code": "600577",
+    "name": "精达股份",
+    "market": "sh"
+  },
+  {
+    "code": "600578",
+    "name": "京能电力",
+    "market": "sh"
+  },
+  {
+    "code": "600579",
+    "name": "克劳斯",
+    "market": "sh"
+  },
+  {
+    "code": "600580",
+    "name": "卧龙电驱",
+    "market": "sh"
+  },
+  {
+    "code": "600581",
+    "name": "八一钢铁",
+    "market": "sh"
+  },
+  {
+    "code": "600582",
+    "name": "天地科技",
+    "market": "sh"
+  },
+  {
+    "code": "600583",
+    "name": "海油工程",
+    "market": "sh"
+  },
+  {
+    "code": "600584",
+    "name": "长电科技",
+    "market": "sh"
+  },
+  {
+    "code": "600585",
+    "name": "海螺水泥",
+    "market": "sh"
+  },
+  {
+    "code": "600586",
+    "name": "金晶科技",
+    "market": "sh"
+  },
+  {
+    "code": "600587",
+    "name": "新华医疗",
+    "market": "sh"
+  },
+  {
+    "code": "600588",
+    "name": "用友网络",
+    "market": "sh"
+  },
+  {
+    "code": "600589",
+    "name": "ST榕泰",
+    "market": "sh"
+  },
+  {
+    "code": "600590",
+    "name": "泰豪科技",
+    "market": "sh"
+  },
+  {
+    "code": "600592",
+    "name": "龙溪股份",
+    "market": "sh"
+  },
+  {
+    "code": "600593",
+    "name": "大连圣亚",
+    "market": "sh"
+  },
+  {
+    "code": "600594",
+    "name": "益佰制药",
+    "market": "sh"
+  },
+  {
+    "code": "600595",
+    "name": "ST中孚",
+    "market": "sh"
+  },
+  {
+    "code": "600596",
+    "name": "新安股份",
+    "market": "sh"
+  },
+  {
+    "code": "600597",
+    "name": "光明乳业",
+    "market": "sh"
+  },
+  {
+    "code": "600598",
+    "name": "北大荒",
+    "market": "sh"
+  },
+  {
+    "code": "600599",
+    "name": "ST熊猫",
+    "market": "sh"
+  },
+  {
+    "code": "600600",
+    "name": "青岛啤酒",
+    "market": "sh"
+  },
+  {
+    "code": "600601",
+    "name": "ST方正",
+    "market": "sh"
+  },
+  {
+    "code": "600602",
+    "name": "云赛智联",
+    "market": "sh"
+  },
+  {
+    "code": "600603",
+    "name": "广汇物流",
+    "market": "sh"
+  },
+  {
+    "code": "600604",
+    "name": "市北高新",
+    "market": "sh"
+  },
+  {
+    "code": "600605",
+    "name": "汇通能源",
+    "market": "sh"
+  },
+  {
+    "code": "600606",
+    "name": "绿地控股",
+    "market": "sh"
+  },
+  {
+    "code": "600608",
+    "name": "ST沪科",
+    "market": "sh"
+  },
+  {
+    "code": "600609",
+    "name": "金杯汽车",
+    "market": "sh"
+  },
+  {
+    "code": "600610",
+    "name": "ST中毅",
+    "market": "sh"
+  },
+  {
+    "code": "600611",
+    "name": "大众交通",
+    "market": "sh"
+  },
+  {
+    "code": "600612",
+    "name": "老凤祥",
+    "market": "sh"
+  },
+  {
+    "code": "600613",
+    "name": "神奇制药",
+    "market": "sh"
+  },
+  {
+    "code": "600615",
+    "name": "*ST丰华",
+    "market": "sh"
+  },
+  {
+    "code": "600616",
+    "name": "金枫酒业",
+    "market": "sh"
+  },
+  {
+    "code": "600617",
+    "name": "国新能源",
+    "market": "sh"
+  },
+  {
+    "code": "600618",
+    "name": "氯碱化工",
+    "market": "sh"
+  },
+  {
+    "code": "600619",
+    "name": "海立股份",
+    "market": "sh"
+  },
+  {
+    "code": "600620",
+    "name": "天宸股份",
+    "market": "sh"
+  },
+  {
+    "code": "600621",
+    "name": "华鑫股份",
+    "market": "sh"
+  },
+  {
+    "code": "600622",
+    "name": "光大嘉宝",
+    "market": "sh"
+  },
+  {
+    "code": "600623",
+    "name": "华谊集团",
+    "market": "sh"
+  },
+  {
+    "code": "600624",
+    "name": "复旦复华",
+    "market": "sh"
+  },
+  {
+    "code": "600626",
+    "name": "申达股份",
+    "market": "sh"
+  },
+  {
+    "code": "600628",
+    "name": "新世界",
+    "market": "sh"
+  },
+  {
+    "code": "600629",
+    "name": "华建集团",
+    "market": "sh"
+  },
+  {
+    "code": "600630",
+    "name": "龙头股份",
+    "market": "sh"
+  },
+  {
+    "code": "600633",
+    "name": "浙数文化",
+    "market": "sh"
+  },
+  {
+    "code": "600635",
+    "name": "大众公用",
+    "market": "sh"
+  },
+  {
+    "code": "600636",
+    "name": "国新文化",
+    "market": "sh"
+  },
+  {
+    "code": "600637",
+    "name": "东方明珠",
+    "market": "sh"
+  },
+  {
+    "code": "600638",
+    "name": "新黄浦",
+    "market": "sh"
+  },
+  {
+    "code": "600639",
+    "name": "浦东金桥",
+    "market": "sh"
+  },
+  {
+    "code": "600640",
+    "name": "新国脉",
+    "market": "sh"
+  },
+  {
+    "code": "600641",
+    "name": "万业企业",
+    "market": "sh"
+  },
+  {
+    "code": "600642",
+    "name": "申能股份",
+    "market": "sh"
+  },
+  {
+    "code": "600643",
+    "name": "爱建集团",
+    "market": "sh"
+  },
+  {
+    "code": "600644",
+    "name": "乐山电力",
+    "market": "sh"
+  },
+  {
+    "code": "600645",
+    "name": "中源协和",
+    "market": "sh"
+  },
+  {
+    "code": "600648",
+    "name": "外高桥",
+    "market": "sh"
+  },
+  {
+    "code": "600649",
+    "name": "城投控股",
+    "market": "sh"
+  },
+  {
+    "code": "600650",
+    "name": "锦江在线",
+    "market": "sh"
+  },
+  {
+    "code": "600651",
+    "name": "飞乐音响",
+    "market": "sh"
+  },
+  {
+    "code": "600652",
+    "name": "ST游久",
+    "market": "sh"
+  },
+  {
+    "code": "600653",
+    "name": "申华控股",
+    "market": "sh"
+  },
+  {
+    "code": "600654",
+    "name": "ST中安",
+    "market": "sh"
+  },
+  {
+    "code": "600655",
+    "name": "豫园股份",
+    "market": "sh"
+  },
+  {
+    "code": "600657",
+    "name": "信达地产",
+    "market": "sh"
+  },
+  {
+    "code": "600658",
+    "name": "电子城",
+    "market": "sh"
+  },
+  {
+    "code": "600660",
+    "name": "福耀玻璃",
+    "market": "sh"
+  },
+  {
+    "code": "600661",
+    "name": "昂立教育",
+    "market": "sh"
+  },
+  {
+    "code": "600662",
+    "name": "外服控股",
+    "market": "sh"
+  },
+  {
+    "code": "600663",
+    "name": "陆家嘴",
+    "market": "sh"
+  },
+  {
+    "code": "600664",
+    "name": "哈药股份",
+    "market": "sh"
+  },
+  {
+    "code": "600665",
+    "name": "天地源",
+    "market": "sh"
+  },
+  {
+    "code": "600666",
+    "name": "ST瑞德",
+    "market": "sh"
+  },
+  {
+    "code": "600667",
+    "name": "太极实业",
+    "market": "sh"
+  },
+  {
+    "code": "600668",
+    "name": "尖峰集团",
+    "market": "sh"
+  },
+  {
+    "code": "600671",
+    "name": "ST目药",
+    "market": "sh"
+  },
+  {
+    "code": "600673",
+    "name": "东阳光",
+    "market": "sh"
+  },
+  {
+    "code": "600674",
+    "name": "川投能源",
+    "market": "sh"
+  },
+  {
+    "code": "600675",
+    "name": "中华企业",
+    "market": "sh"
+  },
+  {
+    "code": "600676",
+    "name": "交运股份",
+    "market": "sh"
+  },
+  {
+    "code": "600677",
+    "name": "航天通信",
+    "market": "sh"
+  },
+  {
+    "code": "600678",
+    "name": "四川金顶",
+    "market": "sh"
+  },
+  {
+    "code": "600679",
+    "name": "上海凤凰",
+    "market": "sh"
+  },
+  {
+    "code": "600680",
+    "name": "ST通脉",
+    "market": "sh"
+  },
+  {
+    "code": "600681",
+    "name": "百川能源",
+    "market": "sh"
+  },
+  {
+    "code": "600682",
+    "name": "南京新百",
+    "market": "sh"
+  },
+  {
+    "code": "600683",
+    "name": "京投发展",
+    "market": "sh"
+  },
+  {
+    "code": "600684",
+    "name": "珠江股份",
+    "market": "sh"
+  },
+  {
+    "code": "600685",
+    "name": "中船防务",
+    "market": "sh"
+  },
+  {
+    "code": "600686",
+    "name": "金龙汽车",
+    "market": "sh"
+  },
+  {
+    "code": "600687",
+    "name": "ST刚泰",
+    "market": "sh"
+  },
+  {
+    "code": "600688",
+    "name": "上海石化",
+    "market": "sh"
+  },
+  {
+    "code": "600689",
+    "name": "上海三毛",
+    "market": "sh"
+  },
+  {
+    "code": "600690",
+    "name": "海尔智家",
+    "market": "sh"
+  },
+  {
+    "code": "600691",
+    "name": "阳煤化工",
+    "market": "sh"
+  },
+  {
+    "code": "600692",
+    "name": "亚通股份",
+    "market": "sh"
+  },
+  {
+    "code": "600693",
+    "name": "东百集团",
+    "market": "sh"
+  },
+  {
+    "code": "600694",
+    "name": "大商股份",
+    "market": "sh"
+  },
+  {
+    "code": "600695",
+    "name": "绿庭投资",
+    "market": "sh"
+  },
+  {
+    "code": "600696",
+    "name": "岩石股份",
+    "market": "sh"
+  },
+  {
+    "code": "600697",
+    "name": "欧亚集团",
+    "market": "sh"
+  },
+  {
+    "code": "600698",
+    "name": "ST天雁",
+    "market": "sh"
+  },
+  {
+    "code": "600699",
+    "name": "均胜电子",
+    "market": "sh"
+  },
+  {
+    "code": "600700",
+    "name": "*ST数码",
+    "market": "sh"
+  },
+  {
+    "code": "600701",
+    "name": "ST工新",
+    "market": "sh"
+  },
+  {
+    "code": "600702",
+    "name": "舍得酒业",
+    "market": "sh"
+  },
+  {
+    "code": "600703",
+    "name": "三安光电",
+    "market": "sh"
+  },
+  {
+    "code": "600704",
+    "name": "物产中大",
+    "market": "sh"
+  },
+  {
+    "code": "600705",
+    "name": "中航产融",
+    "market": "sh"
+  },
+  {
+    "code": "600706",
+    "name": "曲江文旅",
+    "market": "sh"
+  },
+  {
+    "code": "600707",
+    "name": "彩虹股份",
+    "market": "sh"
+  },
+  {
+    "code": "600708",
+    "name": "光明地产",
+    "market": "sh"
+  },
+  {
+    "code": "600710",
+    "name": "苏美达",
+    "market": "sh"
+  },
+  {
+    "code": "600711",
+    "name": "盛屯矿业",
+    "market": "sh"
+  },
+  {
+    "code": "600712",
+    "name": "南宁百货",
+    "market": "sh"
+  },
+  {
+    "code": "600713",
+    "name": "南京医药",
+    "market": "sh"
+  },
+  {
+    "code": "600714",
+    "name": "金瑞矿业",
+    "market": "sh"
+  },
+  {
+    "code": "600715",
+    "name": "文投控股",
+    "market": "sh"
+  },
+  {
+    "code": "600716",
+    "name": "凤凰股份",
+    "market": "sh"
+  },
+  {
+    "code": "600717",
+    "name": "天津港",
+    "market": "sh"
+  },
+  {
+    "code": "600718",
+    "name": "东软集团",
+    "market": "sh"
+  },
+  {
+    "code": "600719",
+    "name": "大连热电",
+    "market": "sh"
+  },
+  {
+    "code": "600720",
+    "name": "祁连山",
+    "market": "sh"
+  },
+  {
+    "code": "600721",
+    "name": "ST百花",
+    "market": "sh"
+  },
+  {
+    "code": "600722",
+    "name": "金牛化工",
+    "market": "sh"
+  },
+  {
+    "code": "600723",
+    "name": "首商股份",
+    "market": "sh"
+  },
+  {
+    "code": "600724",
+    "name": "宁波富达",
+    "market": "sh"
+  },
+  {
+    "code": "600725",
+    "name": "ST云维",
+    "market": "sh"
+  },
+  {
+    "code": "600726",
+    "name": "华电能源",
+    "market": "sh"
+  },
+  {
+    "code": "600727",
+    "name": "鲁北化工",
+    "market": "sh"
+  },
+  {
+    "code": "600728",
+    "name": "佳都科技",
+    "market": "sh"
+  },
+  {
+    "code": "600729",
+    "name": "重庆百货",
+    "market": "sh"
+  },
+  {
+    "code": "600730",
+    "name": "中国高科",
+    "market": "sh"
+  },
+  {
+    "code": "600731",
+    "name": "湖南海利",
+    "market": "sh"
+  },
+  {
+    "code": "600732",
+    "name": "爱旭股份",
+    "market": "sh"
+  },
+  {
+    "code": "600733",
+    "name": "北汽蓝谷",
+    "market": "sh"
+  },
+  {
+    "code": "600734",
+    "name": "ST实达",
+    "market": "sh"
+  },
+  {
+    "code": "600735",
+    "name": "新华锦",
+    "market": "sh"
+  },
+  {
+    "code": "600736",
+    "name": "苏州高新",
+    "market": "sh"
+  },
+  {
+    "code": "600737",
+    "name": "中粮糖业",
+    "market": "sh"
+  },
+  {
+    "code": "600738",
+    "name": "兰州民百",
+    "market": "sh"
+  },
+  {
+    "code": "600739",
+    "name": "辽宁成大",
+    "market": "sh"
+  },
+  {
+    "code": "600740",
+    "name": "山西焦化",
+    "market": "sh"
+  },
+  {
+    "code": "600741",
+    "name": "华域汽车",
+    "market": "sh"
+  },
+  {
+    "code": "600742",
+    "name": "一汽富维",
+    "market": "sh"
+  },
+  {
+    "code": "600743",
+    "name": "华远地产",
+    "market": "sh"
+  },
+  {
+    "code": "600744",
+    "name": "华银电力",
+    "market": "sh"
+  },
+  {
+    "code": "600745",
+    "name": "闻泰科技",
+    "market": "sh"
+  },
+  {
+    "code": "600746",
+    "name": "江苏索普",
+    "market": "sh"
+  },
+  {
+    "code": "600748",
+    "name": "上实发展",
+    "market": "sh"
+  },
+  {
+    "code": "600749",
+    "name": "西藏旅游",
+    "market": "sh"
+  },
+  {
+    "code": "600750",
+    "name": "江中药业",
+    "market": "sh"
+  },
+  {
+    "code": "600751",
+    "name": "海航科技",
+    "market": "sh"
+  },
+  {
+    "code": "600753",
+    "name": "东方银星",
+    "market": "sh"
+  },
+  {
+    "code": "600754",
+    "name": "锦江酒店",
+    "market": "sh"
+  },
+  {
+    "code": "600755",
+    "name": "厦门国贸",
+    "market": "sh"
+  },
+  {
+    "code": "600756",
+    "name": "浪潮软件",
+    "market": "sh"
+  },
+  {
+    "code": "600757",
+    "name": "长江传媒",
+    "market": "sh"
+  },
+  {
+    "code": "600758",
+    "name": "辽宁能源",
+    "market": "sh"
+  },
+  {
+    "code": "600759",
+    "name": "ST洲际",
+    "market": "sh"
+  },
+  {
+    "code": "600760",
+    "name": "中航沈飞",
+    "market": "sh"
+  },
+  {
+    "code": "600761",
+    "name": "安徽合力",
+    "market": "sh"
+  },
+  {
+    "code": "600763",
+    "name": "通策医疗",
+    "market": "sh"
+  },
+  {
+    "code": "600764",
+    "name": "中国海防",
+    "market": "sh"
+  },
+  {
+    "code": "600765",
+    "name": "中航重机",
+    "market": "sh"
+  },
+  {
+    "code": "600766",
+    "name": "ST园城",
+    "market": "sh"
+  },
+  {
+    "code": "600767",
+    "name": "ST运盛",
+    "market": "sh"
+  },
+  {
+    "code": "600768",
+    "name": "宁波富邦",
+    "market": "sh"
+  },
+  {
+    "code": "600769",
+    "name": "祥龙电业",
+    "market": "sh"
+  },
+  {
+    "code": "600770",
+    "name": "综艺股份",
+    "market": "sh"
+  },
+  {
+    "code": "600771",
+    "name": "广誉远",
+    "market": "sh"
+  },
+  {
+    "code": "600773",
+    "name": "西藏城投",
+    "market": "sh"
+  },
+  {
+    "code": "600774",
+    "name": "汉商集团",
+    "market": "sh"
+  },
+  {
+    "code": "600775",
+    "name": "南京熊猫",
+    "market": "sh"
+  },
+  {
+    "code": "600776",
+    "name": "东方通信",
+    "market": "sh"
+  },
+  {
+    "code": "600777",
+    "name": "新潮能源",
+    "market": "sh"
+  },
+  {
+    "code": "600778",
+    "name": "友好集团",
+    "market": "sh"
+  },
+  {
+    "code": "600779",
+    "name": "水井坊",
+    "market": "sh"
+  },
+  {
+    "code": "600780",
+    "name": "通宝能源",
+    "market": "sh"
+  },
+  {
+    "code": "600781",
+    "name": "ST辅仁",
+    "market": "sh"
+  },
+  {
+    "code": "600782",
+    "name": "新钢股份",
+    "market": "sh"
+  },
+  {
+    "code": "600783",
+    "name": "鲁信创投",
+    "market": "sh"
+  },
+  {
+    "code": "600784",
+    "name": "鲁银投资",
+    "market": "sh"
+  },
+  {
+    "code": "600785",
+    "name": "新华百货",
+    "market": "sh"
+  },
+  {
+    "code": "600787",
+    "name": "中储股份",
+    "market": "sh"
+  },
+  {
+    "code": "600789",
+    "name": "鲁抗医药",
+    "market": "sh"
+  },
+  {
+    "code": "600790",
+    "name": "轻纺城",
+    "market": "sh"
+  },
+  {
+    "code": "600791",
+    "name": "京能置业",
+    "market": "sh"
+  },
+  {
+    "code": "600792",
+    "name": "云煤能源",
+    "market": "sh"
+  },
+  {
+    "code": "600793",
+    "name": "ST宜纸",
+    "market": "sh"
+  },
+  {
+    "code": "600794",
+    "name": "保税科技",
+    "market": "sh"
+  },
+  {
+    "code": "600795",
+    "name": "国电电力",
+    "market": "sh"
+  },
+  {
+    "code": "600796",
+    "name": "钱江生化",
+    "market": "sh"
+  },
+  {
+    "code": "600797",
+    "name": "浙大网新",
+    "market": "sh"
+  },
+  {
+    "code": "600798",
+    "name": "宁波海运",
+    "market": "sh"
+  },
+  {
+    "code": "600800",
+    "name": "ST通葡",
+    "market": "sh"
+  },
+  {
+    "code": "600801",
+    "name": "华新水泥",
+    "market": "sh"
+  },
+  {
+    "code": "600802",
+    "name": "福建水泥",
+    "market": "sh"
+  },
+  {
+    "code": "600803",
+    "name": "新奥股份",
+    "market": "sh"
+  },
+  {
+    "code": "600804",
+    "name": "ST鹏博士",
+    "market": "sh"
+  },
+  {
+    "code": "600805",
+    "name": "悦达投资",
+    "market": "sh"
+  },
+  {
+    "code": "600807",
+    "name": "济南高新",
+    "market": "sh"
+  },
+  {
+    "code": "600808",
+    "name": "马钢股份",
+    "market": "sh"
+  },
+  {
+    "code": "600809",
+    "name": "山西汾酒",
+    "market": "sh"
+  },
+  {
+    "code": "600810",
+    "name": "神马股份",
+    "market": "sh"
+  },
+  {
+    "code": "600811",
+    "name": "东方集团",
+    "market": "sh"
+  },
+  {
+    "code": "600812",
+    "name": "华北制药",
+    "market": "sh"
+  },
+  {
+    "code": "600814",
+    "name": "杭州解百",
+    "market": "sh"
+  },
+  {
+    "code": "600815",
+    "name": "厦工股份",
+    "market": "sh"
+  },
+  {
+    "code": "600816",
+    "name": "ST安信",
+    "market": "sh"
+  },
+  {
+    "code": "600817",
+    "name": "宇通重工",
+    "market": "sh"
+  },
+  {
+    "code": "600818",
+    "name": "中路股份",
+    "market": "sh"
+  },
+  {
+    "code": "600819",
+    "name": "耀皮玻璃",
+    "market": "sh"
+  },
+  {
+    "code": "600820",
+    "name": "隧道股份",
+    "market": "sh"
+  },
+  {
+    "code": "600821",
+    "name": "金开新能",
+    "market": "sh"
+  },
+  {
+    "code": "600822",
+    "name": "上海物贸",
+    "market": "sh"
+  },
+  {
+    "code": "600823",
+    "name": "ST世茂",
+    "market": "sh"
+  },
+  {
+    "code": "600824",
+    "name": "益民集团",
+    "market": "sh"
+  },
+  {
+    "code": "600825",
+    "name": "新华传媒",
+    "market": "sh"
+  },
+  {
+    "code": "600826",
+    "name": "兰生股份",
+    "market": "sh"
+  },
+  {
+    "code": "600827",
+    "name": "百联股份",
+    "market": "sh"
+  },
+  {
+    "code": "600828",
+    "name": "茂业商业",
+    "market": "sh"
+  },
+  {
+    "code": "600829",
+    "name": "人民同泰",
+    "market": "sh"
+  },
+  {
+    "code": "600830",
+    "name": "香溢融通",
+    "market": "sh"
+  },
+  {
+    "code": "600831",
+    "name": "广电网络",
+    "market": "sh"
+  },
+  {
+    "code": "600833",
+    "name": "第一医药",
+    "market": "sh"
+  },
+  {
+    "code": "600834",
+    "name": "申通地铁",
+    "market": "sh"
+  },
+  {
+    "code": "600835",
+    "name": "上海机电",
+    "market": "sh"
+  },
+  {
+    "code": "600836",
+    "name": "上海易连",
+    "market": "sh"
+  },
+  {
+    "code": "600837",
+    "name": "海通证券",
+    "market": "sh"
+  },
+  {
+    "code": "600838",
+    "name": "上海九百",
+    "market": "sh"
+  },
+  {
+    "code": "600839",
+    "name": "四川长虹",
+    "market": "sh"
+  },
+  {
+    "code": "600841",
+    "name": "上柴股份",
+    "market": "sh"
+  },
+  {
+    "code": "600843",
+    "name": "上工申贝",
+    "market": "sh"
+  },
+  {
+    "code": "600844",
+    "name": "丹化科技",
+    "market": "sh"
+  },
+  {
+    "code": "600845",
+    "name": "宝信软件",
+    "market": "sh"
+  },
+  {
+    "code": "600846",
+    "name": "同济科技",
+    "market": "sh"
+  },
+  {
+    "code": "600847",
+    "name": "万里股份",
+    "market": "sh"
+  },
+  {
+    "code": "600848",
+    "name": "上海临港",
+    "market": "sh"
+  },
+  {
+    "code": "600850",
+    "name": "电科数字",
+    "market": "sh"
+  },
+  {
+    "code": "600851",
+    "name": "海欣股份",
+    "market": "sh"
+  },
+  {
+    "code": "600853",
+    "name": "龙建股份",
+    "market": "sh"
+  },
+  {
+    "code": "600854",
+    "name": "春兰股份",
+    "market": "sh"
+  },
+  {
+    "code": "600855",
+    "name": "航天长峰",
+    "market": "sh"
+  },
+  {
+    "code": "600856",
+    "name": "ST中天",
+    "market": "sh"
+  },
+  {
+    "code": "600857",
+    "name": "宁波中百",
+    "market": "sh"
+  },
+  {
+    "code": "600858",
+    "name": "银座股份",
+    "market": "sh"
+  },
+  {
+    "code": "600859",
+    "name": "王府井",
+    "market": "sh"
+  },
+  {
+    "code": "600860",
+    "name": "京城股份",
+    "market": "sh"
+  },
+  {
+    "code": "600861",
+    "name": "北京城乡",
+    "market": "sh"
+  },
+  {
+    "code": "600862",
+    "name": "中航高科",
+    "market": "sh"
+  },
+  {
+    "code": "600863",
+    "name": "内蒙华电",
+    "market": "sh"
+  },
+  {
+    "code": "600864",
+    "name": "哈投股份",
+    "market": "sh"
+  },
+  {
+    "code": "600865",
+    "name": "百大集团",
+    "market": "sh"
+  },
+  {
+    "code": "600866",
+    "name": "星湖科技",
+    "market": "sh"
+  },
+  {
+    "code": "600867",
+    "name": "通化东宝",
+    "market": "sh"
+  },
+  {
+    "code": "600868",
+    "name": "梅雁吉祥",
+    "market": "sh"
+  },
+  {
+    "code": "600869",
+    "name": "远东股份",
+    "market": "sh"
+  },
+  {
+    "code": "600870",
+    "name": "ST厦华",
+    "market": "sh"
+  },
+  {
+    "code": "600871",
+    "name": "石化油服",
+    "market": "sh"
+  },
+  {
+    "code": "600872",
+    "name": "中炬高新",
+    "market": "sh"
+  },
+  {
+    "code": "600873",
+    "name": "梅花生物",
+    "market": "sh"
+  },
+  {
+    "code": "600874",
+    "name": "创业环保",
+    "market": "sh"
+  },
+  {
+    "code": "600875",
+    "name": "东方电气",
+    "market": "sh"
+  },
+  {
+    "code": "600876",
+    "name": "洛阳玻璃",
+    "market": "sh"
+  },
+  {
+    "code": "600877",
+    "name": "声光电科",
+    "market": "sh"
+  },
+  {
+    "code": "600879",
+    "name": "航天电子",
+    "market": "sh"
+  },
+  {
+    "code": "600880",
+    "name": "博瑞传播",
+    "market": "sh"
+  },
+  {
+    "code": "600881",
+    "name": "亚泰集团",
+    "market": "sh"
+  },
+  {
+    "code": "600882",
+    "name": "妙可蓝多",
+    "market": "sh"
+  },
+  {
+    "code": "600883",
+    "name": "博闻科技",
+    "market": "sh"
+  },
+  {
+    "code": "600884",
+    "name": "杉杉股份",
+    "market": "sh"
+  },
+  {
+    "code": "600885",
+    "name": "宏发股份",
+    "market": "sh"
+  },
+  {
+    "code": "600886",
+    "name": "国投电力",
+    "market": "sh"
+  },
+  {
+    "code": "600887",
+    "name": "伊利股份",
+    "market": "sh"
+  },
+  {
+    "code": "600888",
+    "name": "新疆众和",
+    "market": "sh"
+  },
+  {
+    "code": "600889",
+    "name": "南京化纤",
+    "market": "sh"
+  },
+  {
+    "code": "600890",
+    "name": "中房股份",
+    "market": "sh"
+  },
+  {
+    "code": "600891",
+    "name": "ST秋林",
+    "market": "sh"
+  },
+  {
+    "code": "600892",
+    "name": "大晟文化",
+    "market": "sh"
+  },
+  {
+    "code": "600893",
+    "name": "航发动力",
+    "market": "sh"
+  },
+  {
+    "code": "600894",
+    "name": "广日股份",
+    "market": "sh"
+  },
+  {
+    "code": "600895",
+    "name": "张江高科",
+    "market": "sh"
+  },
+  {
+    "code": "600896",
+    "name": "览海医疗",
+    "market": "sh"
+  },
+  {
+    "code": "600897",
+    "name": "厦门空港",
+    "market": "sh"
+  },
+  {
+    "code": "600898",
+    "name": "ST美讯",
+    "market": "sh"
+  },
+  {
+    "code": "600900",
+    "name": "长江电力",
+    "market": "sh"
+  },
+  {
+    "code": "600901",
+    "name": "江苏租赁",
+    "market": "sh"
+  },
+  {
+    "code": "600903",
+    "name": "贵州燃气",
+    "market": "sh"
+  },
+  {
+    "code": "600905",
+    "name": "三峡能源",
+    "market": "sh"
+  },
+  {
+    "code": "600906",
+    "name": "财达证券",
+    "market": "sh"
+  },
+  {
+    "code": "600908",
+    "name": "无锡银行",
+    "market": "sh"
+  },
+  {
+    "code": "600909",
+    "name": "华安证券",
+    "market": "sh"
+  },
+  {
+    "code": "600916",
+    "name": "中国黄金",
+    "market": "sh"
+  },
+  {
+    "code": "600917",
+    "name": "重庆燃气",
+    "market": "sh"
+  },
+  {
+    "code": "600918",
+    "name": "中泰证券",
+    "market": "sh"
+  },
+  {
+    "code": "600919",
+    "name": "江苏银行",
+    "market": "sh"
+  },
+  {
+    "code": "600926",
+    "name": "杭州银行",
+    "market": "sh"
+  },
+  {
+    "code": "600927",
+    "name": "永安期货",
+    "market": "sh"
+  },
+  {
+    "code": "600928",
+    "name": "西安银行",
+    "market": "sh"
+  },
+  {
+    "code": "600929",
+    "name": "雪天盐业",
+    "market": "sh"
+  },
+  {
+    "code": "600933",
+    "name": "爱柯迪",
+    "market": "sh"
+  },
+  {
+    "code": "600938",
+    "name": "中国海油",
+    "market": "sh"
+  },
+  {
+    "code": "600939",
+    "name": "重庆建工",
+    "market": "sh"
+  },
+  {
+    "code": "600941",
+    "name": "中国移动",
+    "market": "sh"
+  },
+  {
+    "code": "600955",
+    "name": "维远股份",
+    "market": "sh"
+  },
+  {
+    "code": "600956",
+    "name": "新天绿能",
+    "market": "sh"
+  },
+  {
+    "code": "600958",
+    "name": "东方证券",
+    "market": "sh"
+  },
+  {
+    "code": "600959",
+    "name": "江苏有线",
+    "market": "sh"
+  },
+  {
+    "code": "600960",
+    "name": "渤海汽车",
+    "market": "sh"
+  },
+  {
+    "code": "600961",
+    "name": "株冶集团",
+    "market": "sh"
+  },
+  {
+    "code": "600962",
+    "name": "国投中鲁",
+    "market": "sh"
+  },
+  {
+    "code": "600963",
+    "name": "岳阳林纸",
+    "market": "sh"
+  },
+  {
+    "code": "600965",
+    "name": "福成股份",
+    "market": "sh"
+  },
+  {
+    "code": "600966",
+    "name": "博汇纸业",
+    "market": "sh"
+  },
+  {
+    "code": "600967",
+    "name": "内蒙一机",
+    "market": "sh"
+  },
+  {
+    "code": "600968",
+    "name": "海油发展",
+    "market": "sh"
+  },
+  {
+    "code": "600969",
+    "name": "郴电国际",
+    "market": "sh"
+  },
+  {
+    "code": "600970",
+    "name": "中材国际",
+    "market": "sh"
+  },
+  {
+    "code": "600971",
+    "name": "恒源煤电",
+    "market": "sh"
+  },
+  {
+    "code": "600973",
+    "name": "宝胜股份",
+    "market": "sh"
+  },
+  {
+    "code": "600975",
+    "name": "新五丰",
+    "market": "sh"
+  },
+  {
+    "code": "600976",
+    "name": "健民集团",
+    "market": "sh"
+  },
+  {
+    "code": "600977",
+    "name": "中国电影",
+    "market": "sh"
+  },
+  {
+    "code": "600978",
+    "name": "ST宜华",
+    "market": "sh"
+  },
+  {
+    "code": "600979",
+    "name": "广安爱众",
+    "market": "sh"
+  },
+  {
+    "code": "600980",
+    "name": "北矿科技",
+    "market": "sh"
+  },
+  {
+    "code": "600981",
+    "name": "汇鸿集团",
+    "market": "sh"
+  },
+  {
+    "code": "600982",
+    "name": "宁波能源",
+    "market": "sh"
+  },
+  {
+    "code": "600983",
+    "name": "惠而浦",
+    "market": "sh"
+  },
+  {
+    "code": "600984",
+    "name": "建设机械",
+    "market": "sh"
+  },
+  {
+    "code": "600985",
+    "name": "淮北矿业",
+    "market": "sh"
+  },
+  {
+    "code": "600986",
+    "name": "浙文互联",
+    "market": "sh"
+  },
+  {
+    "code": "600987",
+    "name": "航民股份",
+    "market": "sh"
+  },
+  {
+    "code": "600988",
+    "name": "赤峰黄金",
+    "market": "sh"
+  },
+  {
+    "code": "600989",
+    "name": "宝丰能源",
+    "market": "sh"
+  },
+  {
+    "code": "600990",
+    "name": "四创电子",
+    "market": "sh"
+  },
+  {
+    "code": "600992",
+    "name": "贵绳股份",
+    "market": "sh"
+  },
+  {
+    "code": "600993",
+    "name": "马应龙",
+    "market": "sh"
+  },
+  {
+    "code": "600995",
+    "name": "文山电力",
+    "market": "sh"
+  },
+  {
+    "code": "600996",
+    "name": "贵广网络",
+    "market": "sh"
+  },
+  {
+    "code": "600997",
+    "name": "开滦股份",
+    "market": "sh"
+  },
+  {
+    "code": "600998",
+    "name": "九州通",
+    "market": "sh"
+  },
+  {
+    "code": "600999",
+    "name": "招商证券",
+    "market": "sh"
+  },
+  {
     "code": "000001",
     "name": "平安银行",
     "market": "sz"
@@ -10,18 +4060,283 @@
     "market": "sz"
   },
   {
-    "code": "00001.HK",
-    "name": "长和",
-    "market": "hk"
+    "code": "000004",
+    "name": "国华网安",
+    "market": "sz"
   },
   {
-    "code": "00005.HK",
-    "name": "汇丰控股",
-    "market": "hk"
+    "code": "000005",
+    "name": "ST星源",
+    "market": "sz"
+  },
+  {
+    "code": "000006",
+    "name": "深振业A",
+    "market": "sz"
+  },
+  {
+    "code": "000007",
+    "name": "全新好",
+    "market": "sz"
+  },
+  {
+    "code": "000008",
+    "name": "神州高铁",
+    "market": "sz"
+  },
+  {
+    "code": "000009",
+    "name": "中国宝安",
+    "market": "sz"
+  },
+  {
+    "code": "000010",
+    "name": "美丽生态",
+    "market": "sz"
+  },
+  {
+    "code": "000011",
+    "name": "深物业A",
+    "market": "sz"
+  },
+  {
+    "code": "000012",
+    "name": "南玻A",
+    "market": "sz"
+  },
+  {
+    "code": "000014",
+    "name": "沙河股份",
+    "market": "sz"
+  },
+  {
+    "code": "000016",
+    "name": "深康佳A",
+    "market": "sz"
+  },
+  {
+    "code": "000017",
+    "name": "深中华A",
+    "market": "sz"
+  },
+  {
+    "code": "000019",
+    "name": "深粮控股",
+    "market": "sz"
+  },
+  {
+    "code": "000020",
+    "name": "深华发A",
+    "market": "sz"
+  },
+  {
+    "code": "000021",
+    "name": "深科技",
+    "market": "sz"
+  },
+  {
+    "code": "000023",
+    "name": "深天地A",
+    "market": "sz"
+  },
+  {
+    "code": "000025",
+    "name": "特力A",
+    "market": "sz"
+  },
+  {
+    "code": "000026",
+    "name": "飞亚达",
+    "market": "sz"
+  },
+  {
+    "code": "000027",
+    "name": "深圳能源",
+    "market": "sz"
+  },
+  {
+    "code": "000028",
+    "name": "国药一致",
+    "market": "sz"
+  },
+  {
+    "code": "000029",
+    "name": "深深房A",
+    "market": "sz"
+  },
+  {
+    "code": "000030",
+    "name": "富奥股份",
+    "market": "sz"
+  },
+  {
+    "code": "000031",
+    "name": "大悦城",
+    "market": "sz"
+  },
+  {
+    "code": "000032",
+    "name": "深桑达A",
+    "market": "sz"
+  },
+  {
+    "code": "000034",
+    "name": "神州数码",
+    "market": "sz"
+  },
+  {
+    "code": "000035",
+    "name": "中国天楹",
+    "market": "sz"
+  },
+  {
+    "code": "000036",
+    "name": "华联控股",
+    "market": "sz"
+  },
+  {
+    "code": "000037",
+    "name": "深南电A",
+    "market": "sz"
+  },
+  {
+    "code": "000038",
+    "name": "深大通",
+    "market": "sz"
+  },
+  {
+    "code": "000039",
+    "name": "中集集团",
+    "market": "sz"
+  },
+  {
+    "code": "000040",
+    "name": "东旭蓝天",
+    "market": "sz"
+  },
+  {
+    "code": "000042",
+    "name": "中洲控股",
+    "market": "sz"
+  },
+  {
+    "code": "000045",
+    "name": "深纺织A",
+    "market": "sz"
+  },
+  {
+    "code": "000046",
+    "name": "泛海控股",
+    "market": "sz"
+  },
+  {
+    "code": "000048",
+    "name": "京基智农",
+    "market": "sz"
+  },
+  {
+    "code": "000049",
+    "name": "德赛电池",
+    "market": "sz"
+  },
+  {
+    "code": "000050",
+    "name": "深天马A",
+    "market": "sz"
+  },
+  {
+    "code": "000055",
+    "name": "方大集团",
+    "market": "sz"
+  },
+  {
+    "code": "000056",
+    "name": "皇庭国际",
+    "market": "sz"
+  },
+  {
+    "code": "000058",
+    "name": "深赛格",
+    "market": "sz"
+  },
+  {
+    "code": "000059",
+    "name": "华锦股份",
+    "market": "sz"
+  },
+  {
+    "code": "000060",
+    "name": "中金岭南",
+    "market": "sz"
+  },
+  {
+    "code": "000061",
+    "name": "农产品",
+    "market": "sz"
+  },
+  {
+    "code": "000062",
+    "name": "深圳华强",
+    "market": "sz"
   },
   {
     "code": "000063",
     "name": "中兴通讯",
+    "market": "sz"
+  },
+  {
+    "code": "000065",
+    "name": "北方国际",
+    "market": "sz"
+  },
+  {
+    "code": "000066",
+    "name": "中国长城",
+    "market": "sz"
+  },
+  {
+    "code": "000068",
+    "name": "华控赛格",
+    "market": "sz"
+  },
+  {
+    "code": "000069",
+    "name": "华侨城A",
+    "market": "sz"
+  },
+  {
+    "code": "000070",
+    "name": "特发信息",
+    "market": "sz"
+  },
+  {
+    "code": "000078",
+    "name": "海王生物",
+    "market": "sz"
+  },
+  {
+    "code": "000088",
+    "name": "盐田港",
+    "market": "sz"
+  },
+  {
+    "code": "000089",
+    "name": "深圳机场",
+    "market": "sz"
+  },
+  {
+    "code": "000090",
+    "name": "天健集团",
+    "market": "sz"
+  },
+  {
+    "code": "000096",
+    "name": "广聚能源",
+    "market": "sz"
+  },
+  {
+    "code": "000099",
+    "name": "中信海直",
     "market": "sz"
   },
   {
@@ -30,9 +4345,54 @@
     "market": "sz"
   },
   {
-    "code": "00016.HK",
-    "name": "新鸿基地产",
-    "market": "hk"
+    "code": "000150",
+    "name": "宜华健康",
+    "market": "sz"
+  },
+  {
+    "code": "000151",
+    "name": "中成股份",
+    "market": "sz"
+  },
+  {
+    "code": "000153",
+    "name": "丰原药业",
+    "market": "sz"
+  },
+  {
+    "code": "000155",
+    "name": "川能动力",
+    "market": "sz"
+  },
+  {
+    "code": "000156",
+    "name": "华数传媒",
+    "market": "sz"
+  },
+  {
+    "code": "000157",
+    "name": "中联重科",
+    "market": "sz"
+  },
+  {
+    "code": "000158",
+    "name": "常山北明",
+    "market": "sz"
+  },
+  {
+    "code": "000159",
+    "name": "国际实业",
+    "market": "sz"
+  },
+  {
+    "code": "000166",
+    "name": "申万宏源",
+    "market": "sz"
+  },
+  {
+    "code": "000167",
+    "name": "ST华讯",
+    "market": "sz"
   },
   {
     "code": "000301",
@@ -50,8 +4410,623 @@
     "market": "sz"
   },
   {
+    "code": "000400",
+    "name": "许继电气",
+    "market": "sz"
+  },
+  {
+    "code": "000401",
+    "name": "冀东水泥",
+    "market": "sz"
+  },
+  {
+    "code": "000402",
+    "name": "金融街",
+    "market": "sz"
+  },
+  {
+    "code": "000403",
+    "name": "派林生物",
+    "market": "sz"
+  },
+  {
+    "code": "000404",
+    "name": "长虹华意",
+    "market": "sz"
+  },
+  {
+    "code": "000407",
+    "name": "胜利股份",
+    "market": "sz"
+  },
+  {
+    "code": "000408",
+    "name": "藏格矿业",
+    "market": "sz"
+  },
+  {
+    "code": "000409",
+    "name": "ST地矿",
+    "market": "sz"
+  },
+  {
+    "code": "000410",
+    "name": "沈阳机床",
+    "market": "sz"
+  },
+  {
+    "code": "000411",
+    "name": "英特集团",
+    "market": "sz"
+  },
+  {
+    "code": "000413",
+    "name": "东旭光电",
+    "market": "sz"
+  },
+  {
+    "code": "000415",
+    "name": "渤海租赁",
+    "market": "sz"
+  },
+  {
+    "code": "000416",
+    "name": "民生控股",
+    "market": "sz"
+  },
+  {
+    "code": "000417",
+    "name": "合肥百货",
+    "market": "sz"
+  },
+  {
+    "code": "000418",
+    "name": "小天鹅A",
+    "market": "sz"
+  },
+  {
+    "code": "000419",
+    "name": "通程控股",
+    "market": "sz"
+  },
+  {
+    "code": "000420",
+    "name": "吉林化纤",
+    "market": "sz"
+  },
+  {
+    "code": "000421",
+    "name": "南京公用",
+    "market": "sz"
+  },
+  {
+    "code": "000422",
+    "name": "湖北宜化",
+    "market": "sz"
+  },
+  {
+    "code": "000423",
+    "name": "东阿阿胶",
+    "market": "sz"
+  },
+  {
+    "code": "000425",
+    "name": "徐工机械",
+    "market": "sz"
+  },
+  {
+    "code": "000426",
+    "name": "兴业矿业",
+    "market": "sz"
+  },
+  {
+    "code": "000428",
+    "name": "华天酒店",
+    "market": "sz"
+  },
+  {
+    "code": "000429",
+    "name": "粤高速A",
+    "market": "sz"
+  },
+  {
+    "code": "000430",
+    "name": "张家界",
+    "market": "sz"
+  },
+  {
+    "code": "000488",
+    "name": "晨鸣纸业",
+    "market": "sz"
+  },
+  {
+    "code": "000498",
+    "name": "山东路桥",
+    "market": "sz"
+  },
+  {
+    "code": "000501",
+    "name": "鄂武商A",
+    "market": "sz"
+  },
+  {
+    "code": "000503",
+    "name": "国新健康",
+    "market": "sz"
+  },
+  {
+    "code": "000504",
+    "name": "ST生物",
+    "market": "sz"
+  },
+  {
+    "code": "000505",
+    "name": "京粮控股",
+    "market": "sz"
+  },
+  {
+    "code": "000506",
+    "name": "中润资源",
+    "market": "sz"
+  },
+  {
+    "code": "000507",
+    "name": "珠海港",
+    "market": "sz"
+  },
+  {
+    "code": "000509",
+    "name": "ST华塑",
+    "market": "sz"
+  },
+  {
+    "code": "000510",
+    "name": "新金路",
+    "market": "sz"
+  },
+  {
+    "code": "000513",
+    "name": "丽珠集团",
+    "market": "sz"
+  },
+  {
+    "code": "000514",
+    "name": "渝开发",
+    "market": "sz"
+  },
+  {
+    "code": "000516",
+    "name": "国际医学",
+    "market": "sz"
+  },
+  {
+    "code": "000517",
+    "name": "荣安地产",
+    "market": "sz"
+  },
+  {
+    "code": "000518",
+    "name": "四环生物",
+    "market": "sz"
+  },
+  {
+    "code": "000519",
+    "name": "中兵红箭",
+    "market": "sz"
+  },
+  {
+    "code": "000520",
+    "name": "长航凤凰",
+    "market": "sz"
+  },
+  {
+    "code": "000521",
+    "name": "长虹美菱",
+    "market": "sz"
+  },
+  {
+    "code": "000523",
+    "name": "广州浪奇",
+    "market": "sz"
+  },
+  {
+    "code": "000524",
+    "name": "岭南控股",
+    "market": "sz"
+  },
+  {
+    "code": "000525",
+    "name": "ST红太阳",
+    "market": "sz"
+  },
+  {
+    "code": "000526",
+    "name": "学大教育",
+    "market": "sz"
+  },
+  {
+    "code": "000528",
+    "name": "柳工",
+    "market": "sz"
+  },
+  {
+    "code": "000529",
+    "name": "广弘控股",
+    "market": "sz"
+  },
+  {
+    "code": "000530",
+    "name": "冰山冷热",
+    "market": "sz"
+  },
+  {
+    "code": "000531",
+    "name": "穗恒运A",
+    "market": "sz"
+  },
+  {
+    "code": "000532",
+    "name": "华金资本",
+    "market": "sz"
+  },
+  {
+    "code": "000533",
+    "name": "顺钠股份",
+    "market": "sz"
+  },
+  {
+    "code": "000534",
+    "name": "万泽股份",
+    "market": "sz"
+  },
+  {
+    "code": "000535",
+    "name": "ST猴王",
+    "market": "sz"
+  },
+  {
+    "code": "000536",
+    "name": "华映科技",
+    "market": "sz"
+  },
+  {
+    "code": "000537",
+    "name": "广宇发展",
+    "market": "sz"
+  },
+  {
+    "code": "000538",
+    "name": "云南白药",
+    "market": "sz"
+  },
+  {
+    "code": "000539",
+    "name": "粤电力A",
+    "market": "sz"
+  },
+  {
+    "code": "000540",
+    "name": "中天金融",
+    "market": "sz"
+  },
+  {
+    "code": "000541",
+    "name": "佛山照明",
+    "market": "sz"
+  },
+  {
+    "code": "000543",
+    "name": "皖能电力",
+    "market": "sz"
+  },
+  {
+    "code": "000544",
+    "name": "中原环保",
+    "market": "sz"
+  },
+  {
+    "code": "000545",
+    "name": "金浦钛业",
+    "market": "sz"
+  },
+  {
+    "code": "000546",
+    "name": "金圆股份",
+    "market": "sz"
+  },
+  {
+    "code": "000547",
+    "name": "航天发展",
+    "market": "sz"
+  },
+  {
+    "code": "000548",
+    "name": "湖南投资",
+    "market": "sz"
+  },
+  {
+    "code": "000550",
+    "name": "江铃汽车",
+    "market": "sz"
+  },
+  {
+    "code": "000551",
+    "name": "创元科技",
+    "market": "sz"
+  },
+  {
+    "code": "000552",
+    "name": "靖远煤电",
+    "market": "sz"
+  },
+  {
+    "code": "000553",
+    "name": "安道麦A",
+    "market": "sz"
+  },
+  {
+    "code": "000554",
+    "name": "泰山石油",
+    "market": "sz"
+  },
+  {
+    "code": "000555",
+    "name": "神州信息",
+    "market": "sz"
+  },
+  {
+    "code": "000557",
+    "name": "西部创业",
+    "market": "sz"
+  },
+  {
+    "code": "000558",
+    "name": "莱茵体育",
+    "market": "sz"
+  },
+  {
+    "code": "000559",
+    "name": "万向钱潮",
+    "market": "sz"
+  },
+  {
+    "code": "000560",
+    "name": "我爱我家",
+    "market": "sz"
+  },
+  {
+    "code": "000561",
+    "name": "烽火电子",
+    "market": "sz"
+  },
+  {
+    "code": "000563",
+    "name": "陕国投A",
+    "market": "sz"
+  },
+  {
+    "code": "000564",
+    "name": "ST大集",
+    "market": "sz"
+  },
+  {
+    "code": "000565",
+    "name": "渝三峡A",
+    "market": "sz"
+  },
+  {
+    "code": "000566",
+    "name": "海南海药",
+    "market": "sz"
+  },
+  {
+    "code": "000567",
+    "name": "海德股份",
+    "market": "sz"
+  },
+  {
     "code": "000568",
     "name": "泸州老窖",
+    "market": "sz"
+  },
+  {
+    "code": "000570",
+    "name": "苏常柴A",
+    "market": "sz"
+  },
+  {
+    "code": "000571",
+    "name": "ST大洲",
+    "market": "sz"
+  },
+  {
+    "code": "000572",
+    "name": "海马汽车",
+    "market": "sz"
+  },
+  {
+    "code": "000573",
+    "name": "粤宏远A",
+    "market": "sz"
+  },
+  {
+    "code": "000576",
+    "name": "甘化科工",
+    "market": "sz"
+  },
+  {
+    "code": "000581",
+    "name": "威孚高科",
+    "market": "sz"
+  },
+  {
+    "code": "000582",
+    "name": "北部湾港",
+    "market": "sz"
+  },
+  {
+    "code": "000584",
+    "name": "哈工智能",
+    "market": "sz"
+  },
+  {
+    "code": "000585",
+    "name": "ST东北电",
+    "market": "sz"
+  },
+  {
+    "code": "000586",
+    "name": "汇源通信",
+    "market": "sz"
+  },
+  {
+    "code": "000587",
+    "name": "金洲慈航",
+    "market": "sz"
+  },
+  {
+    "code": "000589",
+    "name": "贵州轮胎",
+    "market": "sz"
+  },
+  {
+    "code": "000590",
+    "name": "启迪药业",
+    "market": "sz"
+  },
+  {
+    "code": "000591",
+    "name": "太阳能",
+    "market": "sz"
+  },
+  {
+    "code": "000592",
+    "name": "平潭发展",
+    "market": "sz"
+  },
+  {
+    "code": "000593",
+    "name": "大通燃气",
+    "market": "sz"
+  },
+  {
+    "code": "000595",
+    "name": "宝塔实业",
+    "market": "sz"
+  },
+  {
+    "code": "000596",
+    "name": "古井贡酒",
+    "market": "sz"
+  },
+  {
+    "code": "000597",
+    "name": "东北制药",
+    "market": "sz"
+  },
+  {
+    "code": "000598",
+    "name": "兴蓉环境",
+    "market": "sz"
+  },
+  {
+    "code": "000599",
+    "name": "青岛双星",
+    "market": "sz"
+  },
+  {
+    "code": "000600",
+    "name": "建投能源",
+    "market": "sz"
+  },
+  {
+    "code": "000601",
+    "name": "韶能股份",
+    "market": "sz"
+  },
+  {
+    "code": "000603",
+    "name": "盛达资源",
+    "market": "sz"
+  },
+  {
+    "code": "000605",
+    "name": "渤海股份",
+    "market": "sz"
+  },
+  {
+    "code": "000606",
+    "name": "ST顺利",
+    "market": "sz"
+  },
+  {
+    "code": "000607",
+    "name": "华媒控股",
+    "market": "sz"
+  },
+  {
+    "code": "000608",
+    "name": "阳光股份",
+    "market": "sz"
+  },
+  {
+    "code": "000609",
+    "name": "ST中迪",
+    "market": "sz"
+  },
+  {
+    "code": "000610",
+    "name": "西安旅游",
+    "market": "sz"
+  },
+  {
+    "code": "000611",
+    "name": "ST天首",
+    "market": "sz"
+  },
+  {
+    "code": "000612",
+    "name": "焦作万方",
+    "market": "sz"
+  },
+  {
+    "code": "000613",
+    "name": "*ST东海A",
+    "market": "sz"
+  },
+  {
+    "code": "000615",
+    "name": "奥园美谷",
+    "market": "sz"
+  },
+  {
+    "code": "000616",
+    "name": "ST海投",
+    "market": "sz"
+  },
+  {
+    "code": "000617",
+    "name": "中油资本",
+    "market": "sz"
+  },
+  {
+    "code": "000619",
+    "name": "海螺型材",
+    "market": "sz"
+  },
+  {
+    "code": "000620",
+    "name": "新华联",
+    "market": "sz"
+  },
+  {
+    "code": "000622",
+    "name": "恒立实业",
+    "market": "sz"
+  },
+  {
+    "code": "000623",
+    "name": "吉林敖东",
     "market": "sz"
   },
   {
@@ -60,8 +5035,103 @@
     "market": "sz"
   },
   {
+    "code": "000626",
+    "name": "远大控股",
+    "market": "sz"
+  },
+  {
+    "code": "000627",
+    "name": "天茂集团",
+    "market": "sz"
+  },
+  {
+    "code": "000628",
+    "name": "高新发展",
+    "market": "sz"
+  },
+  {
+    "code": "000629",
+    "name": "攀钢钒钛",
+    "market": "sz"
+  },
+  {
+    "code": "000630",
+    "name": "铜陵有色",
+    "market": "sz"
+  },
+  {
+    "code": "000631",
+    "name": "顺发恒业",
+    "market": "sz"
+  },
+  {
+    "code": "000632",
+    "name": "三木集团",
+    "market": "sz"
+  },
+  {
+    "code": "000633",
+    "name": "合金投资",
+    "market": "sz"
+  },
+  {
+    "code": "000635",
+    "name": "英力特",
+    "market": "sz"
+  },
+  {
+    "code": "000636",
+    "name": "风华高科",
+    "market": "sz"
+  },
+  {
+    "code": "000637",
+    "name": "茂化实华",
+    "market": "sz"
+  },
+  {
+    "code": "000638",
+    "name": "万方发展",
+    "market": "sz"
+  },
+  {
+    "code": "000639",
+    "name": "西王食品",
+    "market": "sz"
+  },
+  {
+    "code": "000650",
+    "name": "仁和药业",
+    "market": "sz"
+  },
+  {
     "code": "000651",
     "name": "格力电器",
+    "market": "sz"
+  },
+  {
+    "code": "000652",
+    "name": "泰达股份",
+    "market": "sz"
+  },
+  {
+    "code": "000655",
+    "name": "金岭矿业",
+    "market": "sz"
+  },
+  {
+    "code": "000656",
+    "name": "金科股份",
+    "market": "sz"
+  },
+  {
+    "code": "000657",
+    "name": "中钨高新",
+    "market": "sz"
+  },
+  {
+    "code": "000659",
+    "name": "珠海中富",
     "market": "sz"
   },
   {
@@ -70,8 +5140,388 @@
     "market": "sz"
   },
   {
+    "code": "000662",
+    "name": "ST天夏",
+    "market": "sz"
+  },
+  {
+    "code": "000663",
+    "name": "永安林业",
+    "market": "sz"
+  },
+  {
+    "code": "000665",
+    "name": "湖北广电",
+    "market": "sz"
+  },
+  {
+    "code": "000666",
+    "name": "经纬纺机",
+    "market": "sz"
+  },
+  {
+    "code": "000667",
+    "name": "美好置业",
+    "market": "sz"
+  },
+  {
+    "code": "000668",
+    "name": "荣丰控股",
+    "market": "sz"
+  },
+  {
+    "code": "000669",
+    "name": "ST金鸿",
+    "market": "sz"
+  },
+  {
+    "code": "000670",
+    "name": "*ST盈方",
+    "market": "sz"
+  },
+  {
+    "code": "000671",
+    "name": "阳光城",
+    "market": "sz"
+  },
+  {
+    "code": "000672",
+    "name": "上峰水泥",
+    "market": "sz"
+  },
+  {
+    "code": "000673",
+    "name": "ST当代",
+    "market": "sz"
+  },
+  {
+    "code": "000676",
+    "name": "智度股份",
+    "market": "sz"
+  },
+  {
+    "code": "000677",
+    "name": "恒天海龙",
+    "market": "sz"
+  },
+  {
+    "code": "000678",
+    "name": "襄阳轴承",
+    "market": "sz"
+  },
+  {
+    "code": "000679",
+    "name": "大连友谊",
+    "market": "sz"
+  },
+  {
+    "code": "000680",
+    "name": "山推股份",
+    "market": "sz"
+  },
+  {
+    "code": "000681",
+    "name": "视觉中国",
+    "market": "sz"
+  },
+  {
+    "code": "000682",
+    "name": "东方电子",
+    "market": "sz"
+  },
+  {
+    "code": "000683",
+    "name": "远兴能源",
+    "market": "sz"
+  },
+  {
+    "code": "000685",
+    "name": "中山公用",
+    "market": "sz"
+  },
+  {
+    "code": "000686",
+    "name": "东北证券",
+    "market": "sz"
+  },
+  {
+    "code": "000687",
+    "name": "华讯方舟",
+    "market": "sz"
+  },
+  {
+    "code": "000688",
+    "name": "国城矿业",
+    "market": "sz"
+  },
+  {
+    "code": "000690",
+    "name": "宝新能源",
+    "market": "sz"
+  },
+  {
+    "code": "000691",
+    "name": "亚太实业",
+    "market": "sz"
+  },
+  {
+    "code": "000692",
+    "name": "惠天热电",
+    "market": "sz"
+  },
+  {
+    "code": "000695",
+    "name": "滨海能源",
+    "market": "sz"
+  },
+  {
+    "code": "000697",
+    "name": "炼石航空",
+    "market": "sz"
+  },
+  {
+    "code": "000698",
+    "name": "沈阳化工",
+    "market": "sz"
+  },
+  {
+    "code": "000700",
+    "name": "模塑科技",
+    "market": "sz"
+  },
+  {
+    "code": "000701",
+    "name": "厦门信达",
+    "market": "sz"
+  },
+  {
+    "code": "000702",
+    "name": "正虹科技",
+    "market": "sz"
+  },
+  {
+    "code": "000703",
+    "name": "恒逸石化",
+    "market": "sz"
+  },
+  {
+    "code": "000705",
+    "name": "浙江震元",
+    "market": "sz"
+  },
+  {
+    "code": "000707",
+    "name": "双环科技",
+    "market": "sz"
+  },
+  {
+    "code": "000708",
+    "name": "中信特钢",
+    "market": "sz"
+  },
+  {
+    "code": "000709",
+    "name": "河钢股份",
+    "market": "sz"
+  },
+  {
+    "code": "000710",
+    "name": "贝瑞基因",
+    "market": "sz"
+  },
+  {
+    "code": "000711",
+    "name": "京蓝科技",
+    "market": "sz"
+  },
+  {
+    "code": "000712",
+    "name": "锦龙股份",
+    "market": "sz"
+  },
+  {
+    "code": "000713",
+    "name": "丰乐种业",
+    "market": "sz"
+  },
+  {
+    "code": "000715",
+    "name": "中兴商业",
+    "market": "sz"
+  },
+  {
+    "code": "000716",
+    "name": "黑芝麻",
+    "market": "sz"
+  },
+  {
+    "code": "000717",
+    "name": "韶钢松山",
+    "market": "sz"
+  },
+  {
+    "code": "000718",
+    "name": "苏宁环球",
+    "market": "sz"
+  },
+  {
+    "code": "000719",
+    "name": "中原传媒",
+    "market": "sz"
+  },
+  {
+    "code": "000720",
+    "name": "新能泰山",
+    "market": "sz"
+  },
+  {
+    "code": "000721",
+    "name": "西安饮食",
+    "market": "sz"
+  },
+  {
+    "code": "000722",
+    "name": "湖南发展",
+    "market": "sz"
+  },
+  {
+    "code": "000723",
+    "name": "美锦能源",
+    "market": "sz"
+  },
+  {
     "code": "000725",
     "name": "京东方A",
+    "market": "sz"
+  },
+  {
+    "code": "000726",
+    "name": "鲁泰A",
+    "market": "sz"
+  },
+  {
+    "code": "000727",
+    "name": "冠捷科技",
+    "market": "sz"
+  },
+  {
+    "code": "000728",
+    "name": "国元证券",
+    "market": "sz"
+  },
+  {
+    "code": "000729",
+    "name": "燕京啤酒",
+    "market": "sz"
+  },
+  {
+    "code": "000731",
+    "name": "四川美丰",
+    "market": "sz"
+  },
+  {
+    "code": "000732",
+    "name": "泰禾集团",
+    "market": "sz"
+  },
+  {
+    "code": "000733",
+    "name": "振华科技",
+    "market": "sz"
+  },
+  {
+    "code": "000735",
+    "name": "罗牛山",
+    "market": "sz"
+  },
+  {
+    "code": "000736",
+    "name": "中交地产",
+    "market": "sz"
+  },
+  {
+    "code": "000737",
+    "name": "ST南风",
+    "market": "sz"
+  },
+  {
+    "code": "000738",
+    "name": "航发控制",
+    "market": "sz"
+  },
+  {
+    "code": "000739",
+    "name": "普洛药业",
+    "market": "sz"
+  },
+  {
+    "code": "000750",
+    "name": "国海证券",
+    "market": "sz"
+  },
+  {
+    "code": "000751",
+    "name": "锌业股份",
+    "market": "sz"
+  },
+  {
+    "code": "000752",
+    "name": "ST西发",
+    "market": "sz"
+  },
+  {
+    "code": "000753",
+    "name": "漳州发展",
+    "market": "sz"
+  },
+  {
+    "code": "000755",
+    "name": "山西路桥",
+    "market": "sz"
+  },
+  {
+    "code": "000756",
+    "name": "新华制药",
+    "market": "sz"
+  },
+  {
+    "code": "000757",
+    "name": "浩物股份",
+    "market": "sz"
+  },
+  {
+    "code": "000758",
+    "name": "中色股份",
+    "market": "sz"
+  },
+  {
+    "code": "000759",
+    "name": "中百集团",
+    "market": "sz"
+  },
+  {
+    "code": "000760",
+    "name": "斯太退",
+    "market": "sz"
+  },
+  {
+    "code": "000761",
+    "name": "本钢板材",
+    "market": "sz"
+  },
+  {
+    "code": "000762",
+    "name": "西藏矿业",
+    "market": "sz"
+  },
+  {
+    "code": "000766",
+    "name": "通化金马",
+    "market": "sz"
+  },
+  {
+    "code": "000767",
+    "name": "晋控电力",
     "market": "sz"
   },
   {
@@ -80,8 +5530,283 @@
     "market": "sz"
   },
   {
+    "code": "000776",
+    "name": "广发证券",
+    "market": "sz"
+  },
+  {
+    "code": "000777",
+    "name": "中核科技",
+    "market": "sz"
+  },
+  {
+    "code": "000778",
+    "name": "新兴铸管",
+    "market": "sz"
+  },
+  {
+    "code": "000779",
+    "name": "甘咨询",
+    "market": "sz"
+  },
+  {
+    "code": "000780",
+    "name": "ST平能",
+    "market": "sz"
+  },
+  {
+    "code": "000782",
+    "name": "美达股份",
+    "market": "sz"
+  },
+  {
+    "code": "000783",
+    "name": "长江证券",
+    "market": "sz"
+  },
+  {
+    "code": "000785",
+    "name": "居然之家",
+    "market": "sz"
+  },
+  {
+    "code": "000786",
+    "name": "北新建材",
+    "market": "sz"
+  },
+  {
+    "code": "000788",
+    "name": "北大医药",
+    "market": "sz"
+  },
+  {
+    "code": "000789",
+    "name": "万年青",
+    "market": "sz"
+  },
+  {
+    "code": "000790",
+    "name": "华神科技",
+    "market": "sz"
+  },
+  {
+    "code": "000791",
+    "name": "甘肃电投",
+    "market": "sz"
+  },
+  {
     "code": "000792",
     "name": "盐湖股份",
+    "market": "sz"
+  },
+  {
+    "code": "000793",
+    "name": "华闻集团",
+    "market": "sz"
+  },
+  {
+    "code": "000795",
+    "name": "英洛华",
+    "market": "sz"
+  },
+  {
+    "code": "000796",
+    "name": "凯撒旅业",
+    "market": "sz"
+  },
+  {
+    "code": "000797",
+    "name": "中国武夷",
+    "market": "sz"
+  },
+  {
+    "code": "000798",
+    "name": "中水渔业",
+    "market": "sz"
+  },
+  {
+    "code": "000799",
+    "name": "酒鬼酒",
+    "market": "sz"
+  },
+  {
+    "code": "000800",
+    "name": "一汽解放",
+    "market": "sz"
+  },
+  {
+    "code": "000801",
+    "name": "四川九洲",
+    "market": "sz"
+  },
+  {
+    "code": "000802",
+    "name": "北京文化",
+    "market": "sz"
+  },
+  {
+    "code": "000803",
+    "name": "北清环能",
+    "market": "sz"
+  },
+  {
+    "code": "000806",
+    "name": "ST银河",
+    "market": "sz"
+  },
+  {
+    "code": "000807",
+    "name": "云铝股份",
+    "market": "sz"
+  },
+  {
+    "code": "000809",
+    "name": "铁岭新城",
+    "market": "sz"
+  },
+  {
+    "code": "000810",
+    "name": "创维数字",
+    "market": "sz"
+  },
+  {
+    "code": "000811",
+    "name": "冰轮环境",
+    "market": "sz"
+  },
+  {
+    "code": "000812",
+    "name": "陕西金叶",
+    "market": "sz"
+  },
+  {
+    "code": "000813",
+    "name": "德展健康",
+    "market": "sz"
+  },
+  {
+    "code": "000815",
+    "name": "美利云",
+    "market": "sz"
+  },
+  {
+    "code": "000816",
+    "name": "智慧农业",
+    "market": "sz"
+  },
+  {
+    "code": "000818",
+    "name": "航锦科技",
+    "market": "sz"
+  },
+  {
+    "code": "000819",
+    "name": "岳阳兴长",
+    "market": "sz"
+  },
+  {
+    "code": "000820",
+    "name": "*ST节能",
+    "market": "sz"
+  },
+  {
+    "code": "000821",
+    "name": "京山轻机",
+    "market": "sz"
+  },
+  {
+    "code": "000822",
+    "name": "山东海化",
+    "market": "sz"
+  },
+  {
+    "code": "000823",
+    "name": "超声电子",
+    "market": "sz"
+  },
+  {
+    "code": "000825",
+    "name": "太钢不锈",
+    "market": "sz"
+  },
+  {
+    "code": "000826",
+    "name": "启迪环境",
+    "market": "sz"
+  },
+  {
+    "code": "000828",
+    "name": "东莞控股",
+    "market": "sz"
+  },
+  {
+    "code": "000829",
+    "name": "天音控股",
+    "market": "sz"
+  },
+  {
+    "code": "000830",
+    "name": "鲁西化工",
+    "market": "sz"
+  },
+  {
+    "code": "000831",
+    "name": "五矿稀土",
+    "market": "sz"
+  },
+  {
+    "code": "000833",
+    "name": "粤桂股份",
+    "market": "sz"
+  },
+  {
+    "code": "000835",
+    "name": "*ST长动",
+    "market": "sz"
+  },
+  {
+    "code": "000836",
+    "name": "富通信息",
+    "market": "sz"
+  },
+  {
+    "code": "000837",
+    "name": "秦川机床",
+    "market": "sz"
+  },
+  {
+    "code": "000838",
+    "name": "财信发展",
+    "market": "sz"
+  },
+  {
+    "code": "000839",
+    "name": "中信国安",
+    "market": "sz"
+  },
+  {
+    "code": "000848",
+    "name": "承德露露",
+    "market": "sz"
+  },
+  {
+    "code": "000850",
+    "name": "华茂股份",
+    "market": "sz"
+  },
+  {
+    "code": "000851",
+    "name": "高鸿股份",
+    "market": "sz"
+  },
+  {
+    "code": "000852",
+    "name": "石化机械",
+    "market": "sz"
+  },
+  {
+    "code": "000856",
+    "name": "冀东装备",
     "market": "sz"
   },
   {
@@ -90,8 +5815,423 @@
     "market": "sz"
   },
   {
+    "code": "000859",
+    "name": "国风新材",
+    "market": "sz"
+  },
+  {
+    "code": "000860",
+    "name": "顺鑫农业",
+    "market": "sz"
+  },
+  {
+    "code": "000861",
+    "name": "海印股份",
+    "market": "sz"
+  },
+  {
+    "code": "000862",
+    "name": "银星能源",
+    "market": "sz"
+  },
+  {
+    "code": "000863",
+    "name": "三湘印象",
+    "market": "sz"
+  },
+  {
+    "code": "000868",
+    "name": "安凯客车",
+    "market": "sz"
+  },
+  {
+    "code": "000869",
+    "name": "张裕A",
+    "market": "sz"
+  },
+  {
+    "code": "000875",
+    "name": "吉电股份",
+    "market": "sz"
+  },
+  {
     "code": "000876",
     "name": "新希望",
+    "market": "sz"
+  },
+  {
+    "code": "000877",
+    "name": "天山股份",
+    "market": "sz"
+  },
+  {
+    "code": "000878",
+    "name": "云南铜业",
+    "market": "sz"
+  },
+  {
+    "code": "000880",
+    "name": "潍柴重机",
+    "market": "sz"
+  },
+  {
+    "code": "000881",
+    "name": "中广核技",
+    "market": "sz"
+  },
+  {
+    "code": "000882",
+    "name": "华联股份",
+    "market": "sz"
+  },
+  {
+    "code": "000883",
+    "name": "湖北能源",
+    "market": "sz"
+  },
+  {
+    "code": "000885",
+    "name": "城发环境",
+    "market": "sz"
+  },
+  {
+    "code": "000886",
+    "name": "海南高速",
+    "market": "sz"
+  },
+  {
+    "code": "000887",
+    "name": "中鼎股份",
+    "market": "sz"
+  },
+  {
+    "code": "000888",
+    "name": "峨眉山A",
+    "market": "sz"
+  },
+  {
+    "code": "000889",
+    "name": "ST中嘉",
+    "market": "sz"
+  },
+  {
+    "code": "000890",
+    "name": "法尔胜",
+    "market": "sz"
+  },
+  {
+    "code": "000892",
+    "name": "欢瑞世纪",
+    "market": "sz"
+  },
+  {
+    "code": "000893",
+    "name": "亚钾国际",
+    "market": "sz"
+  },
+  {
+    "code": "000895",
+    "name": "双汇发展",
+    "market": "sz"
+  },
+  {
+    "code": "000898",
+    "name": "鞍钢股份",
+    "market": "sz"
+  },
+  {
+    "code": "000899",
+    "name": "赣能股份",
+    "market": "sz"
+  },
+  {
+    "code": "000900",
+    "name": "现代投资",
+    "market": "sz"
+  },
+  {
+    "code": "000901",
+    "name": "航宇科技",
+    "market": "sz"
+  },
+  {
+    "code": "000902",
+    "name": "新洋丰",
+    "market": "sz"
+  },
+  {
+    "code": "000903",
+    "name": "云内动力",
+    "market": "sz"
+  },
+  {
+    "code": "000905",
+    "name": "厦门港务",
+    "market": "sz"
+  },
+  {
+    "code": "000906",
+    "name": "浙商中拓",
+    "market": "sz"
+  },
+  {
+    "code": "000908",
+    "name": "景峰医药",
+    "market": "sz"
+  },
+  {
+    "code": "000909",
+    "name": "数源科技",
+    "market": "sz"
+  },
+  {
+    "code": "000910",
+    "name": "大亚圣象",
+    "market": "sz"
+  },
+  {
+    "code": "000911",
+    "name": "南宁糖业",
+    "market": "sz"
+  },
+  {
+    "code": "000912",
+    "name": "泸天化",
+    "market": "sz"
+  },
+  {
+    "code": "000913",
+    "name": "钱江摩托",
+    "market": "sz"
+  },
+  {
+    "code": "000915",
+    "name": "华特达因",
+    "market": "sz"
+  },
+  {
+    "code": "000917",
+    "name": "电广传媒",
+    "market": "sz"
+  },
+  {
+    "code": "000918",
+    "name": "嘉凯城",
+    "market": "sz"
+  },
+  {
+    "code": "000919",
+    "name": "金陵药业",
+    "market": "sz"
+  },
+  {
+    "code": "000920",
+    "name": "沃顿科技",
+    "market": "sz"
+  },
+  {
+    "code": "000921",
+    "name": "海信家电",
+    "market": "sz"
+  },
+  {
+    "code": "000922",
+    "name": "佳电股份",
+    "market": "sz"
+  },
+  {
+    "code": "000923",
+    "name": "河钢资源",
+    "market": "sz"
+  },
+  {
+    "code": "000925",
+    "name": "众合科技",
+    "market": "sz"
+  },
+  {
+    "code": "000926",
+    "name": "福星股份",
+    "market": "sz"
+  },
+  {
+    "code": "000927",
+    "name": "中国铁物",
+    "market": "sz"
+  },
+  {
+    "code": "000928",
+    "name": "中钢国际",
+    "market": "sz"
+  },
+  {
+    "code": "000929",
+    "name": "兰州黄河",
+    "market": "sz"
+  },
+  {
+    "code": "000930",
+    "name": "中粮科技",
+    "market": "sz"
+  },
+  {
+    "code": "000931",
+    "name": "中关村",
+    "market": "sz"
+  },
+  {
+    "code": "000932",
+    "name": "华菱钢铁",
+    "market": "sz"
+  },
+  {
+    "code": "000933",
+    "name": "神火股份",
+    "market": "sz"
+  },
+  {
+    "code": "000935",
+    "name": "四川双马",
+    "market": "sz"
+  },
+  {
+    "code": "000936",
+    "name": "华西股份",
+    "market": "sz"
+  },
+  {
+    "code": "000937",
+    "name": "冀中能源",
+    "market": "sz"
+  },
+  {
+    "code": "000938",
+    "name": "紫光股份",
+    "market": "sz"
+  },
+  {
+    "code": "000948",
+    "name": "南天信息",
+    "market": "sz"
+  },
+  {
+    "code": "000949",
+    "name": "新乡化纤",
+    "market": "sz"
+  },
+  {
+    "code": "000950",
+    "name": "重药控股",
+    "market": "sz"
+  },
+  {
+    "code": "000951",
+    "name": "中国重汽",
+    "market": "sz"
+  },
+  {
+    "code": "000952",
+    "name": "广济药业",
+    "market": "sz"
+  },
+  {
+    "code": "000953",
+    "name": "河化股份",
+    "market": "sz"
+  },
+  {
+    "code": "000955",
+    "name": "欣龙控股",
+    "market": "sz"
+  },
+  {
+    "code": "000957",
+    "name": "中通客车",
+    "market": "sz"
+  },
+  {
+    "code": "000958",
+    "name": "电投产融",
+    "market": "sz"
+  },
+  {
+    "code": "000959",
+    "name": "首钢股份",
+    "market": "sz"
+  },
+  {
+    "code": "000960",
+    "name": "锡业股份",
+    "market": "sz"
+  },
+  {
+    "code": "000961",
+    "name": "中南建设",
+    "market": "sz"
+  },
+  {
+    "code": "000962",
+    "name": "东方钽业",
+    "market": "sz"
+  },
+  {
+    "code": "000963",
+    "name": "华东医药",
+    "market": "sz"
+  },
+  {
+    "code": "000965",
+    "name": "天保基建",
+    "market": "sz"
+  },
+  {
+    "code": "000966",
+    "name": "长源电力",
+    "market": "sz"
+  },
+  {
+    "code": "000967",
+    "name": "盈峰环境",
+    "market": "sz"
+  },
+  {
+    "code": "000968",
+    "name": "蓝焰控股",
+    "market": "sz"
+  },
+  {
+    "code": "000969",
+    "name": "安泰科技",
+    "market": "sz"
+  },
+  {
+    "code": "000970",
+    "name": "中科三环",
+    "market": "sz"
+  },
+  {
+    "code": "000971",
+    "name": "ST高升",
+    "market": "sz"
+  },
+  {
+    "code": "000972",
+    "name": "ST中基",
+    "market": "sz"
+  },
+  {
+    "code": "000973",
+    "name": "佛塑科技",
+    "market": "sz"
+  },
+  {
+    "code": "000975",
+    "name": "银泰黄金",
+    "market": "sz"
+  },
+  {
+    "code": "000976",
+    "name": "华铁股份",
     "market": "sz"
   },
   {
@@ -100,8 +6240,293 @@
     "market": "sz"
   },
   {
-    "code": "001979",
-    "name": "招商蛇口",
+    "code": "000978",
+    "name": "桂林旅游",
+    "market": "sz"
+  },
+  {
+    "code": "000980",
+    "name": "*ST众泰",
+    "market": "sz"
+  },
+  {
+    "code": "000981",
+    "name": "ST银亿",
+    "market": "sz"
+  },
+  {
+    "code": "000982",
+    "name": "中银绒业",
+    "market": "sz"
+  },
+  {
+    "code": "000983",
+    "name": "山西焦煤",
+    "market": "sz"
+  },
+  {
+    "code": "000985",
+    "name": "大庆华科",
+    "market": "sz"
+  },
+  {
+    "code": "000987",
+    "name": "越秀金控",
+    "market": "sz"
+  },
+  {
+    "code": "000988",
+    "name": "华工科技",
+    "market": "sz"
+  },
+  {
+    "code": "000989",
+    "name": "九芝堂",
+    "market": "sz"
+  },
+  {
+    "code": "000990",
+    "name": "诚志股份",
+    "market": "sz"
+  },
+  {
+    "code": "000993",
+    "name": "闽东电力",
+    "market": "sz"
+  },
+  {
+    "code": "000995",
+    "name": "*ST皇台",
+    "market": "sz"
+  },
+  {
+    "code": "000996",
+    "name": "中国中期",
+    "market": "sz"
+  },
+  {
+    "code": "000997",
+    "name": "新大陆",
+    "market": "sz"
+  },
+  {
+    "code": "000998",
+    "name": "隆平高科",
+    "market": "sz"
+  },
+  {
+    "code": "000999",
+    "name": "华润三九",
+    "market": "sz"
+  },
+  {
+    "code": "001201",
+    "name": "东瑞股份",
+    "market": "sz"
+  },
+  {
+    "code": "001202",
+    "name": "炬申股份",
+    "market": "sz"
+  },
+  {
+    "code": "001203",
+    "name": "大中矿业",
+    "market": "sz"
+  },
+  {
+    "code": "001205",
+    "name": "盛航股份",
+    "market": "sz"
+  },
+  {
+    "code": "001206",
+    "name": "依依股份",
+    "market": "sz"
+  },
+  {
+    "code": "001207",
+    "name": "联科科技",
+    "market": "sz"
+  },
+  {
+    "code": "001208",
+    "name": "华菱线缆",
+    "market": "sz"
+  },
+  {
+    "code": "001210",
+    "name": "金房节能",
+    "market": "sz"
+  },
+  {
+    "code": "001211",
+    "name": "双枪科技",
+    "market": "sz"
+  },
+  {
+    "code": "001212",
+    "name": "中旗新材",
+    "market": "sz"
+  },
+  {
+    "code": "001213",
+    "name": "中铁特货",
+    "market": "sz"
+  },
+  {
+    "code": "001215",
+    "name": "千味央厨",
+    "market": "sz"
+  },
+  {
+    "code": "001216",
+    "name": "华瓷股份",
+    "market": "sz"
+  },
+  {
+    "code": "001217",
+    "name": "华尔泰",
+    "market": "sz"
+  },
+  {
+    "code": "001218",
+    "name": "丽臣实业",
+    "market": "sz"
+  },
+  {
+    "code": "001219",
+    "name": "青岛食品",
+    "market": "sz"
+  },
+  {
+    "code": "001222",
+    "name": "源飞宠物",
+    "market": "sz"
+  },
+  {
+    "code": "002001",
+    "name": "新和成",
+    "market": "sz"
+  },
+  {
+    "code": "002002",
+    "name": "ST金材",
+    "market": "sz"
+  },
+  {
+    "code": "002003",
+    "name": "伟星股份",
+    "market": "sz"
+  },
+  {
+    "code": "002004",
+    "name": "华邦健康",
+    "market": "sz"
+  },
+  {
+    "code": "002005",
+    "name": "ST德豪",
+    "market": "sz"
+  },
+  {
+    "code": "002006",
+    "name": "精功科技",
+    "market": "sz"
+  },
+  {
+    "code": "002007",
+    "name": "华兰生物",
+    "market": "sz"
+  },
+  {
+    "code": "002008",
+    "name": "大族激光",
+    "market": "sz"
+  },
+  {
+    "code": "002009",
+    "name": "天奇股份",
+    "market": "sz"
+  },
+  {
+    "code": "002010",
+    "name": "传化智联",
+    "market": "sz"
+  },
+  {
+    "code": "002011",
+    "name": "盾安环境",
+    "market": "sz"
+  },
+  {
+    "code": "002012",
+    "name": "凯恩股份",
+    "market": "sz"
+  },
+  {
+    "code": "002013",
+    "name": "中航机电",
+    "market": "sz"
+  },
+  {
+    "code": "002014",
+    "name": "永新股份",
+    "market": "sz"
+  },
+  {
+    "code": "002015",
+    "name": "协鑫能科",
+    "market": "sz"
+  },
+  {
+    "code": "002016",
+    "name": "世荣兆业",
+    "market": "sz"
+  },
+  {
+    "code": "002017",
+    "name": "东信和平",
+    "market": "sz"
+  },
+  {
+    "code": "002019",
+    "name": "亿帆医药",
+    "market": "sz"
+  },
+  {
+    "code": "002020",
+    "name": "京新药业",
+    "market": "sz"
+  },
+  {
+    "code": "002021",
+    "name": "ST中捷",
+    "market": "sz"
+  },
+  {
+    "code": "002022",
+    "name": "科华生物",
+    "market": "sz"
+  },
+  {
+    "code": "002023",
+    "name": "海特高新",
+    "market": "sz"
+  },
+  {
+    "code": "002024",
+    "name": "苏宁易购",
+    "market": "sz"
+  },
+  {
+    "code": "002025",
+    "name": "航天电器",
+    "market": "sz"
+  },
+  {
+    "code": "002026",
+    "name": "山东威达",
     "market": "sz"
   },
   {
@@ -110,8 +6535,503 @@
     "market": "sz"
   },
   {
+    "code": "002028",
+    "name": "思源电气",
+    "market": "sz"
+  },
+  {
+    "code": "002029",
+    "name": "七匹狼",
+    "market": "sz"
+  },
+  {
+    "code": "002030",
+    "name": "达安基因",
+    "market": "sz"
+  },
+  {
+    "code": "002031",
+    "name": "巨轮智能",
+    "market": "sz"
+  },
+  {
+    "code": "002032",
+    "name": "苏泊尔",
+    "market": "sz"
+  },
+  {
+    "code": "002033",
+    "name": "丽江股份",
+    "market": "sz"
+  },
+  {
+    "code": "002034",
+    "name": "旺能环境",
+    "market": "sz"
+  },
+  {
+    "code": "002035",
+    "name": "华帝股份",
+    "market": "sz"
+  },
+  {
+    "code": "002036",
+    "name": "联创电子",
+    "market": "sz"
+  },
+  {
+    "code": "002037",
+    "name": "保利联合",
+    "market": "sz"
+  },
+  {
+    "code": "002038",
+    "name": "双鹭药业",
+    "market": "sz"
+  },
+  {
+    "code": "002039",
+    "name": "黔源电力",
+    "market": "sz"
+  },
+  {
+    "code": "002040",
+    "name": "南京港",
+    "market": "sz"
+  },
+  {
+    "code": "002041",
+    "name": "登海种业",
+    "market": "sz"
+  },
+  {
+    "code": "002042",
+    "name": "华孚时尚",
+    "market": "sz"
+  },
+  {
+    "code": "002043",
+    "name": "兔宝宝",
+    "market": "sz"
+  },
+  {
+    "code": "002044",
+    "name": "美年健康",
+    "market": "sz"
+  },
+  {
+    "code": "002045",
+    "name": "国光电器",
+    "market": "sz"
+  },
+  {
+    "code": "002046",
+    "name": "国机精工",
+    "market": "sz"
+  },
+  {
+    "code": "002047",
+    "name": "宝鹰股份",
+    "market": "sz"
+  },
+  {
+    "code": "002048",
+    "name": "宁波华翔",
+    "market": "sz"
+  },
+  {
+    "code": "002049",
+    "name": "紫光国微",
+    "market": "sz"
+  },
+  {
     "code": "002050",
     "name": "三花智控",
+    "market": "sz"
+  },
+  {
+    "code": "002051",
+    "name": "中工国际",
+    "market": "sz"
+  },
+  {
+    "code": "002052",
+    "name": "ST同洲",
+    "market": "sz"
+  },
+  {
+    "code": "002053",
+    "name": "云南能投",
+    "market": "sz"
+  },
+  {
+    "code": "002054",
+    "name": "德美化工",
+    "market": "sz"
+  },
+  {
+    "code": "002055",
+    "name": "得润电子",
+    "market": "sz"
+  },
+  {
+    "code": "002056",
+    "name": "横店东磁",
+    "market": "sz"
+  },
+  {
+    "code": "002057",
+    "name": "中钢天源",
+    "market": "sz"
+  },
+  {
+    "code": "002058",
+    "name": "威尔泰",
+    "market": "sz"
+  },
+  {
+    "code": "002059",
+    "name": "云南旅游",
+    "market": "sz"
+  },
+  {
+    "code": "002060",
+    "name": "粤水电",
+    "market": "sz"
+  },
+  {
+    "code": "002061",
+    "name": "浙江交科",
+    "market": "sz"
+  },
+  {
+    "code": "002062",
+    "name": "宏润建设",
+    "market": "sz"
+  },
+  {
+    "code": "002063",
+    "name": "远光软件",
+    "market": "sz"
+  },
+  {
+    "code": "002064",
+    "name": "华峰化学",
+    "market": "sz"
+  },
+  {
+    "code": "002065",
+    "name": "东华软件",
+    "market": "sz"
+  },
+  {
+    "code": "002066",
+    "name": "瑞泰科技",
+    "market": "sz"
+  },
+  {
+    "code": "002067",
+    "name": "景兴纸业",
+    "market": "sz"
+  },
+  {
+    "code": "002068",
+    "name": "黑猫股份",
+    "market": "sz"
+  },
+  {
+    "code": "002069",
+    "name": "ST獐子岛",
+    "market": "sz"
+  },
+  {
+    "code": "002071",
+    "name": "ST长城",
+    "market": "sz"
+  },
+  {
+    "code": "002072",
+    "name": "ST凯瑞",
+    "market": "sz"
+  },
+  {
+    "code": "002073",
+    "name": "软控股份",
+    "market": "sz"
+  },
+  {
+    "code": "002074",
+    "name": "国轩高科",
+    "market": "sz"
+  },
+  {
+    "code": "002075",
+    "name": "沙钢股份",
+    "market": "sz"
+  },
+  {
+    "code": "002076",
+    "name": "ST雪莱",
+    "market": "sz"
+  },
+  {
+    "code": "002077",
+    "name": "大港股份",
+    "market": "sz"
+  },
+  {
+    "code": "002078",
+    "name": "太阳纸业",
+    "market": "sz"
+  },
+  {
+    "code": "002079",
+    "name": "苏州固锝",
+    "market": "sz"
+  },
+  {
+    "code": "002080",
+    "name": "中材科技",
+    "market": "sz"
+  },
+  {
+    "code": "002081",
+    "name": "金螳螂",
+    "market": "sz"
+  },
+  {
+    "code": "002082",
+    "name": "万邦德",
+    "market": "sz"
+  },
+  {
+    "code": "002083",
+    "name": "孚日股份",
+    "market": "sz"
+  },
+  {
+    "code": "002084",
+    "name": "海鸥住工",
+    "market": "sz"
+  },
+  {
+    "code": "002085",
+    "name": "万丰奥威",
+    "market": "sz"
+  },
+  {
+    "code": "002086",
+    "name": "ST东洋",
+    "market": "sz"
+  },
+  {
+    "code": "002087",
+    "name": "新野纺织",
+    "market": "sz"
+  },
+  {
+    "code": "002088",
+    "name": "鲁阳节能",
+    "market": "sz"
+  },
+  {
+    "code": "002089",
+    "name": "ST新海",
+    "market": "sz"
+  },
+  {
+    "code": "002090",
+    "name": "金智科技",
+    "market": "sz"
+  },
+  {
+    "code": "002091",
+    "name": "江苏国泰",
+    "market": "sz"
+  },
+  {
+    "code": "002092",
+    "name": "中泰化学",
+    "market": "sz"
+  },
+  {
+    "code": "002093",
+    "name": "国脉科技",
+    "market": "sz"
+  },
+  {
+    "code": "002094",
+    "name": "青岛金王",
+    "market": "sz"
+  },
+  {
+    "code": "002095",
+    "name": "生意宝",
+    "market": "sz"
+  },
+  {
+    "code": "002096",
+    "name": "南岭民爆",
+    "market": "sz"
+  },
+  {
+    "code": "002097",
+    "name": "山河智能",
+    "market": "sz"
+  },
+  {
+    "code": "002098",
+    "name": "浔兴股份",
+    "market": "sz"
+  },
+  {
+    "code": "002099",
+    "name": "海翔药业",
+    "market": "sz"
+  },
+  {
+    "code": "002100",
+    "name": "天康生物",
+    "market": "sz"
+  },
+  {
+    "code": "002101",
+    "name": "广东鸿图",
+    "market": "sz"
+  },
+  {
+    "code": "002102",
+    "name": "ST冠福",
+    "market": "sz"
+  },
+  {
+    "code": "002103",
+    "name": "广博股份",
+    "market": "sz"
+  },
+  {
+    "code": "002104",
+    "name": "恒宝股份",
+    "market": "sz"
+  },
+  {
+    "code": "002105",
+    "name": "信隆健康",
+    "market": "sz"
+  },
+  {
+    "code": "002106",
+    "name": "莱宝高科",
+    "market": "sz"
+  },
+  {
+    "code": "002107",
+    "name": "沃华医药",
+    "market": "sz"
+  },
+  {
+    "code": "002108",
+    "name": "沧州明珠",
+    "market": "sz"
+  },
+  {
+    "code": "002109",
+    "name": "兴化股份",
+    "market": "sz"
+  },
+  {
+    "code": "002110",
+    "name": "三钢闽光",
+    "market": "sz"
+  },
+  {
+    "code": "002111",
+    "name": "威海广泰",
+    "market": "sz"
+  },
+  {
+    "code": "002112",
+    "name": "三变科技",
+    "market": "sz"
+  },
+  {
+    "code": "002113",
+    "name": "*ST天润",
+    "market": "sz"
+  },
+  {
+    "code": "002114",
+    "name": "罗平锌电",
+    "market": "sz"
+  },
+  {
+    "code": "002115",
+    "name": "三维通信",
+    "market": "sz"
+  },
+  {
+    "code": "002116",
+    "name": "中国海诚",
+    "market": "sz"
+  },
+  {
+    "code": "002117",
+    "name": "东港股份",
+    "market": "sz"
+  },
+  {
+    "code": "002118",
+    "name": "紫鑫药业",
+    "market": "sz"
+  },
+  {
+    "code": "002119",
+    "name": "康强电子",
+    "market": "sz"
+  },
+  {
+    "code": "002120",
+    "name": "韵达股份",
+    "market": "sz"
+  },
+  {
+    "code": "002121",
+    "name": "科陆电子",
+    "market": "sz"
+  },
+  {
+    "code": "002122",
+    "name": "ST天马",
+    "market": "sz"
+  },
+  {
+    "code": "002123",
+    "name": "梦网科技",
+    "market": "sz"
+  },
+  {
+    "code": "002124",
+    "name": "天邦股份",
+    "market": "sz"
+  },
+  {
+    "code": "002125",
+    "name": "湘潭电化",
+    "market": "sz"
+  },
+  {
+    "code": "002126",
+    "name": "银轮股份",
+    "market": "sz"
+  },
+  {
+    "code": "002127",
+    "name": "南极电商",
+    "market": "sz"
+  },
+  {
+    "code": "002128",
+    "name": "电投能源",
     "market": "sz"
   },
   {
@@ -120,8 +7040,488 @@
     "market": "sz"
   },
   {
+    "code": "002130",
+    "name": "沃尔核材",
+    "market": "sz"
+  },
+  {
+    "code": "002131",
+    "name": "利欧股份",
+    "market": "sz"
+  },
+  {
+    "code": "002132",
+    "name": "恒星科技",
+    "market": "sz"
+  },
+  {
+    "code": "002133",
+    "name": "广宇集团",
+    "market": "sz"
+  },
+  {
+    "code": "002134",
+    "name": "天津普林",
+    "market": "sz"
+  },
+  {
+    "code": "002135",
+    "name": "东南网架",
+    "market": "sz"
+  },
+  {
+    "code": "002136",
+    "name": "安纳达",
+    "market": "sz"
+  },
+  {
+    "code": "002137",
+    "name": "实益达",
+    "market": "sz"
+  },
+  {
+    "code": "002138",
+    "name": "顺络电子",
+    "market": "sz"
+  },
+  {
+    "code": "002139",
+    "name": "拓邦股份",
+    "market": "sz"
+  },
+  {
+    "code": "002140",
+    "name": "东华科技",
+    "market": "sz"
+  },
+  {
+    "code": "002141",
+    "name": "贤丰控股",
+    "market": "sz"
+  },
+  {
     "code": "002142",
     "name": "宁波银行",
+    "market": "sz"
+  },
+  {
+    "code": "002144",
+    "name": "宏达高科",
+    "market": "sz"
+  },
+  {
+    "code": "002145",
+    "name": "中核钛白",
+    "market": "sz"
+  },
+  {
+    "code": "002146",
+    "name": "荣盛发展",
+    "market": "sz"
+  },
+  {
+    "code": "002148",
+    "name": "北纬科技",
+    "market": "sz"
+  },
+  {
+    "code": "002149",
+    "name": "西部材料",
+    "market": "sz"
+  },
+  {
+    "code": "002150",
+    "name": "通润装备",
+    "market": "sz"
+  },
+  {
+    "code": "002151",
+    "name": "北斗星通",
+    "market": "sz"
+  },
+  {
+    "code": "002152",
+    "name": "广电运通",
+    "market": "sz"
+  },
+  {
+    "code": "002153",
+    "name": "石基信息",
+    "market": "sz"
+  },
+  {
+    "code": "002154",
+    "name": "报喜鸟",
+    "market": "sz"
+  },
+  {
+    "code": "002155",
+    "name": "湖南黄金",
+    "market": "sz"
+  },
+  {
+    "code": "002156",
+    "name": "通富微电",
+    "market": "sz"
+  },
+  {
+    "code": "002157",
+    "name": "ST正邦",
+    "market": "sz"
+  },
+  {
+    "code": "002158",
+    "name": "汉钟精机",
+    "market": "sz"
+  },
+  {
+    "code": "002159",
+    "name": "三特索道",
+    "market": "sz"
+  },
+  {
+    "code": "002160",
+    "name": "常铝股份",
+    "market": "sz"
+  },
+  {
+    "code": "002161",
+    "name": "远望谷",
+    "market": "sz"
+  },
+  {
+    "code": "002162",
+    "name": "悦心健康",
+    "market": "sz"
+  },
+  {
+    "code": "002163",
+    "name": "海南发展",
+    "market": "sz"
+  },
+  {
+    "code": "002164",
+    "name": "宁波东力",
+    "market": "sz"
+  },
+  {
+    "code": "002165",
+    "name": "红宝丽",
+    "market": "sz"
+  },
+  {
+    "code": "002166",
+    "name": "莱茵生物",
+    "market": "sz"
+  },
+  {
+    "code": "002167",
+    "name": "东方锆业",
+    "market": "sz"
+  },
+  {
+    "code": "002168",
+    "name": "ST惠程",
+    "market": "sz"
+  },
+  {
+    "code": "002169",
+    "name": "智光电气",
+    "market": "sz"
+  },
+  {
+    "code": "002170",
+    "name": "芭田股份",
+    "market": "sz"
+  },
+  {
+    "code": "002171",
+    "name": "楚江新材",
+    "market": "sz"
+  },
+  {
+    "code": "002172",
+    "name": "澳洋健康",
+    "market": "sz"
+  },
+  {
+    "code": "002173",
+    "name": "创新医疗",
+    "market": "sz"
+  },
+  {
+    "code": "002174",
+    "name": "游族网络",
+    "market": "sz"
+  },
+  {
+    "code": "002175",
+    "name": "ST东网",
+    "market": "sz"
+  },
+  {
+    "code": "002176",
+    "name": "江特电机",
+    "market": "sz"
+  },
+  {
+    "code": "002177",
+    "name": "御银股份",
+    "market": "sz"
+  },
+  {
+    "code": "002178",
+    "name": "延华智能",
+    "market": "sz"
+  },
+  {
+    "code": "002179",
+    "name": "中航光电",
+    "market": "sz"
+  },
+  {
+    "code": "002180",
+    "name": "纳思达",
+    "market": "sz"
+  },
+  {
+    "code": "002181",
+    "name": "粤传媒",
+    "market": "sz"
+  },
+  {
+    "code": "002182",
+    "name": "云海金属",
+    "market": "sz"
+  },
+  {
+    "code": "002183",
+    "name": "怡亚通",
+    "market": "sz"
+  },
+  {
+    "code": "002184",
+    "name": "海得控制",
+    "market": "sz"
+  },
+  {
+    "code": "002185",
+    "name": "华天科技",
+    "market": "sz"
+  },
+  {
+    "code": "002186",
+    "name": "全聚德",
+    "market": "sz"
+  },
+  {
+    "code": "002187",
+    "name": "广百股份",
+    "market": "sz"
+  },
+  {
+    "code": "002188",
+    "name": "ST巴士",
+    "market": "sz"
+  },
+  {
+    "code": "002189",
+    "name": "中光学",
+    "market": "sz"
+  },
+  {
+    "code": "002190",
+    "name": "成飞集成",
+    "market": "sz"
+  },
+  {
+    "code": "002191",
+    "name": "劲嘉股份",
+    "market": "sz"
+  },
+  {
+    "code": "002192",
+    "name": "融捷股份",
+    "market": "sz"
+  },
+  {
+    "code": "002193",
+    "name": "如意集团",
+    "market": "sz"
+  },
+  {
+    "code": "002194",
+    "name": "武汉凡谷",
+    "market": "sz"
+  },
+  {
+    "code": "002195",
+    "name": "二三四五",
+    "market": "sz"
+  },
+  {
+    "code": "002196",
+    "name": "方正电机",
+    "market": "sz"
+  },
+  {
+    "code": "002197",
+    "name": "证通电子",
+    "market": "sz"
+  },
+  {
+    "code": "002198",
+    "name": "嘉应制药",
+    "market": "sz"
+  },
+  {
+    "code": "002199",
+    "name": "东晶电子",
+    "market": "sz"
+  },
+  {
+    "code": "002200",
+    "name": "ST云投",
+    "market": "sz"
+  },
+  {
+    "code": "002201",
+    "name": "九鼎新材",
+    "market": "sz"
+  },
+  {
+    "code": "002202",
+    "name": "金风科技",
+    "market": "sz"
+  },
+  {
+    "code": "002203",
+    "name": "海亮股份",
+    "market": "sz"
+  },
+  {
+    "code": "002204",
+    "name": "大连重工",
+    "market": "sz"
+  },
+  {
+    "code": "002205",
+    "name": "国统股份",
+    "market": "sz"
+  },
+  {
+    "code": "002206",
+    "name": "海利得",
+    "market": "sz"
+  },
+  {
+    "code": "002207",
+    "name": "准油股份",
+    "market": "sz"
+  },
+  {
+    "code": "002208",
+    "name": "合肥城建",
+    "market": "sz"
+  },
+  {
+    "code": "002209",
+    "name": "达意隆",
+    "market": "sz"
+  },
+  {
+    "code": "002210",
+    "name": "ST飞马",
+    "market": "sz"
+  },
+  {
+    "code": "002211",
+    "name": "宏达新材",
+    "market": "sz"
+  },
+  {
+    "code": "002212",
+    "name": "天融信",
+    "market": "sz"
+  },
+  {
+    "code": "002213",
+    "name": "大为股份",
+    "market": "sz"
+  },
+  {
+    "code": "002214",
+    "name": "大立科技",
+    "market": "sz"
+  },
+  {
+    "code": "002215",
+    "name": "诺普信",
+    "market": "sz"
+  },
+  {
+    "code": "002216",
+    "name": "三全食品",
+    "market": "sz"
+  },
+  {
+    "code": "002217",
+    "name": "合力泰",
+    "market": "sz"
+  },
+  {
+    "code": "002218",
+    "name": "拓日新能",
+    "market": "sz"
+  },
+  {
+    "code": "002219",
+    "name": "*ST恒康",
+    "market": "sz"
+  },
+  {
+    "code": "002221",
+    "name": "东华能源",
+    "market": "sz"
+  },
+  {
+    "code": "002222",
+    "name": "福晶科技",
+    "market": "sz"
+  },
+  {
+    "code": "002223",
+    "name": "鱼跃医疗",
+    "market": "sz"
+  },
+  {
+    "code": "002224",
+    "name": "三力士",
+    "market": "sz"
+  },
+  {
+    "code": "002225",
+    "name": "濮耐股份",
+    "market": "sz"
+  },
+  {
+    "code": "002226",
+    "name": "江南化工",
+    "market": "sz"
+  },
+  {
+    "code": "002227",
+    "name": "奥特迅",
+    "market": "sz"
+  },
+  {
+    "code": "002228",
+    "name": "合兴包装",
+    "market": "sz"
+  },
+  {
+    "code": "002229",
+    "name": "鸿博股份",
     "market": "sz"
   },
   {
@@ -130,8 +7530,363 @@
     "market": "sz"
   },
   {
+    "code": "002231",
+    "name": "奥维通信",
+    "market": "sz"
+  },
+  {
+    "code": "002232",
+    "name": "启明信息",
+    "market": "sz"
+  },
+  {
+    "code": "002233",
+    "name": "塔牌集团",
+    "market": "sz"
+  },
+  {
+    "code": "002234",
+    "name": "民和股份",
+    "market": "sz"
+  },
+  {
+    "code": "002235",
+    "name": "安妮股份",
+    "market": "sz"
+  },
+  {
+    "code": "002236",
+    "name": "大华股份",
+    "market": "sz"
+  },
+  {
+    "code": "002237",
+    "name": "恒邦股份",
+    "market": "sz"
+  },
+  {
+    "code": "002238",
+    "name": "天威视讯",
+    "market": "sz"
+  },
+  {
+    "code": "002239",
+    "name": "奥特佳",
+    "market": "sz"
+  },
+  {
+    "code": "002240",
+    "name": "盛新锂能",
+    "market": "sz"
+  },
+  {
     "code": "002241",
     "name": "歌尔股份",
+    "market": "sz"
+  },
+  {
+    "code": "002242",
+    "name": "九阳股份",
+    "market": "sz"
+  },
+  {
+    "code": "002243",
+    "name": "力合科创",
+    "market": "sz"
+  },
+  {
+    "code": "002244",
+    "name": "滨江集团",
+    "market": "sz"
+  },
+  {
+    "code": "002245",
+    "name": "蔚蓝锂芯",
+    "market": "sz"
+  },
+  {
+    "code": "002246",
+    "name": "北化股份",
+    "market": "sz"
+  },
+  {
+    "code": "002247",
+    "name": "聚力文化",
+    "market": "sz"
+  },
+  {
+    "code": "002248",
+    "name": "华东数控",
+    "market": "sz"
+  },
+  {
+    "code": "002249",
+    "name": "大洋电机",
+    "market": "sz"
+  },
+  {
+    "code": "002250",
+    "name": "联化科技",
+    "market": "sz"
+  },
+  {
+    "code": "002251",
+    "name": "步步高",
+    "market": "sz"
+  },
+  {
+    "code": "002252",
+    "name": "上海莱士",
+    "market": "sz"
+  },
+  {
+    "code": "002253",
+    "name": "川大智胜",
+    "market": "sz"
+  },
+  {
+    "code": "002254",
+    "name": "泰和新材",
+    "market": "sz"
+  },
+  {
+    "code": "002255",
+    "name": "宝坻股份",
+    "market": "sz"
+  },
+  {
+    "code": "002256",
+    "name": "兆新股份",
+    "market": "sz"
+  },
+  {
+    "code": "002258",
+    "name": "利尔化学",
+    "market": "sz"
+  },
+  {
+    "code": "002259",
+    "name": "ST升达",
+    "market": "sz"
+  },
+  {
+    "code": "002260",
+    "name": "ST德奥",
+    "market": "sz"
+  },
+  {
+    "code": "002261",
+    "name": "拓维信息",
+    "market": "sz"
+  },
+  {
+    "code": "002262",
+    "name": "恩华药业",
+    "market": "sz"
+  },
+  {
+    "code": "002263",
+    "name": "大东南",
+    "market": "sz"
+  },
+  {
+    "code": "002264",
+    "name": "新华都",
+    "market": "sz"
+  },
+  {
+    "code": "002265",
+    "name": "西仪股份",
+    "market": "sz"
+  },
+  {
+    "code": "002266",
+    "name": "浙富控股",
+    "market": "sz"
+  },
+  {
+    "code": "002267",
+    "name": "陕天然气",
+    "market": "sz"
+  },
+  {
+    "code": "002268",
+    "name": "卫信康",
+    "market": "sz"
+  },
+  {
+    "code": "002269",
+    "name": "ST美邦",
+    "market": "sz"
+  },
+  {
+    "code": "002270",
+    "name": "华明装备",
+    "market": "sz"
+  },
+  {
+    "code": "002271",
+    "name": "东方雨虹",
+    "market": "sz"
+  },
+  {
+    "code": "002272",
+    "name": "川润股份",
+    "market": "sz"
+  },
+  {
+    "code": "002273",
+    "name": "水晶光电",
+    "market": "sz"
+  },
+  {
+    "code": "002274",
+    "name": "华昌化工",
+    "market": "sz"
+  },
+  {
+    "code": "002275",
+    "name": "桂林三金",
+    "market": "sz"
+  },
+  {
+    "code": "002276",
+    "name": "万马股份",
+    "market": "sz"
+  },
+  {
+    "code": "002277",
+    "name": "友阿股份",
+    "market": "sz"
+  },
+  {
+    "code": "002278",
+    "name": "神开股份",
+    "market": "sz"
+  },
+  {
+    "code": "002279",
+    "name": "久其软件",
+    "market": "sz"
+  },
+  {
+    "code": "002280",
+    "name": "联络互动",
+    "market": "sz"
+  },
+  {
+    "code": "002281",
+    "name": "光迅科技",
+    "market": "sz"
+  },
+  {
+    "code": "002282",
+    "name": "博深股份",
+    "market": "sz"
+  },
+  {
+    "code": "002283",
+    "name": "天润工业",
+    "market": "sz"
+  },
+  {
+    "code": "002284",
+    "name": "亚太股份",
+    "market": "sz"
+  },
+  {
+    "code": "002285",
+    "name": "世联行",
+    "market": "sz"
+  },
+  {
+    "code": "002286",
+    "name": "保龄宝",
+    "market": "sz"
+  },
+  {
+    "code": "002287",
+    "name": "奇正藏药",
+    "market": "sz"
+  },
+  {
+    "code": "002288",
+    "name": "超华科技",
+    "market": "sz"
+  },
+  {
+    "code": "002289",
+    "name": "ST宇顺",
+    "market": "sz"
+  },
+  {
+    "code": "002290",
+    "name": "中科三环",
+    "market": "sz"
+  },
+  {
+    "code": "002291",
+    "name": "星期六",
+    "market": "sz"
+  },
+  {
+    "code": "002292",
+    "name": "奥飞娱乐",
+    "market": "sz"
+  },
+  {
+    "code": "002293",
+    "name": "罗莱生活",
+    "market": "sz"
+  },
+  {
+    "code": "002294",
+    "name": "信立泰",
+    "market": "sz"
+  },
+  {
+    "code": "002295",
+    "name": "精艺股份",
+    "market": "sz"
+  },
+  {
+    "code": "002296",
+    "name": "辉煌科技",
+    "market": "sz"
+  },
+  {
+    "code": "002297",
+    "name": "博云新材",
+    "market": "sz"
+  },
+  {
+    "code": "002298",
+    "name": "中电兴发",
+    "market": "sz"
+  },
+  {
+    "code": "002299",
+    "name": "圣农发展",
+    "market": "sz"
+  },
+  {
+    "code": "002300",
+    "name": "太阳电缆",
+    "market": "sz"
+  },
+  {
+    "code": "002301",
+    "name": "齐心集团",
+    "market": "sz"
+  },
+  {
+    "code": "002302",
+    "name": "西部建设",
+    "market": "sz"
+  },
+  {
+    "code": "002303",
+    "name": "美盈森",
     "market": "sz"
   },
   {
@@ -140,8 +7895,553 @@
     "market": "sz"
   },
   {
+    "code": "002305",
+    "name": "南国置业",
+    "market": "sz"
+  },
+  {
+    "code": "002306",
+    "name": "中科云网",
+    "market": "sz"
+  },
+  {
+    "code": "002307",
+    "name": "北新路桥",
+    "market": "sz"
+  },
+  {
+    "code": "002308",
+    "name": "威创股份",
+    "market": "sz"
+  },
+  {
+    "code": "002309",
+    "name": "ST中利",
+    "market": "sz"
+  },
+  {
+    "code": "002310",
+    "name": "东方园林",
+    "market": "sz"
+  },
+  {
+    "code": "002311",
+    "name": "海大集团",
+    "market": "sz"
+  },
+  {
+    "code": "002312",
+    "name": "川发龙蟒",
+    "market": "sz"
+  },
+  {
+    "code": "002313",
+    "name": "*ST日海",
+    "market": "sz"
+  },
+  {
+    "code": "002314",
+    "name": "南山控股",
+    "market": "sz"
+  },
+  {
+    "code": "002315",
+    "name": "焦点科技",
+    "market": "sz"
+  },
+  {
+    "code": "002316",
+    "name": "亚联发展",
+    "market": "sz"
+  },
+  {
+    "code": "002317",
+    "name": "众生药业",
+    "market": "sz"
+  },
+  {
+    "code": "002318",
+    "name": "久立特材",
+    "market": "sz"
+  },
+  {
+    "code": "002319",
+    "name": "乐通股份",
+    "market": "sz"
+  },
+  {
+    "code": "002320",
+    "name": "海峡股份",
+    "market": "sz"
+  },
+  {
+    "code": "002321",
+    "name": "华英农业",
+    "market": "sz"
+  },
+  {
+    "code": "002322",
+    "name": "理工能科",
+    "market": "sz"
+  },
+  {
+    "code": "002323",
+    "name": "ST雅博",
+    "market": "sz"
+  },
+  {
+    "code": "002324",
+    "name": "普利特",
+    "market": "sz"
+  },
+  {
+    "code": "002325",
+    "name": "洪涛股份",
+    "market": "sz"
+  },
+  {
+    "code": "002326",
+    "name": "永太科技",
+    "market": "sz"
+  },
+  {
+    "code": "002327",
+    "name": "富安娜",
+    "market": "sz"
+  },
+  {
+    "code": "002328",
+    "name": "新朋股份",
+    "market": "sz"
+  },
+  {
+    "code": "002329",
+    "name": "皇氏集团",
+    "market": "sz"
+  },
+  {
+    "code": "002330",
+    "name": "得利斯",
+    "market": "sz"
+  },
+  {
+    "code": "002331",
+    "name": "皖通科技",
+    "market": "sz"
+  },
+  {
+    "code": "002332",
+    "name": "仙琚制药",
+    "market": "sz"
+  },
+  {
+    "code": "002333",
+    "name": "罗普斯金",
+    "market": "sz"
+  },
+  {
+    "code": "002334",
+    "name": "英威腾",
+    "market": "sz"
+  },
+  {
+    "code": "002335",
+    "name": "科华数据",
+    "market": "sz"
+  },
+  {
+    "code": "002336",
+    "name": "人人乐",
+    "market": "sz"
+  },
+  {
+    "code": "002337",
+    "name": "赛象科技",
+    "market": "sz"
+  },
+  {
+    "code": "002338",
+    "name": "奥普光电",
+    "market": "sz"
+  },
+  {
+    "code": "002339",
+    "name": "积成电子",
+    "market": "sz"
+  },
+  {
+    "code": "002340",
+    "name": "格林美",
+    "market": "sz"
+  },
+  {
+    "code": "002341",
+    "name": "ST新纶",
+    "market": "sz"
+  },
+  {
+    "code": "002342",
+    "name": "巨力索具",
+    "market": "sz"
+  },
+  {
+    "code": "002343",
+    "name": "慈文传媒",
+    "market": "sz"
+  },
+  {
+    "code": "002344",
+    "name": "海宁皮城",
+    "market": "sz"
+  },
+  {
+    "code": "002345",
+    "name": "潮宏基",
+    "market": "sz"
+  },
+  {
+    "code": "002346",
+    "name": "柘中股份",
+    "market": "sz"
+  },
+  {
+    "code": "002347",
+    "name": "泰尔股份",
+    "market": "sz"
+  },
+  {
+    "code": "002348",
+    "name": "高乐股份",
+    "market": "sz"
+  },
+  {
+    "code": "002349",
+    "name": "精华制药",
+    "market": "sz"
+  },
+  {
+    "code": "002350",
+    "name": "北京科锐",
+    "market": "sz"
+  },
+  {
+    "code": "002351",
+    "name": "漫步者",
+    "market": "sz"
+  },
+  {
+    "code": "002352",
+    "name": "顺丰控股",
+    "market": "sz"
+  },
+  {
+    "code": "002353",
+    "name": "杰瑞股份",
+    "market": "sz"
+  },
+  {
+    "code": "002354",
+    "name": "天神娱乐",
+    "market": "sz"
+  },
+  {
+    "code": "002355",
+    "name": "兴民智通",
+    "market": "sz"
+  },
+  {
+    "code": "002356",
+    "name": "ST赫美",
+    "market": "sz"
+  },
+  {
+    "code": "002357",
+    "name": "富临运业",
+    "market": "sz"
+  },
+  {
+    "code": "002358",
+    "name": "ST森源",
+    "market": "sz"
+  },
+  {
+    "code": "002359",
+    "name": "ST北讯",
+    "market": "sz"
+  },
+  {
+    "code": "002360",
+    "name": "同德化工",
+    "market": "sz"
+  },
+  {
+    "code": "002361",
+    "name": "神剑股份",
+    "market": "sz"
+  },
+  {
+    "code": "002362",
+    "name": "汉王科技",
+    "market": "sz"
+  },
+  {
+    "code": "002363",
+    "name": "隆基机械",
+    "market": "sz"
+  },
+  {
+    "code": "002364",
+    "name": "中恒电气",
+    "market": "sz"
+  },
+  {
+    "code": "002365",
+    "name": "永安药业",
+    "market": "sz"
+  },
+  {
+    "code": "002366",
+    "name": "台海核电",
+    "market": "sz"
+  },
+  {
+    "code": "002367",
+    "name": "康力电梯",
+    "market": "sz"
+  },
+  {
+    "code": "002368",
+    "name": "太极股份",
+    "market": "sz"
+  },
+  {
+    "code": "002369",
+    "name": "卓翼科技",
+    "market": "sz"
+  },
+  {
+    "code": "002370",
+    "name": "亚太药业",
+    "market": "sz"
+  },
+  {
     "code": "002371",
     "name": "北方华创",
+    "market": "sz"
+  },
+  {
+    "code": "002372",
+    "name": "伟星新材",
+    "market": "sz"
+  },
+  {
+    "code": "002373",
+    "name": "千方科技",
+    "market": "sz"
+  },
+  {
+    "code": "002374",
+    "name": "丽鹏股份",
+    "market": "sz"
+  },
+  {
+    "code": "002375",
+    "name": "亚厦股份",
+    "market": "sz"
+  },
+  {
+    "code": "002376",
+    "name": "新北洋",
+    "market": "sz"
+  },
+  {
+    "code": "002377",
+    "name": "国创高新",
+    "market": "sz"
+  },
+  {
+    "code": "002378",
+    "name": "章源钨业",
+    "market": "sz"
+  },
+  {
+    "code": "002379",
+    "name": "宏创控股",
+    "market": "sz"
+  },
+  {
+    "code": "002380",
+    "name": "科远智慧",
+    "market": "sz"
+  },
+  {
+    "code": "002381",
+    "name": "双箭股份",
+    "market": "sz"
+  },
+  {
+    "code": "002382",
+    "name": "蓝帆医疗",
+    "market": "sz"
+  },
+  {
+    "code": "002383",
+    "name": "合众思壮",
+    "market": "sz"
+  },
+  {
+    "code": "002384",
+    "name": "东山精密",
+    "market": "sz"
+  },
+  {
+    "code": "002385",
+    "name": "大北农",
+    "market": "sz"
+  },
+  {
+    "code": "002386",
+    "name": "天原股份",
+    "market": "sz"
+  },
+  {
+    "code": "002387",
+    "name": "维信诺",
+    "market": "sz"
+  },
+  {
+    "code": "002388",
+    "name": "新亚制程",
+    "market": "sz"
+  },
+  {
+    "code": "002389",
+    "name": "航天彩虹",
+    "market": "sz"
+  },
+  {
+    "code": "002390",
+    "name": "信邦制药",
+    "market": "sz"
+  },
+  {
+    "code": "002391",
+    "name": "长青股份",
+    "market": "sz"
+  },
+  {
+    "code": "002392",
+    "name": "北京利尔",
+    "market": "sz"
+  },
+  {
+    "code": "002393",
+    "name": "力生制药",
+    "market": "sz"
+  },
+  {
+    "code": "002394",
+    "name": "联发股份",
+    "market": "sz"
+  },
+  {
+    "code": "002395",
+    "name": "双象股份",
+    "market": "sz"
+  },
+  {
+    "code": "002396",
+    "name": "星网锐捷",
+    "market": "sz"
+  },
+  {
+    "code": "002397",
+    "name": "梦洁股份",
+    "market": "sz"
+  },
+  {
+    "code": "002398",
+    "name": "垒知集团",
+    "market": "sz"
+  },
+  {
+    "code": "002399",
+    "name": "海普瑞",
+    "market": "sz"
+  },
+  {
+    "code": "002400",
+    "name": "省广集团",
+    "market": "sz"
+  },
+  {
+    "code": "002401",
+    "name": "中远海科",
+    "market": "sz"
+  },
+  {
+    "code": "002402",
+    "name": "和而泰",
+    "market": "sz"
+  },
+  {
+    "code": "002403",
+    "name": "爱仕达",
+    "market": "sz"
+  },
+  {
+    "code": "002404",
+    "name": "嘉欣丝绸",
+    "market": "sz"
+  },
+  {
+    "code": "002405",
+    "name": "四维图新",
+    "market": "sz"
+  },
+  {
+    "code": "002406",
+    "name": "远东传动",
+    "market": "sz"
+  },
+  {
+    "code": "002407",
+    "name": "多氟多",
+    "market": "sz"
+  },
+  {
+    "code": "002408",
+    "name": "齐翔腾达",
+    "market": "sz"
+  },
+  {
+    "code": "002409",
+    "name": "雅克科技",
+    "market": "sz"
+  },
+  {
+    "code": "002410",
+    "name": "广联达",
+    "market": "sz"
+  },
+  {
+    "code": "002411",
+    "name": "延安必康",
+    "market": "sz"
+  },
+  {
+    "code": "002412",
+    "name": "汉森制药",
+    "market": "sz"
+  },
+  {
+    "code": "002413",
+    "name": "雷科防务",
+    "market": "sz"
+  },
+  {
+    "code": "002414",
+    "name": "高德红外",
     "market": "sz"
   },
   {
@@ -150,8 +8450,888 @@
     "market": "sz"
   },
   {
+    "code": "002416",
+    "name": "爱施德",
+    "market": "sz"
+  },
+  {
+    "code": "002417",
+    "name": "深南股份",
+    "market": "sz"
+  },
+  {
+    "code": "002418",
+    "name": "康盛股份",
+    "market": "sz"
+  },
+  {
+    "code": "002419",
+    "name": "天虹股份",
+    "market": "sz"
+  },
+  {
+    "code": "002420",
+    "name": "毅昌科技",
+    "market": "sz"
+  },
+  {
+    "code": "002421",
+    "name": "达实智能",
+    "market": "sz"
+  },
+  {
+    "code": "002422",
+    "name": "科伦药业",
+    "market": "sz"
+  },
+  {
+    "code": "002423",
+    "name": "中粮资本",
+    "market": "sz"
+  },
+  {
+    "code": "002424",
+    "name": "贵州百灵",
+    "market": "sz"
+  },
+  {
+    "code": "002425",
+    "name": "凯撒文化",
+    "market": "sz"
+  },
+  {
+    "code": "002426",
+    "name": "胜利精密",
+    "market": "sz"
+  },
+  {
+    "code": "002427",
+    "name": "ST尤夫",
+    "market": "sz"
+  },
+  {
+    "code": "002428",
+    "name": "云南锗业",
+    "market": "sz"
+  },
+  {
+    "code": "002429",
+    "name": "兆驰股份",
+    "market": "sz"
+  },
+  {
+    "code": "002430",
+    "name": "杭氧股份",
+    "market": "sz"
+  },
+  {
+    "code": "002431",
+    "name": "棕榈股份",
+    "market": "sz"
+  },
+  {
+    "code": "002432",
+    "name": "九安医疗",
+    "market": "sz"
+  },
+  {
+    "code": "002433",
+    "name": "ST太安",
+    "market": "sz"
+  },
+  {
+    "code": "002434",
+    "name": "万里扬",
+    "market": "sz"
+  },
+  {
+    "code": "002435",
+    "name": "长江健康",
+    "market": "sz"
+  },
+  {
+    "code": "002436",
+    "name": "兴森科技",
+    "market": "sz"
+  },
+  {
+    "code": "002437",
+    "name": "誉衡药业",
+    "market": "sz"
+  },
+  {
+    "code": "002438",
+    "name": "江苏神通",
+    "market": "sz"
+  },
+  {
+    "code": "002439",
+    "name": "启明星辰",
+    "market": "sz"
+  },
+  {
+    "code": "002440",
+    "name": "闰土股份",
+    "market": "sz"
+  },
+  {
+    "code": "002441",
+    "name": "众业达",
+    "market": "sz"
+  },
+  {
+    "code": "002442",
+    "name": "龙星化工",
+    "market": "sz"
+  },
+  {
+    "code": "002443",
+    "name": "金洲管道",
+    "market": "sz"
+  },
+  {
+    "code": "002444",
+    "name": "巨星科技",
+    "market": "sz"
+  },
+  {
+    "code": "002445",
+    "name": "ST中南",
+    "market": "sz"
+  },
+  {
+    "code": "002446",
+    "name": "盛路通信",
+    "market": "sz"
+  },
+  {
+    "code": "002447",
+    "name": "晨鑫科技",
+    "market": "sz"
+  },
+  {
+    "code": "002448",
+    "name": "中原内配",
+    "market": "sz"
+  },
+  {
+    "code": "002449",
+    "name": "国星光电",
+    "market": "sz"
+  },
+  {
+    "code": "002450",
+    "name": "ST康得",
+    "market": "sz"
+  },
+  {
+    "code": "002451",
+    "name": "摩恩电气",
+    "market": "sz"
+  },
+  {
+    "code": "002452",
+    "name": "长高集团",
+    "market": "sz"
+  },
+  {
+    "code": "002453",
+    "name": "华软科技",
+    "market": "sz"
+  },
+  {
+    "code": "002454",
+    "name": "松芝股份",
+    "market": "sz"
+  },
+  {
+    "code": "002455",
+    "name": "百川股份",
+    "market": "sz"
+  },
+  {
+    "code": "002456",
+    "name": "欧菲光",
+    "market": "sz"
+  },
+  {
+    "code": "002457",
+    "name": "青龙管业",
+    "market": "sz"
+  },
+  {
+    "code": "002458",
+    "name": "益生股份",
+    "market": "sz"
+  },
+  {
+    "code": "002459",
+    "name": "晶澳科技",
+    "market": "sz"
+  },
+  {
+    "code": "002460",
+    "name": "赣锋锂业",
+    "market": "sz"
+  },
+  {
+    "code": "002461",
+    "name": "珠江啤酒",
+    "market": "sz"
+  },
+  {
+    "code": "002462",
+    "name": "嘉事堂",
+    "market": "sz"
+  },
+  {
+    "code": "002463",
+    "name": "沪电股份",
+    "market": "sz"
+  },
+  {
+    "code": "002464",
+    "name": "ST众应",
+    "market": "sz"
+  },
+  {
+    "code": "002465",
+    "name": "海格通信",
+    "market": "sz"
+  },
+  {
+    "code": "002466",
+    "name": "天齐锂业",
+    "market": "sz"
+  },
+  {
+    "code": "002467",
+    "name": "二六三",
+    "market": "sz"
+  },
+  {
+    "code": "002468",
+    "name": "申通快递",
+    "market": "sz"
+  },
+  {
+    "code": "002469",
+    "name": "三维工程",
+    "market": "sz"
+  },
+  {
+    "code": "002470",
+    "name": "ST金正",
+    "market": "sz"
+  },
+  {
+    "code": "002471",
+    "name": "中超控股",
+    "market": "sz"
+  },
+  {
+    "code": "002472",
+    "name": "双环传动",
+    "market": "sz"
+  },
+  {
+    "code": "002473",
+    "name": "ST圣莱",
+    "market": "sz"
+  },
+  {
+    "code": "002474",
+    "name": "榕基软件",
+    "market": "sz"
+  },
+  {
     "code": "002475",
     "name": "立讯精密",
+    "market": "sz"
+  },
+  {
+    "code": "002476",
+    "name": "宝莫股份",
+    "market": "sz"
+  },
+  {
+    "code": "002477",
+    "name": "雏鹰退",
+    "market": "sz"
+  },
+  {
+    "code": "002478",
+    "name": "常宝股份",
+    "market": "sz"
+  },
+  {
+    "code": "002479",
+    "name": "富春环保",
+    "market": "sz"
+  },
+  {
+    "code": "002480",
+    "name": "新筑股份",
+    "market": "sz"
+  },
+  {
+    "code": "002481",
+    "name": "双塔食品",
+    "market": "sz"
+  },
+  {
+    "code": "002482",
+    "name": "广田集团",
+    "market": "sz"
+  },
+  {
+    "code": "002483",
+    "name": "润邦股份",
+    "market": "sz"
+  },
+  {
+    "code": "002484",
+    "name": "江海股份",
+    "market": "sz"
+  },
+  {
+    "code": "002485",
+    "name": "雪松发展",
+    "market": "sz"
+  },
+  {
+    "code": "002486",
+    "name": "嘉麟杰",
+    "market": "sz"
+  },
+  {
+    "code": "002487",
+    "name": "大金重工",
+    "market": "sz"
+  },
+  {
+    "code": "002488",
+    "name": "金固股份",
+    "market": "sz"
+  },
+  {
+    "code": "002489",
+    "name": "浙江永强",
+    "market": "sz"
+  },
+  {
+    "code": "002490",
+    "name": "山东墨龙",
+    "market": "sz"
+  },
+  {
+    "code": "002491",
+    "name": "通鼎互联",
+    "market": "sz"
+  },
+  {
+    "code": "002492",
+    "name": "恒基达鑫",
+    "market": "sz"
+  },
+  {
+    "code": "002493",
+    "name": "荣盛石化",
+    "market": "sz"
+  },
+  {
+    "code": "002494",
+    "name": "华斯股份",
+    "market": "sz"
+  },
+  {
+    "code": "002495",
+    "name": "佳隆股份",
+    "market": "sz"
+  },
+  {
+    "code": "002496",
+    "name": "ST辉丰",
+    "market": "sz"
+  },
+  {
+    "code": "002497",
+    "name": "雅化集团",
+    "market": "sz"
+  },
+  {
+    "code": "002498",
+    "name": "汉缆股份",
+    "market": "sz"
+  },
+  {
+    "code": "002499",
+    "name": "科林环保",
+    "market": "sz"
+  },
+  {
+    "code": "002500",
+    "name": "山西证券",
+    "market": "sz"
+  },
+  {
+    "code": "002501",
+    "name": "利源精制",
+    "market": "sz"
+  },
+  {
+    "code": "002502",
+    "name": "ST鼎龙",
+    "market": "sz"
+  },
+  {
+    "code": "002503",
+    "name": "搜于特",
+    "market": "sz"
+  },
+  {
+    "code": "002504",
+    "name": "ST弘高",
+    "market": "sz"
+  },
+  {
+    "code": "002505",
+    "name": "鹏都农牧",
+    "market": "sz"
+  },
+  {
+    "code": "002506",
+    "name": "协鑫集成",
+    "market": "sz"
+  },
+  {
+    "code": "002507",
+    "name": "涪陵榨菜",
+    "market": "sz"
+  },
+  {
+    "code": "002508",
+    "name": "老板电器",
+    "market": "sz"
+  },
+  {
+    "code": "002509",
+    "name": "ST天茂",
+    "market": "sz"
+  },
+  {
+    "code": "002510",
+    "name": "天汽模",
+    "market": "sz"
+  },
+  {
+    "code": "002511",
+    "name": "中顺洁柔",
+    "market": "sz"
+  },
+  {
+    "code": "002512",
+    "name": "达华智能",
+    "market": "sz"
+  },
+  {
+    "code": "002513",
+    "name": "蓝丰生化",
+    "market": "sz"
+  },
+  {
+    "code": "002514",
+    "name": "宝馨科技",
+    "market": "sz"
+  },
+  {
+    "code": "002515",
+    "name": "金字火腿",
+    "market": "sz"
+  },
+  {
+    "code": "002516",
+    "name": "旷达科技",
+    "market": "sz"
+  },
+  {
+    "code": "002517",
+    "name": "恺英网络",
+    "market": "sz"
+  },
+  {
+    "code": "002518",
+    "name": "科士达",
+    "market": "sz"
+  },
+  {
+    "code": "002519",
+    "name": "银河电子",
+    "market": "sz"
+  },
+  {
+    "code": "002520",
+    "name": "日发精机",
+    "market": "sz"
+  },
+  {
+    "code": "002521",
+    "name": "齐峰新材",
+    "market": "sz"
+  },
+  {
+    "code": "002522",
+    "name": "浙江众成",
+    "market": "sz"
+  },
+  {
+    "code": "002523",
+    "name": "天桥起重",
+    "market": "sz"
+  },
+  {
+    "code": "002524",
+    "name": "光正眼科",
+    "market": "sz"
+  },
+  {
+    "code": "002526",
+    "name": "山东矿机",
+    "market": "sz"
+  },
+  {
+    "code": "002527",
+    "name": "新时达",
+    "market": "sz"
+  },
+  {
+    "code": "002528",
+    "name": "英飞拓",
+    "market": "sz"
+  },
+  {
+    "code": "002529",
+    "name": "海源复材",
+    "market": "sz"
+  },
+  {
+    "code": "002530",
+    "name": "金财互联",
+    "market": "sz"
+  },
+  {
+    "code": "002531",
+    "name": "天顺风能",
+    "market": "sz"
+  },
+  {
+    "code": "002532",
+    "name": "天山铝业",
+    "market": "sz"
+  },
+  {
+    "code": "002533",
+    "name": "金杯电工",
+    "market": "sz"
+  },
+  {
+    "code": "002534",
+    "name": "西子洁能",
+    "market": "sz"
+  },
+  {
+    "code": "002535",
+    "name": "ST林重",
+    "market": "sz"
+  },
+  {
+    "code": "002536",
+    "name": "飞龙股份",
+    "market": "sz"
+  },
+  {
+    "code": "002537",
+    "name": "海联金汇",
+    "market": "sz"
+  },
+  {
+    "code": "002538",
+    "name": "司尔特",
+    "market": "sz"
+  },
+  {
+    "code": "002539",
+    "name": "云图控股",
+    "market": "sz"
+  },
+  {
+    "code": "002540",
+    "name": "亚太科技",
+    "market": "sz"
+  },
+  {
+    "code": "002541",
+    "name": "鸿路钢构",
+    "market": "sz"
+  },
+  {
+    "code": "002542",
+    "name": "中化岩土",
+    "market": "sz"
+  },
+  {
+    "code": "002543",
+    "name": "万和电气",
+    "market": "sz"
+  },
+  {
+    "code": "002544",
+    "name": "普天科技",
+    "market": "sz"
+  },
+  {
+    "code": "002545",
+    "name": "东方铁塔",
+    "market": "sz"
+  },
+  {
+    "code": "002546",
+    "name": "新联电子",
+    "market": "sz"
+  },
+  {
+    "code": "002547",
+    "name": "春兴精工",
+    "market": "sz"
+  },
+  {
+    "code": "002548",
+    "name": "金新农",
+    "market": "sz"
+  },
+  {
+    "code": "002549",
+    "name": "凯美特气",
+    "market": "sz"
+  },
+  {
+    "code": "002550",
+    "name": "千红制药",
+    "market": "sz"
+  },
+  {
+    "code": "002551",
+    "name": "尚荣医疗",
+    "market": "sz"
+  },
+  {
+    "code": "002552",
+    "name": "宝鼎科技",
+    "market": "sz"
+  },
+  {
+    "code": "002553",
+    "name": "南方轴承",
+    "market": "sz"
+  },
+  {
+    "code": "002554",
+    "name": "惠博普",
+    "market": "sz"
+  },
+  {
+    "code": "002555",
+    "name": "三七互娱",
+    "market": "sz"
+  },
+  {
+    "code": "002556",
+    "name": "辉隆股份",
+    "market": "sz"
+  },
+  {
+    "code": "002557",
+    "name": "洽洽食品",
+    "market": "sz"
+  },
+  {
+    "code": "002558",
+    "name": "巨人网络",
+    "market": "sz"
+  },
+  {
+    "code": "002559",
+    "name": "亚威股份",
+    "market": "sz"
+  },
+  {
+    "code": "002560",
+    "name": "通达股份",
+    "market": "sz"
+  },
+  {
+    "code": "002561",
+    "name": "徐家汇",
+    "market": "sz"
+  },
+  {
+    "code": "002562",
+    "name": "兄弟科技",
+    "market": "sz"
+  },
+  {
+    "code": "002563",
+    "name": "森马服饰",
+    "market": "sz"
+  },
+  {
+    "code": "002564",
+    "name": "天沃科技",
+    "market": "sz"
+  },
+  {
+    "code": "002565",
+    "name": "顺灏股份",
+    "market": "sz"
+  },
+  {
+    "code": "002566",
+    "name": "益盛药业",
+    "market": "sz"
+  },
+  {
+    "code": "002567",
+    "name": "唐人神",
+    "market": "sz"
+  },
+  {
+    "code": "002568",
+    "name": "百润股份",
+    "market": "sz"
+  },
+  {
+    "code": "002569",
+    "name": "ST步森",
+    "market": "sz"
+  },
+  {
+    "code": "002570",
+    "name": "贝因美",
+    "market": "sz"
+  },
+  {
+    "code": "002571",
+    "name": "德力股份",
+    "market": "sz"
+  },
+  {
+    "code": "002572",
+    "name": "索菲亚",
+    "market": "sz"
+  },
+  {
+    "code": "002573",
+    "name": "清新环境",
+    "market": "sz"
+  },
+  {
+    "code": "002574",
+    "name": "明牌珠宝",
+    "market": "sz"
+  },
+  {
+    "code": "002575",
+    "name": "群兴玩具",
+    "market": "sz"
+  },
+  {
+    "code": "002576",
+    "name": "通达动力",
+    "market": "sz"
+  },
+  {
+    "code": "002577",
+    "name": "雷柏科技",
+    "market": "sz"
+  },
+  {
+    "code": "002578",
+    "name": "闽发铝业",
+    "market": "sz"
+  },
+  {
+    "code": "002579",
+    "name": "中京电子",
+    "market": "sz"
+  },
+  {
+    "code": "002580",
+    "name": "圣阳股份",
+    "market": "sz"
+  },
+  {
+    "code": "002581",
+    "name": "未名医药",
+    "market": "sz"
+  },
+  {
+    "code": "002582",
+    "name": "好想你",
+    "market": "sz"
+  },
+  {
+    "code": "002583",
+    "name": "海能达",
+    "market": "sz"
+  },
+  {
+    "code": "002584",
+    "name": "西陇科学",
+    "market": "sz"
+  },
+  {
+    "code": "002585",
+    "name": "双星新材",
+    "market": "sz"
+  },
+  {
+    "code": "002586",
+    "name": "*ST围海",
+    "market": "sz"
+  },
+  {
+    "code": "002587",
+    "name": "奥拓电子",
+    "market": "sz"
+  },
+  {
+    "code": "002588",
+    "name": "史丹利",
+    "market": "sz"
+  },
+  {
+    "code": "002589",
+    "name": "瑞康医药",
+    "market": "sz"
+  },
+  {
+    "code": "002590",
+    "name": "万安科技",
+    "market": "sz"
+  },
+  {
+    "code": "002591",
+    "name": "恒大高新",
+    "market": "sz"
+  },
+  {
+    "code": "002592",
+    "name": "ST八菱",
+    "market": "sz"
+  },
+  {
+    "code": "002593",
+    "name": "日上集团",
     "market": "sz"
   },
   {
@@ -160,8 +9340,1518 @@
     "market": "sz"
   },
   {
+    "code": "002595",
+    "name": "豪迈科技",
+    "market": "sz"
+  },
+  {
+    "code": "002596",
+    "name": "海南瑞泽",
+    "market": "sz"
+  },
+  {
+    "code": "002597",
+    "name": "金禾实业",
+    "market": "sz"
+  },
+  {
+    "code": "002598",
+    "name": "山东章鼓",
+    "market": "sz"
+  },
+  {
+    "code": "002599",
+    "name": "盛通股份",
+    "market": "sz"
+  },
+  {
+    "code": "002600",
+    "name": "领益智造",
+    "market": "sz"
+  },
+  {
+    "code": "002601",
+    "name": "龙佰集团",
+    "market": "sz"
+  },
+  {
+    "code": "002602",
+    "name": "世纪华通",
+    "market": "sz"
+  },
+  {
+    "code": "002603",
+    "name": "以岭药业",
+    "market": "sz"
+  },
+  {
+    "code": "002604",
+    "name": "ST龙力",
+    "market": "sz"
+  },
+  {
+    "code": "002605",
+    "name": "姚记科技",
+    "market": "sz"
+  },
+  {
+    "code": "002606",
+    "name": "大连电瓷",
+    "market": "sz"
+  },
+  {
+    "code": "002607",
+    "name": "中公教育",
+    "market": "sz"
+  },
+  {
+    "code": "002608",
+    "name": "江苏国信",
+    "market": "sz"
+  },
+  {
+    "code": "002609",
+    "name": "捷顺科技",
+    "market": "sz"
+  },
+  {
+    "code": "002610",
+    "name": "爱康科技",
+    "market": "sz"
+  },
+  {
+    "code": "002611",
+    "name": "东方精工",
+    "market": "sz"
+  },
+  {
+    "code": "002612",
+    "name": "朗姿股份",
+    "market": "sz"
+  },
+  {
+    "code": "002613",
+    "name": "北玻股份",
+    "market": "sz"
+  },
+  {
+    "code": "002614",
+    "name": "奥佳华",
+    "market": "sz"
+  },
+  {
+    "code": "002615",
+    "name": "哈尔斯",
+    "market": "sz"
+  },
+  {
+    "code": "002616",
+    "name": "长青集团",
+    "market": "sz"
+  },
+  {
+    "code": "002617",
+    "name": "露笑科技",
+    "market": "sz"
+  },
+  {
+    "code": "002618",
+    "name": "丹邦科技",
+    "market": "sz"
+  },
+  {
+    "code": "002619",
+    "name": "艾格拉斯",
+    "market": "sz"
+  },
+  {
+    "code": "002620",
+    "name": "瑞和股份",
+    "market": "sz"
+  },
+  {
+    "code": "002621",
+    "name": "美吉姆",
+    "market": "sz"
+  },
+  {
+    "code": "002622",
+    "name": "ST德森",
+    "market": "sz"
+  },
+  {
+    "code": "002623",
+    "name": "亚玛顿",
+    "market": "sz"
+  },
+  {
+    "code": "002624",
+    "name": "完美世界",
+    "market": "sz"
+  },
+  {
+    "code": "002625",
+    "name": "光启技术",
+    "market": "sz"
+  },
+  {
+    "code": "002626",
+    "name": "金达威",
+    "market": "sz"
+  },
+  {
+    "code": "002627",
+    "name": "三峡旅游",
+    "market": "sz"
+  },
+  {
+    "code": "002628",
+    "name": "成都路桥",
+    "market": "sz"
+  },
+  {
+    "code": "002629",
+    "name": "ST仁智",
+    "market": "sz"
+  },
+  {
+    "code": "002630",
+    "name": "华西能源",
+    "market": "sz"
+  },
+  {
+    "code": "002631",
+    "name": "德尔未来",
+    "market": "sz"
+  },
+  {
+    "code": "002632",
+    "name": "道明光学",
+    "market": "sz"
+  },
+  {
+    "code": "002633",
+    "name": "申科股份",
+    "market": "sz"
+  },
+  {
+    "code": "002634",
+    "name": "棒杰股份",
+    "market": "sz"
+  },
+  {
+    "code": "002635",
+    "name": "安洁科技",
+    "market": "sz"
+  },
+  {
+    "code": "002636",
+    "name": "金安国纪",
+    "market": "sz"
+  },
+  {
+    "code": "002637",
+    "name": "赞宇科技",
+    "market": "sz"
+  },
+  {
+    "code": "002638",
+    "name": "勤上股份",
+    "market": "sz"
+  },
+  {
+    "code": "002639",
+    "name": "雪人股份",
+    "market": "sz"
+  },
+  {
+    "code": "002640",
+    "name": "跨境通",
+    "market": "sz"
+  },
+  {
+    "code": "002641",
+    "name": "永高股份",
+    "market": "sz"
+  },
+  {
+    "code": "002642",
+    "name": "荣联科技",
+    "market": "sz"
+  },
+  {
+    "code": "002643",
+    "name": "万润股份",
+    "market": "sz"
+  },
+  {
+    "code": "002644",
+    "name": "佛慈制药",
+    "market": "sz"
+  },
+  {
+    "code": "002645",
+    "name": "华宏科技",
+    "market": "sz"
+  },
+  {
+    "code": "002646",
+    "name": "青青稞酒",
+    "market": "sz"
+  },
+  {
+    "code": "002647",
+    "name": "仁东控股",
+    "market": "sz"
+  },
+  {
+    "code": "002648",
+    "name": "卫星化学",
+    "market": "sz"
+  },
+  {
+    "code": "002649",
+    "name": "博彦科技",
+    "market": "sz"
+  },
+  {
+    "code": "002650",
+    "name": "加加食品",
+    "market": "sz"
+  },
+  {
+    "code": "002651",
+    "name": "利君股份",
+    "market": "sz"
+  },
+  {
+    "code": "002652",
+    "name": "扬子新材",
+    "market": "sz"
+  },
+  {
+    "code": "002653",
+    "name": "海思科",
+    "market": "sz"
+  },
+  {
+    "code": "002654",
+    "name": "万润科技",
+    "market": "sz"
+  },
+  {
+    "code": "002655",
+    "name": "共达电声",
+    "market": "sz"
+  },
+  {
+    "code": "002656",
+    "name": "ST摩登",
+    "market": "sz"
+  },
+  {
+    "code": "002657",
+    "name": "中科金财",
+    "market": "sz"
+  },
+  {
+    "code": "002658",
+    "name": "雪迪龙",
+    "market": "sz"
+  },
+  {
+    "code": "002659",
+    "name": "凯文教育",
+    "market": "sz"
+  },
+  {
+    "code": "002660",
+    "name": "茂硕电源",
+    "market": "sz"
+  },
+  {
+    "code": "002661",
+    "name": "克明食品",
+    "market": "sz"
+  },
+  {
+    "code": "002662",
+    "name": "京威股份",
+    "market": "sz"
+  },
+  {
+    "code": "002663",
+    "name": "普邦股份",
+    "market": "sz"
+  },
+  {
+    "code": "002664",
+    "name": "长鹰信质",
+    "market": "sz"
+  },
+  {
+    "code": "002665",
+    "name": "首航高科",
+    "market": "sz"
+  },
+  {
+    "code": "002666",
+    "name": "德联集团",
+    "market": "sz"
+  },
+  {
+    "code": "002667",
+    "name": "鞍重股份",
+    "market": "sz"
+  },
+  {
+    "code": "002668",
+    "name": "ST奥马",
+    "market": "sz"
+  },
+  {
+    "code": "002669",
+    "name": "康达新材",
+    "market": "sz"
+  },
+  {
+    "code": "002670",
+    "name": "国盛金控",
+    "market": "sz"
+  },
+  {
+    "code": "002671",
+    "name": "龙泉股份",
+    "market": "sz"
+  },
+  {
+    "code": "002672",
+    "name": "东江环保",
+    "market": "sz"
+  },
+  {
+    "code": "002673",
+    "name": "西部证券",
+    "market": "sz"
+  },
+  {
+    "code": "002674",
+    "name": "兴业科技",
+    "market": "sz"
+  },
+  {
+    "code": "002675",
+    "name": "东诚药业",
+    "market": "sz"
+  },
+  {
+    "code": "002676",
+    "name": "顺威股份",
+    "market": "sz"
+  },
+  {
+    "code": "002677",
+    "name": "浙江美大",
+    "market": "sz"
+  },
+  {
+    "code": "002678",
+    "name": "珠江钢琴",
+    "market": "sz"
+  },
+  {
+    "code": "002679",
+    "name": "福建金森",
+    "market": "sz"
+  },
+  {
+    "code": "002680",
+    "name": "ST长生",
+    "market": "sz"
+  },
+  {
+    "code": "002681",
+    "name": "奋达科技",
+    "market": "sz"
+  },
+  {
+    "code": "002682",
+    "name": "龙洲股份",
+    "market": "sz"
+  },
+  {
+    "code": "002683",
+    "name": "宏大爆破",
+    "market": "sz"
+  },
+  {
+    "code": "002684",
+    "name": "ST猛狮",
+    "market": "sz"
+  },
+  {
+    "code": "002685",
+    "name": "华东重机",
+    "market": "sz"
+  },
+  {
+    "code": "002686",
+    "name": "亿利达",
+    "market": "sz"
+  },
+  {
+    "code": "002687",
+    "name": "乔治白",
+    "market": "sz"
+  },
+  {
+    "code": "002688",
+    "name": "金河生物",
+    "market": "sz"
+  },
+  {
+    "code": "002689",
+    "name": "远大智能",
+    "market": "sz"
+  },
+  {
+    "code": "002690",
+    "name": "美亚光电",
+    "market": "sz"
+  },
+  {
+    "code": "002691",
+    "name": "冀凯股份",
+    "market": "sz"
+  },
+  {
+    "code": "002692",
+    "name": "ST远程",
+    "market": "sz"
+  },
+  {
+    "code": "002693",
+    "name": "双成药业",
+    "market": "sz"
+  },
+  {
+    "code": "002694",
+    "name": "顾地科技",
+    "market": "sz"
+  },
+  {
+    "code": "002695",
+    "name": "煌上煌",
+    "market": "sz"
+  },
+  {
+    "code": "002696",
+    "name": "百洋股份",
+    "market": "sz"
+  },
+  {
+    "code": "002697",
+    "name": "红旗连锁",
+    "market": "sz"
+  },
+  {
+    "code": "002698",
+    "name": "博实股份",
+    "market": "sz"
+  },
+  {
+    "code": "002699",
+    "name": "美盛文化",
+    "market": "sz"
+  },
+  {
+    "code": "002700",
+    "name": "ST浩源",
+    "market": "sz"
+  },
+  {
+    "code": "002701",
+    "name": "奥瑞金",
+    "market": "sz"
+  },
+  {
+    "code": "002702",
+    "name": "海欣食品",
+    "market": "sz"
+  },
+  {
+    "code": "002703",
+    "name": "浙江世宝",
+    "market": "sz"
+  },
+  {
+    "code": "002705",
+    "name": "新宝股份",
+    "market": "sz"
+  },
+  {
+    "code": "002706",
+    "name": "良信股份",
+    "market": "sz"
+  },
+  {
+    "code": "002707",
+    "name": "众信旅游",
+    "market": "sz"
+  },
+  {
+    "code": "002708",
+    "name": "光洋股份",
+    "market": "sz"
+  },
+  {
+    "code": "002709",
+    "name": "天赐材料",
+    "market": "sz"
+  },
+  {
+    "code": "002711",
+    "name": "ST欧浦",
+    "market": "sz"
+  },
+  {
+    "code": "002712",
+    "name": "思美传媒",
+    "market": "sz"
+  },
+  {
+    "code": "002713",
+    "name": "东易日盛",
+    "market": "sz"
+  },
+  {
     "code": "002714",
     "name": "牧原股份",
+    "market": "sz"
+  },
+  {
+    "code": "002715",
+    "name": "登云股份",
+    "market": "sz"
+  },
+  {
+    "code": "002716",
+    "name": "ST金贵",
+    "market": "sz"
+  },
+  {
+    "code": "002717",
+    "name": "岭南股份",
+    "market": "sz"
+  },
+  {
+    "code": "002718",
+    "name": "友邦吊顶",
+    "market": "sz"
+  },
+  {
+    "code": "002719",
+    "name": "麦趣尔",
+    "market": "sz"
+  },
+  {
+    "code": "002721",
+    "name": "金一文化",
+    "market": "sz"
+  },
+  {
+    "code": "002722",
+    "name": "金轮股份",
+    "market": "sz"
+  },
+  {
+    "code": "002723",
+    "name": "金莱特",
+    "market": "sz"
+  },
+  {
+    "code": "002724",
+    "name": "海洋王",
+    "market": "sz"
+  },
+  {
+    "code": "002725",
+    "name": "跃岭股份",
+    "market": "sz"
+  },
+  {
+    "code": "002726",
+    "name": "龙大美食",
+    "market": "sz"
+  },
+  {
+    "code": "002727",
+    "name": "一心堂",
+    "market": "sz"
+  },
+  {
+    "code": "002728",
+    "name": "特一药业",
+    "market": "sz"
+  },
+  {
+    "code": "002729",
+    "name": "好利科技",
+    "market": "sz"
+  },
+  {
+    "code": "002730",
+    "name": "电光科技",
+    "market": "sz"
+  },
+  {
+    "code": "002731",
+    "name": "萃华珠宝",
+    "market": "sz"
+  },
+  {
+    "code": "002732",
+    "name": "燕塘乳业",
+    "market": "sz"
+  },
+  {
+    "code": "002733",
+    "name": "雄韬股份",
+    "market": "sz"
+  },
+  {
+    "code": "002734",
+    "name": "利民股份",
+    "market": "sz"
+  },
+  {
+    "code": "002735",
+    "name": "王子新材",
+    "market": "sz"
+  },
+  {
+    "code": "002736",
+    "name": "国信证券",
+    "market": "sz"
+  },
+  {
+    "code": "002737",
+    "name": "葵花药业",
+    "market": "sz"
+  },
+  {
+    "code": "002738",
+    "name": "中矿资源",
+    "market": "sz"
+  },
+  {
+    "code": "002739",
+    "name": "万达电影",
+    "market": "sz"
+  },
+  {
+    "code": "002740",
+    "name": "ST爱迪尔",
+    "market": "sz"
+  },
+  {
+    "code": "002741",
+    "name": "光华科技",
+    "market": "sz"
+  },
+  {
+    "code": "002742",
+    "name": "三圣股份",
+    "market": "sz"
+  },
+  {
+    "code": "002743",
+    "name": "富煌钢构",
+    "market": "sz"
+  },
+  {
+    "code": "002745",
+    "name": "木林森",
+    "market": "sz"
+  },
+  {
+    "code": "002746",
+    "name": "仙坛股份",
+    "market": "sz"
+  },
+  {
+    "code": "002747",
+    "name": "埃斯顿",
+    "market": "sz"
+  },
+  {
+    "code": "002748",
+    "name": "世龙实业",
+    "market": "sz"
+  },
+  {
+    "code": "002749",
+    "name": "国光股份",
+    "market": "sz"
+  },
+  {
+    "code": "002750",
+    "name": "龙津药业",
+    "market": "sz"
+  },
+  {
+    "code": "002751",
+    "name": "易尚展示",
+    "market": "sz"
+  },
+  {
+    "code": "002752",
+    "name": "昇兴股份",
+    "market": "sz"
+  },
+  {
+    "code": "002753",
+    "name": "永东股份",
+    "market": "sz"
+  },
+  {
+    "code": "002755",
+    "name": "奥赛康",
+    "market": "sz"
+  },
+  {
+    "code": "002756",
+    "name": "永兴材料",
+    "market": "sz"
+  },
+  {
+    "code": "002757",
+    "name": "南兴股份",
+    "market": "sz"
+  },
+  {
+    "code": "002758",
+    "name": "浙农股份",
+    "market": "sz"
+  },
+  {
+    "code": "002759",
+    "name": "天际股份",
+    "market": "sz"
+  },
+  {
+    "code": "002760",
+    "name": "凤形股份",
+    "market": "sz"
+  },
+  {
+    "code": "002761",
+    "name": "浙江建投",
+    "market": "sz"
+  },
+  {
+    "code": "002762",
+    "name": "金发拉比",
+    "market": "sz"
+  },
+  {
+    "code": "002763",
+    "name": "汇洁股份",
+    "market": "sz"
+  },
+  {
+    "code": "002765",
+    "name": "蓝黛科技",
+    "market": "sz"
+  },
+  {
+    "code": "002766",
+    "name": "ST索菱",
+    "market": "sz"
+  },
+  {
+    "code": "002767",
+    "name": "先锋电子",
+    "market": "sz"
+  },
+  {
+    "code": "002768",
+    "name": "国恩股份",
+    "market": "sz"
+  },
+  {
+    "code": "002769",
+    "name": "普路通",
+    "market": "sz"
+  },
+  {
+    "code": "002770",
+    "name": "ST科迪",
+    "market": "sz"
+  },
+  {
+    "code": "002771",
+    "name": "真视通",
+    "market": "sz"
+  },
+  {
+    "code": "002772",
+    "name": "众兴菌业",
+    "market": "sz"
+  },
+  {
+    "code": "002773",
+    "name": "康弘药业",
+    "market": "sz"
+  },
+  {
+    "code": "002774",
+    "name": "快意电梯",
+    "market": "sz"
+  },
+  {
+    "code": "002775",
+    "name": "文科园林",
+    "market": "sz"
+  },
+  {
+    "code": "002776",
+    "name": "ST柏龙",
+    "market": "sz"
+  },
+  {
+    "code": "002777",
+    "name": "久远银海",
+    "market": "sz"
+  },
+  {
+    "code": "002778",
+    "name": "中晟高科",
+    "market": "sz"
+  },
+  {
+    "code": "002779",
+    "name": "中坚科技",
+    "market": "sz"
+  },
+  {
+    "code": "002780",
+    "name": "三夫户外",
+    "market": "sz"
+  },
+  {
+    "code": "002781",
+    "name": "奇信股份",
+    "market": "sz"
+  },
+  {
+    "code": "002782",
+    "name": "可立克",
+    "market": "sz"
+  },
+  {
+    "code": "002783",
+    "name": "凯龙股份",
+    "market": "sz"
+  },
+  {
+    "code": "002785",
+    "name": "万里石",
+    "market": "sz"
+  },
+  {
+    "code": "002786",
+    "name": "银宝山新",
+    "market": "sz"
+  },
+  {
+    "code": "002787",
+    "name": "华源控股",
+    "market": "sz"
+  },
+  {
+    "code": "002788",
+    "name": "鹭燕医药",
+    "market": "sz"
+  },
+  {
+    "code": "002789",
+    "name": "建艺集团",
+    "market": "sz"
+  },
+  {
+    "code": "002790",
+    "name": "瑞尔特",
+    "market": "sz"
+  },
+  {
+    "code": "002791",
+    "name": "坚朗五金",
+    "market": "sz"
+  },
+  {
+    "code": "002792",
+    "name": "通宇通讯",
+    "market": "sz"
+  },
+  {
+    "code": "002793",
+    "name": "罗欣药业",
+    "market": "sz"
+  },
+  {
+    "code": "002795",
+    "name": "永和智控",
+    "market": "sz"
+  },
+  {
+    "code": "002796",
+    "name": "世嘉科技",
+    "market": "sz"
+  },
+  {
+    "code": "002797",
+    "name": "第一创业",
+    "market": "sz"
+  },
+  {
+    "code": "002798",
+    "name": "帝欧家居",
+    "market": "sz"
+  },
+  {
+    "code": "002799",
+    "name": "环球印务",
+    "market": "sz"
+  },
+  {
+    "code": "002800",
+    "name": "天顺股份",
+    "market": "sz"
+  },
+  {
+    "code": "002801",
+    "name": "微光股份",
+    "market": "sz"
+  },
+  {
+    "code": "002802",
+    "name": "洪汇新材",
+    "market": "sz"
+  },
+  {
+    "code": "002803",
+    "name": "吉宏股份",
+    "market": "sz"
+  },
+  {
+    "code": "002805",
+    "name": "丰元股份",
+    "market": "sz"
+  },
+  {
+    "code": "002806",
+    "name": "华锋股份",
+    "market": "sz"
+  },
+  {
+    "code": "002807",
+    "name": "江阴银行",
+    "market": "sz"
+  },
+  {
+    "code": "002808",
+    "name": "恒久科技",
+    "market": "sz"
+  },
+  {
+    "code": "002809",
+    "name": "红墙股份",
+    "market": "sz"
+  },
+  {
+    "code": "002810",
+    "name": "山东赫达",
+    "market": "sz"
+  },
+  {
+    "code": "002811",
+    "name": "郑中设计",
+    "market": "sz"
+  },
+  {
+    "code": "002812",
+    "name": "恩捷股份",
+    "market": "sz"
+  },
+  {
+    "code": "002813",
+    "name": "路畅科技",
+    "market": "sz"
+  },
+  {
+    "code": "002815",
+    "name": "崇达技术",
+    "market": "sz"
+  },
+  {
+    "code": "002816",
+    "name": "和科达",
+    "market": "sz"
+  },
+  {
+    "code": "002817",
+    "name": "黄山胶囊",
+    "market": "sz"
+  },
+  {
+    "code": "002818",
+    "name": "富森美",
+    "market": "sz"
+  },
+  {
+    "code": "002819",
+    "name": "东方中科",
+    "market": "sz"
+  },
+  {
+    "code": "002820",
+    "name": "桂发祥",
+    "market": "sz"
+  },
+  {
+    "code": "002821",
+    "name": "凯莱英",
+    "market": "sz"
+  },
+  {
+    "code": "002822",
+    "name": "中装建设",
+    "market": "sz"
+  },
+  {
+    "code": "002823",
+    "name": "凯中精密",
+    "market": "sz"
+  },
+  {
+    "code": "002824",
+    "name": "和胜股份",
+    "market": "sz"
+  },
+  {
+    "code": "002825",
+    "name": "纳尔股份",
+    "market": "sz"
+  },
+  {
+    "code": "002826",
+    "name": "易明医药",
+    "market": "sz"
+  },
+  {
+    "code": "002827",
+    "name": "高争民爆",
+    "market": "sz"
+  },
+  {
+    "code": "002828",
+    "name": "贝肯能源",
+    "market": "sz"
+  },
+  {
+    "code": "002829",
+    "name": "星网宇达",
+    "market": "sz"
+  },
+  {
+    "code": "002830",
+    "name": "名雕股份",
+    "market": "sz"
+  },
+  {
+    "code": "002831",
+    "name": "裕同科技",
+    "market": "sz"
+  },
+  {
+    "code": "002832",
+    "name": "比音勒芬",
+    "market": "sz"
+  },
+  {
+    "code": "002833",
+    "name": "弘亚数控",
+    "market": "sz"
+  },
+  {
+    "code": "002835",
+    "name": "同为股份",
+    "market": "sz"
+  },
+  {
+    "code": "002836",
+    "name": "新宏泽",
+    "market": "sz"
+  },
+  {
+    "code": "002837",
+    "name": "英维克",
+    "market": "sz"
+  },
+  {
+    "code": "002838",
+    "name": "道恩股份",
+    "market": "sz"
+  },
+  {
+    "code": "002839",
+    "name": "张家港行",
+    "market": "sz"
+  },
+  {
+    "code": "002840",
+    "name": "华统股份",
+    "market": "sz"
+  },
+  {
+    "code": "002841",
+    "name": "视源股份",
+    "market": "sz"
+  },
+  {
+    "code": "002842",
+    "name": "翔鹭钨业",
+    "market": "sz"
+  },
+  {
+    "code": "002843",
+    "name": "泰嘉股份",
+    "market": "sz"
+  },
+  {
+    "code": "002845",
+    "name": "同兴达",
+    "market": "sz"
+  },
+  {
+    "code": "002846",
+    "name": "英联股份",
+    "market": "sz"
+  },
+  {
+    "code": "002847",
+    "name": "盐津铺子",
+    "market": "sz"
+  },
+  {
+    "code": "002849",
+    "name": "威星智能",
+    "market": "sz"
+  },
+  {
+    "code": "002850",
+    "name": "科达利",
+    "market": "sz"
+  },
+  {
+    "code": "002851",
+    "name": "麦格米特",
+    "market": "sz"
+  },
+  {
+    "code": "002852",
+    "name": "道道全",
+    "market": "sz"
+  },
+  {
+    "code": "002853",
+    "name": "皮阿诺",
+    "market": "sz"
+  },
+  {
+    "code": "002855",
+    "name": "捷荣技术",
+    "market": "sz"
+  },
+  {
+    "code": "002856",
+    "name": "美芝股份",
+    "market": "sz"
+  },
+  {
+    "code": "002857",
+    "name": "三晖电气",
+    "market": "sz"
+  },
+  {
+    "code": "002858",
+    "name": "力盛赛车",
+    "market": "sz"
+  },
+  {
+    "code": "002859",
+    "name": "洁美科技",
+    "market": "sz"
+  },
+  {
+    "code": "002860",
+    "name": "星帅尔",
+    "market": "sz"
+  },
+  {
+    "code": "002861",
+    "name": "瀛通通讯",
+    "market": "sz"
+  },
+  {
+    "code": "002862",
+    "name": "实丰文化",
+    "market": "sz"
+  },
+  {
+    "code": "002863",
+    "name": "今飞凯达",
+    "market": "sz"
+  },
+  {
+    "code": "002864",
+    "name": "盘龙药业",
+    "market": "sz"
+  },
+  {
+    "code": "002865",
+    "name": "钧达股份",
+    "market": "sz"
+  },
+  {
+    "code": "002866",
+    "name": "传艺科技",
+    "market": "sz"
+  },
+  {
+    "code": "002867",
+    "name": "周大生",
+    "market": "sz"
+  },
+  {
+    "code": "002868",
+    "name": "绿康生化",
+    "market": "sz"
+  },
+  {
+    "code": "002869",
+    "name": "金溢科技",
+    "market": "sz"
+  },
+  {
+    "code": "002870",
+    "name": "香山股份",
+    "market": "sz"
+  },
+  {
+    "code": "002871",
+    "name": "伟隆股份",
+    "market": "sz"
+  },
+  {
+    "code": "002872",
+    "name": "ST天圣",
+    "market": "sz"
+  },
+  {
+    "code": "002873",
+    "name": "新天药业",
+    "market": "sz"
+  },
+  {
+    "code": "002875",
+    "name": "安奈儿",
+    "market": "sz"
+  },
+  {
+    "code": "002876",
+    "name": "三利谱",
+    "market": "sz"
+  },
+  {
+    "code": "002877",
+    "name": "智能自控",
+    "market": "sz"
+  },
+  {
+    "code": "002878",
+    "name": "元隆雅图",
+    "market": "sz"
+  },
+  {
+    "code": "002879",
+    "name": "长缆科技",
+    "market": "sz"
+  },
+  {
+    "code": "002880",
+    "name": "卫光生物",
+    "market": "sz"
+  },
+  {
+    "code": "002881",
+    "name": "美格智能",
+    "market": "sz"
+  },
+  {
+    "code": "002882",
+    "name": "金龙羽",
+    "market": "sz"
+  },
+  {
+    "code": "002883",
+    "name": "中设股份",
+    "market": "sz"
+  },
+  {
+    "code": "002884",
+    "name": "凌霄泵业",
+    "market": "sz"
+  },
+  {
+    "code": "002885",
+    "name": "京泉华",
+    "market": "sz"
+  },
+  {
+    "code": "002886",
+    "name": "沃特股份",
+    "market": "sz"
+  },
+  {
+    "code": "002887",
+    "name": "绿茵生态",
+    "market": "sz"
+  },
+  {
+    "code": "002888",
+    "name": "惠威科技",
+    "market": "sz"
+  },
+  {
+    "code": "002889",
+    "name": "东方嘉盛",
+    "market": "sz"
+  },
+  {
+    "code": "002890",
+    "name": "弘宇股份",
+    "market": "sz"
+  },
+  {
+    "code": "002891",
+    "name": "中宠股份",
+    "market": "sz"
+  },
+  {
+    "code": "002892",
+    "name": "科力尔",
+    "market": "sz"
+  },
+  {
+    "code": "002893",
+    "name": "华通热力",
+    "market": "sz"
+  },
+  {
+    "code": "002895",
+    "name": "川恒股份",
+    "market": "sz"
+  },
+  {
+    "code": "002896",
+    "name": "中大力德",
+    "market": "sz"
+  },
+  {
+    "code": "002897",
+    "name": "意华股份",
+    "market": "sz"
+  },
+  {
+    "code": "002898",
+    "name": "赛隆药业",
+    "market": "sz"
+  },
+  {
+    "code": "002899",
+    "name": "英派斯",
+    "market": "sz"
+  },
+  {
+    "code": "002900",
+    "name": "哈三联",
+    "market": "sz"
+  },
+  {
+    "code": "002901",
+    "name": "大博医疗",
+    "market": "sz"
+  },
+  {
+    "code": "002902",
+    "name": "铭普光磁",
+    "market": "sz"
+  },
+  {
+    "code": "002903",
+    "name": "宇环数控",
+    "market": "sz"
+  },
+  {
+    "code": "002905",
+    "name": "金逸影视",
+    "market": "sz"
+  },
+  {
+    "code": "002906",
+    "name": "华阳集团",
+    "market": "sz"
+  },
+  {
+    "code": "002907",
+    "name": "华森制药",
+    "market": "sz"
+  },
+  {
+    "code": "002908",
+    "name": "德生科技",
+    "market": "sz"
+  },
+  {
+    "code": "002909",
+    "name": "集泰股份",
+    "market": "sz"
+  },
+  {
+    "code": "002910",
+    "name": "庄园牧场",
+    "market": "sz"
+  },
+  {
+    "code": "002911",
+    "name": "佛燃能源",
+    "market": "sz"
+  },
+  {
+    "code": "002912",
+    "name": "中新赛克",
+    "market": "sz"
+  },
+  {
+    "code": "002913",
+    "name": "奥士康",
+    "market": "sz"
+  },
+  {
+    "code": "002915",
+    "name": "中欣氟材",
     "market": "sz"
   },
   {
@@ -170,14 +10860,11384 @@
     "market": "sz"
   },
   {
+    "code": "002917",
+    "name": "金奥博",
+    "market": "sz"
+  },
+  {
+    "code": "002918",
+    "name": "蒙娜丽莎",
+    "market": "sz"
+  },
+  {
+    "code": "002919",
+    "name": "名臣健康",
+    "market": "sz"
+  },
+  {
     "code": "002920",
     "name": "德赛西威",
+    "market": "sz"
+  },
+  {
+    "code": "002921",
+    "name": "联诚精密",
+    "market": "sz"
+  },
+  {
+    "code": "002922",
+    "name": "伊戈尔",
+    "market": "sz"
+  },
+  {
+    "code": "002923",
+    "name": "润都股份",
+    "market": "sz"
+  },
+  {
+    "code": "002925",
+    "name": "盈趣科技",
+    "market": "sz"
+  },
+  {
+    "code": "002926",
+    "name": "华西证券",
+    "market": "sz"
+  },
+  {
+    "code": "002927",
+    "name": "泰永长征",
+    "market": "sz"
+  },
+  {
+    "code": "002928",
+    "name": "华夏航空",
+    "market": "sz"
+  },
+  {
+    "code": "002929",
+    "name": "润建股份",
+    "market": "sz"
+  },
+  {
+    "code": "002930",
+    "name": "宏川智慧",
+    "market": "sz"
+  },
+  {
+    "code": "002931",
+    "name": "锋龙股份",
+    "market": "sz"
+  },
+  {
+    "code": "002932",
+    "name": "明德生物",
+    "market": "sz"
+  },
+  {
+    "code": "002933",
+    "name": "新兴装备",
+    "market": "sz"
+  },
+  {
+    "code": "002935",
+    "name": "天奥电子",
+    "market": "sz"
+  },
+  {
+    "code": "002936",
+    "name": "郑州银行",
+    "market": "sz"
+  },
+  {
+    "code": "002937",
+    "name": "兴瑞科技",
+    "market": "sz"
+  },
+  {
+    "code": "002938",
+    "name": "鹏鼎控股",
+    "market": "sz"
+  },
+  {
+    "code": "002939",
+    "name": "长城证券",
+    "market": "sz"
+  },
+  {
+    "code": "002940",
+    "name": "昂利康",
+    "market": "sz"
+  },
+  {
+    "code": "002941",
+    "name": "新疆交建",
+    "market": "sz"
+  },
+  {
+    "code": "002942",
+    "name": "新农股份",
+    "market": "sz"
+  },
+  {
+    "code": "002943",
+    "name": "宇晶股份",
+    "market": "sz"
+  },
+  {
+    "code": "002945",
+    "name": "华林证券",
+    "market": "sz"
+  },
+  {
+    "code": "002946",
+    "name": "新乳业",
+    "market": "sz"
+  },
+  {
+    "code": "002947",
+    "name": "恒铭达",
+    "market": "sz"
+  },
+  {
+    "code": "002948",
+    "name": "青岛银行",
+    "market": "sz"
+  },
+  {
+    "code": "002949",
+    "name": "华阳国际",
+    "market": "sz"
+  },
+  {
+    "code": "002950",
+    "name": "奥美医疗",
+    "market": "sz"
+  },
+  {
+    "code": "002951",
+    "name": "金时科技",
+    "market": "sz"
+  },
+  {
+    "code": "002952",
+    "name": "亚世光电",
+    "market": "sz"
+  },
+  {
+    "code": "002953",
+    "name": "日丰股份",
+    "market": "sz"
+  },
+  {
+    "code": "002955",
+    "name": "鸿合科技",
+    "market": "sz"
+  },
+  {
+    "code": "002956",
+    "name": "西麦食品",
+    "market": "sz"
+  },
+  {
+    "code": "002957",
+    "name": "科瑞技术",
+    "market": "sz"
+  },
+  {
+    "code": "002958",
+    "name": "青农商行",
+    "market": "sz"
+  },
+  {
+    "code": "002959",
+    "name": "小熊电器",
+    "market": "sz"
+  },
+  {
+    "code": "002960",
+    "name": "青鸟消防",
+    "market": "sz"
+  },
+  {
+    "code": "002961",
+    "name": "瑞达期货",
+    "market": "sz"
+  },
+  {
+    "code": "002962",
+    "name": "五方光电",
+    "market": "sz"
+  },
+  {
+    "code": "002963",
+    "name": "豪尔赛",
+    "market": "sz"
+  },
+  {
+    "code": "002965",
+    "name": "祥鑫科技",
+    "market": "sz"
+  },
+  {
+    "code": "002966",
+    "name": "苏州银行",
+    "market": "sz"
+  },
+  {
+    "code": "002967",
+    "name": "广电计量",
+    "market": "sz"
+  },
+  {
+    "code": "002968",
+    "name": "新大正",
+    "market": "sz"
+  },
+  {
+    "code": "002969",
+    "name": "嘉美包装",
+    "market": "sz"
+  },
+  {
+    "code": "002970",
+    "name": "锐明技术",
+    "market": "sz"
+  },
+  {
+    "code": "002971",
+    "name": "和远气体",
+    "market": "sz"
+  },
+  {
+    "code": "002972",
+    "name": "科安达",
+    "market": "sz"
+  },
+  {
+    "code": "002973",
+    "name": "侨银股份",
+    "market": "sz"
+  },
+  {
+    "code": "002975",
+    "name": "博杰股份",
+    "market": "sz"
+  },
+  {
+    "code": "002976",
+    "name": "瑞玛精密",
+    "market": "sz"
+  },
+  {
+    "code": "002977",
+    "name": "天箭科技",
+    "market": "sz"
+  },
+  {
+    "code": "002978",
+    "name": "安宁股份",
+    "market": "sz"
+  },
+  {
+    "code": "002979",
+    "name": "雷赛智能",
+    "market": "sz"
+  },
+  {
+    "code": "002980",
+    "name": "华盛昌",
+    "market": "sz"
+  },
+  {
+    "code": "002981",
+    "name": "朝阳科技",
+    "market": "sz"
+  },
+  {
+    "code": "002982",
+    "name": "湘佳股份",
+    "market": "sz"
+  },
+  {
+    "code": "002983",
+    "name": "芯瑞达",
+    "market": "sz"
+  },
+  {
+    "code": "002984",
+    "name": "森麒麟",
+    "market": "sz"
+  },
+  {
+    "code": "002985",
+    "name": "北摩高科",
+    "market": "sz"
+  },
+  {
+    "code": "002986",
+    "name": "宇新股份",
+    "market": "sz"
+  },
+  {
+    "code": "002987",
+    "name": "京北方",
+    "market": "sz"
+  },
+  {
+    "code": "002988",
+    "name": "豪美新材",
+    "market": "sz"
+  },
+  {
+    "code": "002989",
+    "name": "中天精装",
+    "market": "sz"
+  },
+  {
+    "code": "002990",
+    "name": "盛视科技",
+    "market": "sz"
+  },
+  {
+    "code": "002991",
+    "name": "甘源食品",
+    "market": "sz"
+  },
+  {
+    "code": "002992",
+    "name": "宝明科技",
+    "market": "sz"
+  },
+  {
+    "code": "002993",
+    "name": "奥海科技",
+    "market": "sz"
+  },
+  {
+    "code": "002995",
+    "name": "天地在线",
+    "market": "sz"
+  },
+  {
+    "code": "002996",
+    "name": "顺博合金",
+    "market": "sz"
+  },
+  {
+    "code": "002997",
+    "name": "瑞鹄模具",
+    "market": "sz"
+  },
+  {
+    "code": "002998",
+    "name": "优彩资源",
+    "market": "sz"
+  },
+  {
+    "code": "002999",
+    "name": "天禾股份",
+    "market": "sz"
+  },
+  {
+    "code": "003000",
+    "name": "劲仔食品",
+    "market": "sz"
+  },
+  {
+    "code": "003001",
+    "name": "中岩大地",
+    "market": "sz"
+  },
+  {
+    "code": "003002",
+    "name": "壶化股份",
+    "market": "sz"
+  },
+  {
+    "code": "003003",
+    "name": "天元股份",
+    "market": "sz"
+  },
+  {
+    "code": "003004",
+    "name": "声迅股份",
+    "market": "sz"
+  },
+  {
+    "code": "003005",
+    "name": "竞业达",
+    "market": "sz"
+  },
+  {
+    "code": "003006",
+    "name": "百亚股份",
+    "market": "sz"
+  },
+  {
+    "code": "003007",
+    "name": "直真科技",
+    "market": "sz"
+  },
+  {
+    "code": "003008",
+    "name": "开普检测",
+    "market": "sz"
+  },
+  {
+    "code": "003009",
+    "name": "掌阅科技",
+    "market": "sz"
+  },
+  {
+    "code": "003010",
+    "name": "若羽臣",
+    "market": "sz"
+  },
+  {
+    "code": "003011",
+    "name": "海象新材",
+    "market": "sz"
+  },
+  {
+    "code": "003012",
+    "name": "东鹏控股",
+    "market": "sz"
+  },
+  {
+    "code": "003013",
+    "name": "地铁设计",
+    "market": "sz"
+  },
+  {
+    "code": "003015",
+    "name": "日久光电",
+    "market": "sz"
+  },
+  {
+    "code": "003016",
+    "name": "欣贺股份",
+    "market": "sz"
+  },
+  {
+    "code": "003017",
+    "name": "大洋生物",
+    "market": "sz"
+  },
+  {
+    "code": "003018",
+    "name": "金富科技",
+    "market": "sz"
+  },
+  {
+    "code": "003019",
+    "name": "宸展光电",
+    "market": "sz"
+  },
+  {
+    "code": "003020",
+    "name": "立方制药",
+    "market": "sz"
+  },
+  {
+    "code": "003021",
+    "name": "兆威机电",
+    "market": "sz"
+  },
+  {
+    "code": "003022",
+    "name": "联泓新科",
+    "market": "sz"
+  },
+  {
+    "code": "003023",
+    "name": "彩虹集团",
+    "market": "sz"
+  },
+  {
+    "code": "003025",
+    "name": "思进智能",
+    "market": "sz"
+  },
+  {
+    "code": "003026",
+    "name": "中晶科技",
+    "market": "sz"
+  },
+  {
+    "code": "003027",
+    "name": "同兴环保",
+    "market": "sz"
+  },
+  {
+    "code": "003028",
+    "name": "振邦智能",
+    "market": "sz"
+  },
+  {
+    "code": "003029",
+    "name": "吉大正元",
+    "market": "sz"
+  },
+  {
+    "code": "003030",
+    "name": "祖名股份",
+    "market": "sz"
+  },
+  {
+    "code": "003031",
+    "name": "中瓷电子",
+    "market": "sz"
+  },
+  {
+    "code": "003032",
+    "name": "传智教育",
+    "market": "sz"
+  },
+  {
+    "code": "003033",
+    "name": "征和工业",
+    "market": "sz"
+  },
+  {
+    "code": "003035",
+    "name": "南网能源",
+    "market": "sz"
+  },
+  {
+    "code": "003036",
+    "name": "泰坦股份",
+    "market": "sz"
+  },
+  {
+    "code": "003037",
+    "name": "三和管桩",
+    "market": "sz"
+  },
+  {
+    "code": "003038",
+    "name": "鑫铂股份",
+    "market": "sz"
+  },
+  {
+    "code": "003039",
+    "name": "顺控发展",
+    "market": "sz"
+  },
+  {
+    "code": "003040",
+    "name": "楚天龙",
+    "market": "sz"
+  },
+  {
+    "code": "003041",
+    "name": "真爱美家",
+    "market": "sz"
+  },
+  {
+    "code": "003042",
+    "name": "中农联合",
+    "market": "sz"
+  },
+  {
+    "code": "003043",
+    "name": "华亚智能",
     "market": "sz"
   },
   {
     "code": "003816",
     "name": "中国广核",
     "market": "sz"
+  },
+  {
+    "code": "300001",
+    "name": "特锐德",
+    "market": "sz"
+  },
+  {
+    "code": "300002",
+    "name": "神州泰岳",
+    "market": "sz"
+  },
+  {
+    "code": "300003",
+    "name": "乐普医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300004",
+    "name": "南风股份",
+    "market": "sz"
+  },
+  {
+    "code": "300005",
+    "name": "探路者",
+    "market": "sz"
+  },
+  {
+    "code": "300006",
+    "name": "莱美药业",
+    "market": "sz"
+  },
+  {
+    "code": "300007",
+    "name": "汉威科技",
+    "market": "sz"
+  },
+  {
+    "code": "300008",
+    "name": "天海防务",
+    "market": "sz"
+  },
+  {
+    "code": "300009",
+    "name": "安科生物",
+    "market": "sz"
+  },
+  {
+    "code": "300010",
+    "name": "豆神教育",
+    "market": "sz"
+  },
+  {
+    "code": "300011",
+    "name": "鼎汉技术",
+    "market": "sz"
+  },
+  {
+    "code": "300012",
+    "name": "华测检测",
+    "market": "sz"
+  },
+  {
+    "code": "300013",
+    "name": "新宁物流",
+    "market": "sz"
+  },
+  {
+    "code": "300014",
+    "name": "亿纬锂能",
+    "market": "sz"
+  },
+  {
+    "code": "300015",
+    "name": "爱尔眼科",
+    "market": "sz"
+  },
+  {
+    "code": "300016",
+    "name": "北陆药业",
+    "market": "sz"
+  },
+  {
+    "code": "300017",
+    "name": "网宿科技",
+    "market": "sz"
+  },
+  {
+    "code": "300018",
+    "name": "中元股份",
+    "market": "sz"
+  },
+  {
+    "code": "300019",
+    "name": "硅宝科技",
+    "market": "sz"
+  },
+  {
+    "code": "300020",
+    "name": "银江技术",
+    "market": "sz"
+  },
+  {
+    "code": "300021",
+    "name": "大禹节水",
+    "market": "sz"
+  },
+  {
+    "code": "300022",
+    "name": "吉峰科技",
+    "market": "sz"
+  },
+  {
+    "code": "300023",
+    "name": "ST宝德",
+    "market": "sz"
+  },
+  {
+    "code": "300024",
+    "name": "机器人",
+    "market": "sz"
+  },
+  {
+    "code": "300025",
+    "name": "华星创业",
+    "market": "sz"
+  },
+  {
+    "code": "300026",
+    "name": "红日药业",
+    "market": "sz"
+  },
+  {
+    "code": "300027",
+    "name": "华谊兄弟",
+    "market": "sz"
+  },
+  {
+    "code": "300028",
+    "name": "金亚退",
+    "market": "sz"
+  },
+  {
+    "code": "300029",
+    "name": "ST天龙",
+    "market": "sz"
+  },
+  {
+    "code": "300030",
+    "name": "阳普医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300031",
+    "name": "宝通科技",
+    "market": "sz"
+  },
+  {
+    "code": "300032",
+    "name": "金龙机电",
+    "market": "sz"
+  },
+  {
+    "code": "300033",
+    "name": "同花顺",
+    "market": "sz"
+  },
+  {
+    "code": "300034",
+    "name": "钢研高纳",
+    "market": "sz"
+  },
+  {
+    "code": "300035",
+    "name": "中科电气",
+    "market": "sz"
+  },
+  {
+    "code": "300036",
+    "name": "超图软件",
+    "market": "sz"
+  },
+  {
+    "code": "300037",
+    "name": "新宙邦",
+    "market": "sz"
+  },
+  {
+    "code": "300038",
+    "name": "数知退",
+    "market": "sz"
+  },
+  {
+    "code": "300039",
+    "name": "上海凯宝",
+    "market": "sz"
+  },
+  {
+    "code": "300040",
+    "name": "九洲集团",
+    "market": "sz"
+  },
+  {
+    "code": "300041",
+    "name": "回天新材",
+    "market": "sz"
+  },
+  {
+    "code": "300042",
+    "name": "朗科科技",
+    "market": "sz"
+  },
+  {
+    "code": "300043",
+    "name": "星辉娱乐",
+    "market": "sz"
+  },
+  {
+    "code": "300044",
+    "name": "赛为智能",
+    "market": "sz"
+  },
+  {
+    "code": "300045",
+    "name": "华力创通",
+    "market": "sz"
+  },
+  {
+    "code": "300046",
+    "name": "台基股份",
+    "market": "sz"
+  },
+  {
+    "code": "300047",
+    "name": "天源迪科",
+    "market": "sz"
+  },
+  {
+    "code": "300048",
+    "name": "合康新能",
+    "market": "sz"
+  },
+  {
+    "code": "300049",
+    "name": "福瑞股份",
+    "market": "sz"
+  },
+  {
+    "code": "300050",
+    "name": "世纪鼎利",
+    "market": "sz"
+  },
+  {
+    "code": "300051",
+    "name": "ST三五",
+    "market": "sz"
+  },
+  {
+    "code": "300052",
+    "name": "中青宝",
+    "market": "sz"
+  },
+  {
+    "code": "300053",
+    "name": "欧比特",
+    "market": "sz"
+  },
+  {
+    "code": "300054",
+    "name": "鼎龙股份",
+    "market": "sz"
+  },
+  {
+    "code": "300055",
+    "name": "万邦达",
+    "market": "sz"
+  },
+  {
+    "code": "300056",
+    "name": "中创环保",
+    "market": "sz"
+  },
+  {
+    "code": "300057",
+    "name": "万顺新材",
+    "market": "sz"
+  },
+  {
+    "code": "300058",
+    "name": "蓝色光标",
+    "market": "sz"
+  },
+  {
+    "code": "300059",
+    "name": "东方财富",
+    "market": "sz"
+  },
+  {
+    "code": "300061",
+    "name": "旗天科技",
+    "market": "sz"
+  },
+  {
+    "code": "300062",
+    "name": "中能电气",
+    "market": "sz"
+  },
+  {
+    "code": "300063",
+    "name": "天龙集团",
+    "market": "sz"
+  },
+  {
+    "code": "300064",
+    "name": "ST金刚",
+    "market": "sz"
+  },
+  {
+    "code": "300065",
+    "name": "海兰信",
+    "market": "sz"
+  },
+  {
+    "code": "300066",
+    "name": "三川智慧",
+    "market": "sz"
+  },
+  {
+    "code": "300067",
+    "name": "ST安控",
+    "market": "sz"
+  },
+  {
+    "code": "300068",
+    "name": "南都电源",
+    "market": "sz"
+  },
+  {
+    "code": "300069",
+    "name": "金利华电",
+    "market": "sz"
+  },
+  {
+    "code": "300070",
+    "name": "碧水源",
+    "market": "sz"
+  },
+  {
+    "code": "300071",
+    "name": "*ST嘉信",
+    "market": "sz"
+  },
+  {
+    "code": "300072",
+    "name": "三聚环保",
+    "market": "sz"
+  },
+  {
+    "code": "300073",
+    "name": "当升科技",
+    "market": "sz"
+  },
+  {
+    "code": "300074",
+    "name": "华平股份",
+    "market": "sz"
+  },
+  {
+    "code": "300075",
+    "name": "数字政通",
+    "market": "sz"
+  },
+  {
+    "code": "300076",
+    "name": "GQY视讯",
+    "market": "sz"
+  },
+  {
+    "code": "300077",
+    "name": "国民技术",
+    "market": "sz"
+  },
+  {
+    "code": "300078",
+    "name": "思创医惠",
+    "market": "sz"
+  },
+  {
+    "code": "300079",
+    "name": "数码视讯",
+    "market": "sz"
+  },
+  {
+    "code": "300080",
+    "name": "易成新能",
+    "market": "sz"
+  },
+  {
+    "code": "300081",
+    "name": "恒信东方",
+    "market": "sz"
+  },
+  {
+    "code": "300082",
+    "name": "奥克股份",
+    "market": "sz"
+  },
+  {
+    "code": "300083",
+    "name": "创世纪",
+    "market": "sz"
+  },
+  {
+    "code": "300084",
+    "name": "海默科技",
+    "market": "sz"
+  },
+  {
+    "code": "300085",
+    "name": "银之杰",
+    "market": "sz"
+  },
+  {
+    "code": "300086",
+    "name": "康芝药业",
+    "market": "sz"
+  },
+  {
+    "code": "300087",
+    "name": "荃银高科",
+    "market": "sz"
+  },
+  {
+    "code": "300088",
+    "name": "长信科技",
+    "market": "sz"
+  },
+  {
+    "code": "300089",
+    "name": "ST文化",
+    "market": "sz"
+  },
+  {
+    "code": "300090",
+    "name": "盛运退",
+    "market": "sz"
+  },
+  {
+    "code": "300091",
+    "name": "金通灵",
+    "market": "sz"
+  },
+  {
+    "code": "300092",
+    "name": "科新机电",
+    "market": "sz"
+  },
+  {
+    "code": "300093",
+    "name": "金刚玻璃",
+    "market": "sz"
+  },
+  {
+    "code": "300094",
+    "name": "国联水产",
+    "market": "sz"
+  },
+  {
+    "code": "300095",
+    "name": "华伍股份",
+    "market": "sz"
+  },
+  {
+    "code": "300096",
+    "name": "易联众",
+    "market": "sz"
+  },
+  {
+    "code": "300097",
+    "name": "智云股份",
+    "market": "sz"
+  },
+  {
+    "code": "300098",
+    "name": "高新兴",
+    "market": "sz"
+  },
+  {
+    "code": "300099",
+    "name": "精准信息",
+    "market": "sz"
+  },
+  {
+    "code": "300100",
+    "name": "双林股份",
+    "market": "sz"
+  },
+  {
+    "code": "300101",
+    "name": "振芯科技",
+    "market": "sz"
+  },
+  {
+    "code": "300102",
+    "name": "乾照光电",
+    "market": "sz"
+  },
+  {
+    "code": "300103",
+    "name": "达刚控股",
+    "market": "sz"
+  },
+  {
+    "code": "300105",
+    "name": "龙源技术",
+    "market": "sz"
+  },
+  {
+    "code": "300106",
+    "name": "西部牧业",
+    "market": "sz"
+  },
+  {
+    "code": "300107",
+    "name": "建新股份",
+    "market": "sz"
+  },
+  {
+    "code": "300108",
+    "name": "ST吉药",
+    "market": "sz"
+  },
+  {
+    "code": "300109",
+    "name": "新开源",
+    "market": "sz"
+  },
+  {
+    "code": "300110",
+    "name": "华仁药业",
+    "market": "sz"
+  },
+  {
+    "code": "300111",
+    "name": "向日葵",
+    "market": "sz"
+  },
+  {
+    "code": "300112",
+    "name": "万讯自控",
+    "market": "sz"
+  },
+  {
+    "code": "300113",
+    "name": "顺网科技",
+    "market": "sz"
+  },
+  {
+    "code": "300114",
+    "name": "中航电测",
+    "market": "sz"
+  },
+  {
+    "code": "300115",
+    "name": "长盈精密",
+    "market": "sz"
+  },
+  {
+    "code": "300116",
+    "name": "保力新",
+    "market": "sz"
+  },
+  {
+    "code": "300117",
+    "name": "嘉寓股份",
+    "market": "sz"
+  },
+  {
+    "code": "300118",
+    "name": "东方日升",
+    "market": "sz"
+  },
+  {
+    "code": "300119",
+    "name": "瑞普生物",
+    "market": "sz"
+  },
+  {
+    "code": "300120",
+    "name": "经纬辉开",
+    "market": "sz"
+  },
+  {
+    "code": "300121",
+    "name": "阳谷华泰",
+    "market": "sz"
+  },
+  {
+    "code": "300122",
+    "name": "智飞生物",
+    "market": "sz"
+  },
+  {
+    "code": "300123",
+    "name": "亚光科技",
+    "market": "sz"
+  },
+  {
+    "code": "300124",
+    "name": "汇川技术",
+    "market": "sz"
+  },
+  {
+    "code": "300125",
+    "name": "聆达股份",
+    "market": "sz"
+  },
+  {
+    "code": "300126",
+    "name": "锐奇股份",
+    "market": "sz"
+  },
+  {
+    "code": "300127",
+    "name": "银河磁体",
+    "market": "sz"
+  },
+  {
+    "code": "300128",
+    "name": "锦富技术",
+    "market": "sz"
+  },
+  {
+    "code": "300129",
+    "name": "泰胜风能",
+    "market": "sz"
+  },
+  {
+    "code": "300130",
+    "name": "新国都",
+    "market": "sz"
+  },
+  {
+    "code": "300131",
+    "name": "英唐智控",
+    "market": "sz"
+  },
+  {
+    "code": "300132",
+    "name": "青松股份",
+    "market": "sz"
+  },
+  {
+    "code": "300133",
+    "name": "华策影视",
+    "market": "sz"
+  },
+  {
+    "code": "300134",
+    "name": "大富科技",
+    "market": "sz"
+  },
+  {
+    "code": "300135",
+    "name": "宝利国际",
+    "market": "sz"
+  },
+  {
+    "code": "300136",
+    "name": "信维通信",
+    "market": "sz"
+  },
+  {
+    "code": "300137",
+    "name": "先河环保",
+    "market": "sz"
+  },
+  {
+    "code": "300138",
+    "name": "晨光生物",
+    "market": "sz"
+  },
+  {
+    "code": "300139",
+    "name": "晓程科技",
+    "market": "sz"
+  },
+  {
+    "code": "300140",
+    "name": "中环装备",
+    "market": "sz"
+  },
+  {
+    "code": "300141",
+    "name": "和顺电气",
+    "market": "sz"
+  },
+  {
+    "code": "300142",
+    "name": "沃森生物",
+    "market": "sz"
+  },
+  {
+    "code": "300143",
+    "name": "盈康生命",
+    "market": "sz"
+  },
+  {
+    "code": "300144",
+    "name": "宋城演艺",
+    "market": "sz"
+  },
+  {
+    "code": "300145",
+    "name": "中金环境",
+    "market": "sz"
+  },
+  {
+    "code": "300146",
+    "name": "汤臣倍健",
+    "market": "sz"
+  },
+  {
+    "code": "300147",
+    "name": "香雪制药",
+    "market": "sz"
+  },
+  {
+    "code": "300148",
+    "name": "天舟文化",
+    "market": "sz"
+  },
+  {
+    "code": "300149",
+    "name": "睿智医药",
+    "market": "sz"
+  },
+  {
+    "code": "300150",
+    "name": "世纪瑞尔",
+    "market": "sz"
+  },
+  {
+    "code": "300151",
+    "name": "昌红科技",
+    "market": "sz"
+  },
+  {
+    "code": "300152",
+    "name": "科融环境",
+    "market": "sz"
+  },
+  {
+    "code": "300153",
+    "name": "科泰电源",
+    "market": "sz"
+  },
+  {
+    "code": "300154",
+    "name": "瑞凌股份",
+    "market": "sz"
+  },
+  {
+    "code": "300155",
+    "name": "安居宝",
+    "market": "sz"
+  },
+  {
+    "code": "300156",
+    "name": "神雾退",
+    "market": "sz"
+  },
+  {
+    "code": "300157",
+    "name": "恒泰艾普",
+    "market": "sz"
+  },
+  {
+    "code": "300158",
+    "name": "振东制药",
+    "market": "sz"
+  },
+  {
+    "code": "300159",
+    "name": "新研股份",
+    "market": "sz"
+  },
+  {
+    "code": "300160",
+    "name": "秀强股份",
+    "market": "sz"
+  },
+  {
+    "code": "300161",
+    "name": "华中数控",
+    "market": "sz"
+  },
+  {
+    "code": "300162",
+    "name": "雷曼光电",
+    "market": "sz"
+  },
+  {
+    "code": "300163",
+    "name": "先锋新材",
+    "market": "sz"
+  },
+  {
+    "code": "300164",
+    "name": "通源石油",
+    "market": "sz"
+  },
+  {
+    "code": "300165",
+    "name": "天瑞仪器",
+    "market": "sz"
+  },
+  {
+    "code": "300166",
+    "name": "东方国信",
+    "market": "sz"
+  },
+  {
+    "code": "300167",
+    "name": "迪威迅",
+    "market": "sz"
+  },
+  {
+    "code": "300168",
+    "name": "万达信息",
+    "market": "sz"
+  },
+  {
+    "code": "300169",
+    "name": "天晟新材",
+    "market": "sz"
+  },
+  {
+    "code": "300170",
+    "name": "汉得信息",
+    "market": "sz"
+  },
+  {
+    "code": "300171",
+    "name": "东富龙",
+    "market": "sz"
+  },
+  {
+    "code": "300172",
+    "name": "中电环保",
+    "market": "sz"
+  },
+  {
+    "code": "300173",
+    "name": "福能东方",
+    "market": "sz"
+  },
+  {
+    "code": "300174",
+    "name": "元力股份",
+    "market": "sz"
+  },
+  {
+    "code": "300175",
+    "name": "朗源股份",
+    "market": "sz"
+  },
+  {
+    "code": "300176",
+    "name": "派生科技",
+    "market": "sz"
+  },
+  {
+    "code": "300177",
+    "name": "中海达",
+    "market": "sz"
+  },
+  {
+    "code": "300178",
+    "name": "腾邦退",
+    "market": "sz"
+  },
+  {
+    "code": "300179",
+    "name": "四方达",
+    "market": "sz"
+  },
+  {
+    "code": "300180",
+    "name": "华峰超纤",
+    "market": "sz"
+  },
+  {
+    "code": "300181",
+    "name": "佐力药业",
+    "market": "sz"
+  },
+  {
+    "code": "300182",
+    "name": "捷成股份",
+    "market": "sz"
+  },
+  {
+    "code": "300183",
+    "name": "东软载波",
+    "market": "sz"
+  },
+  {
+    "code": "300184",
+    "name": "力源信息",
+    "market": "sz"
+  },
+  {
+    "code": "300185",
+    "name": "通裕重工",
+    "market": "sz"
+  },
+  {
+    "code": "300187",
+    "name": "永清环保",
+    "market": "sz"
+  },
+  {
+    "code": "300188",
+    "name": "美亚柏科",
+    "market": "sz"
+  },
+  {
+    "code": "300189",
+    "name": "神农科技",
+    "market": "sz"
+  },
+  {
+    "code": "300190",
+    "name": "维尔利",
+    "market": "sz"
+  },
+  {
+    "code": "300191",
+    "name": "潜能恒信",
+    "market": "sz"
+  },
+  {
+    "code": "300192",
+    "name": "科德教育",
+    "market": "sz"
+  },
+  {
+    "code": "300193",
+    "name": "佳士科技",
+    "market": "sz"
+  },
+  {
+    "code": "300194",
+    "name": "福安药业",
+    "market": "sz"
+  },
+  {
+    "code": "300195",
+    "name": "长荣股份",
+    "market": "sz"
+  },
+  {
+    "code": "300196",
+    "name": "长海股份",
+    "market": "sz"
+  },
+  {
+    "code": "300197",
+    "name": "节能铁汉",
+    "market": "sz"
+  },
+  {
+    "code": "300198",
+    "name": "纳川股份",
+    "market": "sz"
+  },
+  {
+    "code": "300199",
+    "name": "翰宇药业",
+    "market": "sz"
+  },
+  {
+    "code": "300200",
+    "name": "高盟新材",
+    "market": "sz"
+  },
+  {
+    "code": "300201",
+    "name": "海伦哲",
+    "market": "sz"
+  },
+  {
+    "code": "300202",
+    "name": "聚龙股份",
+    "market": "sz"
+  },
+  {
+    "code": "300203",
+    "name": "聚光科技",
+    "market": "sz"
+  },
+  {
+    "code": "300204",
+    "name": "舒泰神",
+    "market": "sz"
+  },
+  {
+    "code": "300205",
+    "name": "天喻信息",
+    "market": "sz"
+  },
+  {
+    "code": "300206",
+    "name": "理邦仪器",
+    "market": "sz"
+  },
+  {
+    "code": "300207",
+    "name": "欣旺达",
+    "market": "sz"
+  },
+  {
+    "code": "300208",
+    "name": "青岛中程",
+    "market": "sz"
+  },
+  {
+    "code": "300209",
+    "name": "天泽信息",
+    "market": "sz"
+  },
+  {
+    "code": "300210",
+    "name": "森远股份",
+    "market": "sz"
+  },
+  {
+    "code": "300211",
+    "name": "亿通科技",
+    "market": "sz"
+  },
+  {
+    "code": "300212",
+    "name": "易华录",
+    "market": "sz"
+  },
+  {
+    "code": "300213",
+    "name": "佳讯飞鸿",
+    "market": "sz"
+  },
+  {
+    "code": "300214",
+    "name": "日科化学",
+    "market": "sz"
+  },
+  {
+    "code": "300215",
+    "name": "电科院",
+    "market": "sz"
+  },
+  {
+    "code": "300216",
+    "name": "千山退",
+    "market": "sz"
+  },
+  {
+    "code": "300217",
+    "name": "东方电热",
+    "market": "sz"
+  },
+  {
+    "code": "300218",
+    "name": "安利股份",
+    "market": "sz"
+  },
+  {
+    "code": "300219",
+    "name": "鸿利智汇",
+    "market": "sz"
+  },
+  {
+    "code": "300220",
+    "name": "ST金运",
+    "market": "sz"
+  },
+  {
+    "code": "300221",
+    "name": "银禧科技",
+    "market": "sz"
+  },
+  {
+    "code": "300222",
+    "name": "科大智能",
+    "market": "sz"
+  },
+  {
+    "code": "300223",
+    "name": "北京君正",
+    "market": "sz"
+  },
+  {
+    "code": "300224",
+    "name": "正海磁材",
+    "market": "sz"
+  },
+  {
+    "code": "300225",
+    "name": "金力泰",
+    "market": "sz"
+  },
+  {
+    "code": "300226",
+    "name": "上海钢联",
+    "market": "sz"
+  },
+  {
+    "code": "300227",
+    "name": "光韵达",
+    "market": "sz"
+  },
+  {
+    "code": "300228",
+    "name": "富瑞特装",
+    "market": "sz"
+  },
+  {
+    "code": "300229",
+    "name": "拓尔思",
+    "market": "sz"
+  },
+  {
+    "code": "300230",
+    "name": "永利股份",
+    "market": "sz"
+  },
+  {
+    "code": "300231",
+    "name": "银信科技",
+    "market": "sz"
+  },
+  {
+    "code": "300232",
+    "name": "洲明科技",
+    "market": "sz"
+  },
+  {
+    "code": "300233",
+    "name": "金城医药",
+    "market": "sz"
+  },
+  {
+    "code": "300234",
+    "name": "开尔新材",
+    "market": "sz"
+  },
+  {
+    "code": "300235",
+    "name": "方直科技",
+    "market": "sz"
+  },
+  {
+    "code": "300236",
+    "name": "上海新阳",
+    "market": "sz"
+  },
+  {
+    "code": "300237",
+    "name": "美晨生态",
+    "market": "sz"
+  },
+  {
+    "code": "300238",
+    "name": "冠昊生物",
+    "market": "sz"
+  },
+  {
+    "code": "300239",
+    "name": "东宝生物",
+    "market": "sz"
+  },
+  {
+    "code": "300240",
+    "name": "飞力达",
+    "market": "sz"
+  },
+  {
+    "code": "300241",
+    "name": "瑞丰光电",
+    "market": "sz"
+  },
+  {
+    "code": "300242",
+    "name": "佳云科技",
+    "market": "sz"
+  },
+  {
+    "code": "300243",
+    "name": "瑞丰高材",
+    "market": "sz"
+  },
+  {
+    "code": "300244",
+    "name": "迪安诊断",
+    "market": "sz"
+  },
+  {
+    "code": "300245",
+    "name": "天玑科技",
+    "market": "sz"
+  },
+  {
+    "code": "300246",
+    "name": "宝莱特",
+    "market": "sz"
+  },
+  {
+    "code": "300247",
+    "name": "融捷健康",
+    "market": "sz"
+  },
+  {
+    "code": "300248",
+    "name": "新开普",
+    "market": "sz"
+  },
+  {
+    "code": "300249",
+    "name": "依米康",
+    "market": "sz"
+  },
+  {
+    "code": "300250",
+    "name": "初灵信息",
+    "market": "sz"
+  },
+  {
+    "code": "300251",
+    "name": "光线传媒",
+    "market": "sz"
+  },
+  {
+    "code": "300252",
+    "name": "金信诺",
+    "market": "sz"
+  },
+  {
+    "code": "300253",
+    "name": "卫宁健康",
+    "market": "sz"
+  },
+  {
+    "code": "300254",
+    "name": "仟源医药",
+    "market": "sz"
+  },
+  {
+    "code": "300255",
+    "name": "常山药业",
+    "market": "sz"
+  },
+  {
+    "code": "300256",
+    "name": "星星科技",
+    "market": "sz"
+  },
+  {
+    "code": "300257",
+    "name": "开山股份",
+    "market": "sz"
+  },
+  {
+    "code": "300258",
+    "name": "精锻科技",
+    "market": "sz"
+  },
+  {
+    "code": "300259",
+    "name": "新天科技",
+    "market": "sz"
+  },
+  {
+    "code": "300260",
+    "name": "新莱应材",
+    "market": "sz"
+  },
+  {
+    "code": "300261",
+    "name": "雅本化学",
+    "market": "sz"
+  },
+  {
+    "code": "300262",
+    "name": "巴安水务",
+    "market": "sz"
+  },
+  {
+    "code": "300263",
+    "name": "隆华科技",
+    "market": "sz"
+  },
+  {
+    "code": "300264",
+    "name": "佳创视讯",
+    "market": "sz"
+  },
+  {
+    "code": "300265",
+    "name": "通光线缆",
+    "market": "sz"
+  },
+  {
+    "code": "300266",
+    "name": "兴源环境",
+    "market": "sz"
+  },
+  {
+    "code": "300267",
+    "name": "尔康制药",
+    "market": "sz"
+  },
+  {
+    "code": "300268",
+    "name": "ST佳沃",
+    "market": "sz"
+  },
+  {
+    "code": "300269",
+    "name": "联建光电",
+    "market": "sz"
+  },
+  {
+    "code": "300270",
+    "name": "中威电子",
+    "market": "sz"
+  },
+  {
+    "code": "300271",
+    "name": "华宇软件",
+    "market": "sz"
+  },
+  {
+    "code": "300272",
+    "name": "开能健康",
+    "market": "sz"
+  },
+  {
+    "code": "300273",
+    "name": "和佳医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300274",
+    "name": "阳光电源",
+    "market": "sz"
+  },
+  {
+    "code": "300275",
+    "name": "梅安森",
+    "market": "sz"
+  },
+  {
+    "code": "300276",
+    "name": "三丰智能",
+    "market": "sz"
+  },
+  {
+    "code": "300277",
+    "name": "海联讯",
+    "market": "sz"
+  },
+  {
+    "code": "300278",
+    "name": "华昌达",
+    "market": "sz"
+  },
+  {
+    "code": "300279",
+    "name": "和晶科技",
+    "market": "sz"
+  },
+  {
+    "code": "300280",
+    "name": "紫天科技",
+    "market": "sz"
+  },
+  {
+    "code": "300281",
+    "name": "金明精机",
+    "market": "sz"
+  },
+  {
+    "code": "300282",
+    "name": "ST三盛",
+    "market": "sz"
+  },
+  {
+    "code": "300283",
+    "name": "温州宏丰",
+    "market": "sz"
+  },
+  {
+    "code": "300284",
+    "name": "苏交科",
+    "market": "sz"
+  },
+  {
+    "code": "300285",
+    "name": "国瓷材料",
+    "market": "sz"
+  },
+  {
+    "code": "300286",
+    "name": "安科瑞",
+    "market": "sz"
+  },
+  {
+    "code": "300287",
+    "name": "飞利信",
+    "market": "sz"
+  },
+  {
+    "code": "300288",
+    "name": "朗玛信息",
+    "market": "sz"
+  },
+  {
+    "code": "300289",
+    "name": "利德曼",
+    "market": "sz"
+  },
+  {
+    "code": "300290",
+    "name": "荣科科技",
+    "market": "sz"
+  },
+  {
+    "code": "300291",
+    "name": "华录百纳",
+    "market": "sz"
+  },
+  {
+    "code": "300292",
+    "name": "吴通控股",
+    "market": "sz"
+  },
+  {
+    "code": "300293",
+    "name": "蓝英装备",
+    "market": "sz"
+  },
+  {
+    "code": "300294",
+    "name": "博雅生物",
+    "market": "sz"
+  },
+  {
+    "code": "300295",
+    "name": "三六五网",
+    "market": "sz"
+  },
+  {
+    "code": "300296",
+    "name": "利亚德",
+    "market": "sz"
+  },
+  {
+    "code": "300297",
+    "name": "蓝盾股份",
+    "market": "sz"
+  },
+  {
+    "code": "300298",
+    "name": "三诺生物",
+    "market": "sz"
+  },
+  {
+    "code": "300299",
+    "name": "富春股份",
+    "market": "sz"
+  },
+  {
+    "code": "300300",
+    "name": "海峡创新",
+    "market": "sz"
+  },
+  {
+    "code": "300301",
+    "name": "长方集团",
+    "market": "sz"
+  },
+  {
+    "code": "300302",
+    "name": "同有科技",
+    "market": "sz"
+  },
+  {
+    "code": "300303",
+    "name": "聚飞光电",
+    "market": "sz"
+  },
+  {
+    "code": "300304",
+    "name": "云意电气",
+    "market": "sz"
+  },
+  {
+    "code": "300305",
+    "name": "裕兴股份",
+    "market": "sz"
+  },
+  {
+    "code": "300306",
+    "name": "远方信息",
+    "market": "sz"
+  },
+  {
+    "code": "300307",
+    "name": "慈星股份",
+    "market": "sz"
+  },
+  {
+    "code": "300308",
+    "name": "中际旭创",
+    "market": "sz"
+  },
+  {
+    "code": "300309",
+    "name": "吉艾科技",
+    "market": "sz"
+  },
+  {
+    "code": "300310",
+    "name": "宜通世纪",
+    "market": "sz"
+  },
+  {
+    "code": "300311",
+    "name": "任子行",
+    "market": "sz"
+  },
+  {
+    "code": "300312",
+    "name": "ST邦讯",
+    "market": "sz"
+  },
+  {
+    "code": "300313",
+    "name": "ST天山",
+    "market": "sz"
+  },
+  {
+    "code": "300314",
+    "name": "戴维医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300315",
+    "name": "掌趣科技",
+    "market": "sz"
+  },
+  {
+    "code": "300316",
+    "name": "晶盛机电",
+    "market": "sz"
+  },
+  {
+    "code": "300317",
+    "name": "珈伟新能",
+    "market": "sz"
+  },
+  {
+    "code": "300318",
+    "name": "博晖创新",
+    "market": "sz"
+  },
+  {
+    "code": "300319",
+    "name": "麦捷科技",
+    "market": "sz"
+  },
+  {
+    "code": "300320",
+    "name": "海达股份",
+    "market": "sz"
+  },
+  {
+    "code": "300321",
+    "name": "同大股份",
+    "market": "sz"
+  },
+  {
+    "code": "300322",
+    "name": "硕贝德",
+    "market": "sz"
+  },
+  {
+    "code": "300323",
+    "name": "华灿光电",
+    "market": "sz"
+  },
+  {
+    "code": "300324",
+    "name": "旋极信息",
+    "market": "sz"
+  },
+  {
+    "code": "300325",
+    "name": "ST德威",
+    "market": "sz"
+  },
+  {
+    "code": "300326",
+    "name": "凯利泰",
+    "market": "sz"
+  },
+  {
+    "code": "300327",
+    "name": "中颖电子",
+    "market": "sz"
+  },
+  {
+    "code": "300328",
+    "name": "宜安科技",
+    "market": "sz"
+  },
+  {
+    "code": "300329",
+    "name": "海伦钢琴",
+    "market": "sz"
+  },
+  {
+    "code": "300330",
+    "name": "华虹计通",
+    "market": "sz"
+  },
+  {
+    "code": "300331",
+    "name": "苏大维格",
+    "market": "sz"
+  },
+  {
+    "code": "300332",
+    "name": "天壕环境",
+    "market": "sz"
+  },
+  {
+    "code": "300333",
+    "name": "兆日科技",
+    "market": "sz"
+  },
+  {
+    "code": "300334",
+    "name": "津膜科技",
+    "market": "sz"
+  },
+  {
+    "code": "300335",
+    "name": "迪森股份",
+    "market": "sz"
+  },
+  {
+    "code": "300336",
+    "name": "新文化",
+    "market": "sz"
+  },
+  {
+    "code": "300337",
+    "name": "银邦股份",
+    "market": "sz"
+  },
+  {
+    "code": "300338",
+    "name": "开元教育",
+    "market": "sz"
+  },
+  {
+    "code": "300339",
+    "name": "润和软件",
+    "market": "sz"
+  },
+  {
+    "code": "300340",
+    "name": "科恒股份",
+    "market": "sz"
+  },
+  {
+    "code": "300341",
+    "name": "麦克奥迪",
+    "market": "sz"
+  },
+  {
+    "code": "300342",
+    "name": "天银机电",
+    "market": "sz"
+  },
+  {
+    "code": "300343",
+    "name": "联创股份",
+    "market": "sz"
+  },
+  {
+    "code": "300344",
+    "name": "立方数科",
+    "market": "sz"
+  },
+  {
+    "code": "300345",
+    "name": "华民股份",
+    "market": "sz"
+  },
+  {
+    "code": "300346",
+    "name": "南大光电",
+    "market": "sz"
+  },
+  {
+    "code": "300347",
+    "name": "泰格医药",
+    "market": "sz"
+  },
+  {
+    "code": "300348",
+    "name": "长亮科技",
+    "market": "sz"
+  },
+  {
+    "code": "300349",
+    "name": "金卡智能",
+    "market": "sz"
+  },
+  {
+    "code": "300350",
+    "name": "华鹏飞",
+    "market": "sz"
+  },
+  {
+    "code": "300351",
+    "name": "永贵电器",
+    "market": "sz"
+  },
+  {
+    "code": "300352",
+    "name": "北信源",
+    "market": "sz"
+  },
+  {
+    "code": "300353",
+    "name": "东土科技",
+    "market": "sz"
+  },
+  {
+    "code": "300354",
+    "name": "东华测试",
+    "market": "sz"
+  },
+  {
+    "code": "300355",
+    "name": "蒙草生态",
+    "market": "sz"
+  },
+  {
+    "code": "300356",
+    "name": "ST光一",
+    "market": "sz"
+  },
+  {
+    "code": "300357",
+    "name": "我武生物",
+    "market": "sz"
+  },
+  {
+    "code": "300358",
+    "name": "楚天科技",
+    "market": "sz"
+  },
+  {
+    "code": "300359",
+    "name": "全通教育",
+    "market": "sz"
+  },
+  {
+    "code": "300360",
+    "name": "炬华科技",
+    "market": "sz"
+  },
+  {
+    "code": "300361",
+    "name": "奥赛康",
+    "market": "sz"
+  },
+  {
+    "code": "300362",
+    "name": "天翔退",
+    "market": "sz"
+  },
+  {
+    "code": "300363",
+    "name": "博腾股份",
+    "market": "sz"
+  },
+  {
+    "code": "300364",
+    "name": "中文在线",
+    "market": "sz"
+  },
+  {
+    "code": "300365",
+    "name": "恒华科技",
+    "market": "sz"
+  },
+  {
+    "code": "300366",
+    "name": "创意信息",
+    "market": "sz"
+  },
+  {
+    "code": "300367",
+    "name": "ST网力",
+    "market": "sz"
+  },
+  {
+    "code": "300368",
+    "name": "汇金股份",
+    "market": "sz"
+  },
+  {
+    "code": "300369",
+    "name": "绿盟科技",
+    "market": "sz"
+  },
+  {
+    "code": "300370",
+    "name": "ST安控",
+    "market": "sz"
+  },
+  {
+    "code": "300371",
+    "name": "汇中股份",
+    "market": "sz"
+  },
+  {
+    "code": "300372",
+    "name": "欣泰退",
+    "market": "sz"
+  },
+  {
+    "code": "300373",
+    "name": "扬杰科技",
+    "market": "sz"
+  },
+  {
+    "code": "300374",
+    "name": "中铁装配",
+    "market": "sz"
+  },
+  {
+    "code": "300375",
+    "name": "鹏翎股份",
+    "market": "sz"
+  },
+  {
+    "code": "300376",
+    "name": "易事特",
+    "market": "sz"
+  },
+  {
+    "code": "300377",
+    "name": "赢时胜",
+    "market": "sz"
+  },
+  {
+    "code": "300378",
+    "name": "鼎捷软件",
+    "market": "sz"
+  },
+  {
+    "code": "300379",
+    "name": "东方通",
+    "market": "sz"
+  },
+  {
+    "code": "300380",
+    "name": "安硕信息",
+    "market": "sz"
+  },
+  {
+    "code": "300381",
+    "name": "溢多利",
+    "market": "sz"
+  },
+  {
+    "code": "300382",
+    "name": "斯莱克",
+    "market": "sz"
+  },
+  {
+    "code": "300383",
+    "name": "光环新网",
+    "market": "sz"
+  },
+  {
+    "code": "300384",
+    "name": "三联虹普",
+    "market": "sz"
+  },
+  {
+    "code": "300385",
+    "name": "雪浪环境",
+    "market": "sz"
+  },
+  {
+    "code": "300386",
+    "name": "飞天诚信",
+    "market": "sz"
+  },
+  {
+    "code": "300387",
+    "name": "富邦股份",
+    "market": "sz"
+  },
+  {
+    "code": "300388",
+    "name": "节能国祯",
+    "market": "sz"
+  },
+  {
+    "code": "300389",
+    "name": "艾比森",
+    "market": "sz"
+  },
+  {
+    "code": "300390",
+    "name": "天华超净",
+    "market": "sz"
+  },
+  {
+    "code": "300391",
+    "name": "康跃科技",
+    "market": "sz"
+  },
+  {
+    "code": "300392",
+    "name": "腾信股份",
+    "market": "sz"
+  },
+  {
+    "code": "300393",
+    "name": "中来股份",
+    "market": "sz"
+  },
+  {
+    "code": "300394",
+    "name": "天孚通信",
+    "market": "sz"
+  },
+  {
+    "code": "300395",
+    "name": "菲利华",
+    "market": "sz"
+  },
+  {
+    "code": "300396",
+    "name": "迪瑞医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300397",
+    "name": "天和防务",
+    "market": "sz"
+  },
+  {
+    "code": "300398",
+    "name": "飞凯材料",
+    "market": "sz"
+  },
+  {
+    "code": "300399",
+    "name": "天利科技",
+    "market": "sz"
+  },
+  {
+    "code": "300400",
+    "name": "劲拓股份",
+    "market": "sz"
+  },
+  {
+    "code": "300401",
+    "name": "花园生物",
+    "market": "sz"
+  },
+  {
+    "code": "300402",
+    "name": "宝色股份",
+    "market": "sz"
+  },
+  {
+    "code": "300403",
+    "name": "汉宇集团",
+    "market": "sz"
+  },
+  {
+    "code": "300404",
+    "name": "博济医药",
+    "market": "sz"
+  },
+  {
+    "code": "300405",
+    "name": "科隆股份",
+    "market": "sz"
+  },
+  {
+    "code": "300406",
+    "name": "九强生物",
+    "market": "sz"
+  },
+  {
+    "code": "300407",
+    "name": "凯发电气",
+    "market": "sz"
+  },
+  {
+    "code": "300408",
+    "name": "三环集团",
+    "market": "sz"
+  },
+  {
+    "code": "300409",
+    "name": "道氏技术",
+    "market": "sz"
+  },
+  {
+    "code": "300410",
+    "name": "正业科技",
+    "market": "sz"
+  },
+  {
+    "code": "300411",
+    "name": "金盾股份",
+    "market": "sz"
+  },
+  {
+    "code": "300412",
+    "name": "迦南科技",
+    "market": "sz"
+  },
+  {
+    "code": "300413",
+    "name": "芒果超媒",
+    "market": "sz"
+  },
+  {
+    "code": "300414",
+    "name": "中光防雷",
+    "market": "sz"
+  },
+  {
+    "code": "300415",
+    "name": "伊之密",
+    "market": "sz"
+  },
+  {
+    "code": "300416",
+    "name": "苏试试验",
+    "market": "sz"
+  },
+  {
+    "code": "300417",
+    "name": "南华仪器",
+    "market": "sz"
+  },
+  {
+    "code": "300418",
+    "name": "昆仑万维",
+    "market": "sz"
+  },
+  {
+    "code": "300419",
+    "name": "浩丰科技",
+    "market": "sz"
+  },
+  {
+    "code": "300420",
+    "name": "五洋停车",
+    "market": "sz"
+  },
+  {
+    "code": "300421",
+    "name": "力星股份",
+    "market": "sz"
+  },
+  {
+    "code": "300422",
+    "name": "博世科",
+    "market": "sz"
+  },
+  {
+    "code": "300423",
+    "name": "昇辉科技",
+    "market": "sz"
+  },
+  {
+    "code": "300424",
+    "name": "航新科技",
+    "market": "sz"
+  },
+  {
+    "code": "300425",
+    "name": "中建环能",
+    "market": "sz"
+  },
+  {
+    "code": "300426",
+    "name": "唐德影视",
+    "market": "sz"
+  },
+  {
+    "code": "300427",
+    "name": "红相股份",
+    "market": "sz"
+  },
+  {
+    "code": "300428",
+    "name": "立中集团",
+    "market": "sz"
+  },
+  {
+    "code": "300429",
+    "name": "强力新材",
+    "market": "sz"
+  },
+  {
+    "code": "300430",
+    "name": "诚益通",
+    "market": "sz"
+  },
+  {
+    "code": "300432",
+    "name": "富临精工",
+    "market": "sz"
+  },
+  {
+    "code": "300433",
+    "name": "蓝思科技",
+    "market": "sz"
+  },
+  {
+    "code": "300434",
+    "name": "金石亚药",
+    "market": "sz"
+  },
+  {
+    "code": "300435",
+    "name": "中泰股份",
+    "market": "sz"
+  },
+  {
+    "code": "300436",
+    "name": "广生堂",
+    "market": "sz"
+  },
+  {
+    "code": "300437",
+    "name": "清水源",
+    "market": "sz"
+  },
+  {
+    "code": "300438",
+    "name": "鹏辉能源",
+    "market": "sz"
+  },
+  {
+    "code": "300439",
+    "name": "美康生物",
+    "market": "sz"
+  },
+  {
+    "code": "300440",
+    "name": "运达科技",
+    "market": "sz"
+  },
+  {
+    "code": "300441",
+    "name": "鲍斯股份",
+    "market": "sz"
+  },
+  {
+    "code": "300442",
+    "name": "普丽盛",
+    "market": "sz"
+  },
+  {
+    "code": "300443",
+    "name": "金雷股份",
+    "market": "sz"
+  },
+  {
+    "code": "300444",
+    "name": "双杰电气",
+    "market": "sz"
+  },
+  {
+    "code": "300445",
+    "name": "康斯特",
+    "market": "sz"
+  },
+  {
+    "code": "300446",
+    "name": "乐凯新材",
+    "market": "sz"
+  },
+  {
+    "code": "300447",
+    "name": "全信股份",
+    "market": "sz"
+  },
+  {
+    "code": "300448",
+    "name": "浩云科技",
+    "market": "sz"
+  },
+  {
+    "code": "300449",
+    "name": "汉邦高科",
+    "market": "sz"
+  },
+  {
+    "code": "300450",
+    "name": "先导智能",
+    "market": "sz"
+  },
+  {
+    "code": "300451",
+    "name": "创业慧康",
+    "market": "sz"
+  },
+  {
+    "code": "300452",
+    "name": "山河药辅",
+    "market": "sz"
+  },
+  {
+    "code": "300453",
+    "name": "三鑫医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300454",
+    "name": "深信服",
+    "market": "sz"
+  },
+  {
+    "code": "300455",
+    "name": "康拓红外",
+    "market": "sz"
+  },
+  {
+    "code": "300456",
+    "name": "赛微电子",
+    "market": "sz"
+  },
+  {
+    "code": "300457",
+    "name": "赢合科技",
+    "market": "sz"
+  },
+  {
+    "code": "300458",
+    "name": "全志科技",
+    "market": "sz"
+  },
+  {
+    "code": "300459",
+    "name": "汤姆猫",
+    "market": "sz"
+  },
+  {
+    "code": "300460",
+    "name": "惠伦晶体",
+    "market": "sz"
+  },
+  {
+    "code": "300461",
+    "name": "田中精机",
+    "market": "sz"
+  },
+  {
+    "code": "300462",
+    "name": "华铭智能",
+    "market": "sz"
+  },
+  {
+    "code": "300463",
+    "name": "迈克生物",
+    "market": "sz"
+  },
+  {
+    "code": "300464",
+    "name": "星徽股份",
+    "market": "sz"
+  },
+  {
+    "code": "300465",
+    "name": "高伟达",
+    "market": "sz"
+  },
+  {
+    "code": "300466",
+    "name": "赛摩智能",
+    "market": "sz"
+  },
+  {
+    "code": "300467",
+    "name": "迅游科技",
+    "market": "sz"
+  },
+  {
+    "code": "300468",
+    "name": "四方精创",
+    "market": "sz"
+  },
+  {
+    "code": "300469",
+    "name": "信息发展",
+    "market": "sz"
+  },
+  {
+    "code": "300470",
+    "name": "中密控股",
+    "market": "sz"
+  },
+  {
+    "code": "300471",
+    "name": "厚普股份",
+    "market": "sz"
+  },
+  {
+    "code": "300472",
+    "name": "新元科技",
+    "market": "sz"
+  },
+  {
+    "code": "300473",
+    "name": "德尔股份",
+    "market": "sz"
+  },
+  {
+    "code": "300474",
+    "name": "景嘉微",
+    "market": "sz"
+  },
+  {
+    "code": "300475",
+    "name": "香农芯创",
+    "market": "sz"
+  },
+  {
+    "code": "300476",
+    "name": "胜宏科技",
+    "market": "sz"
+  },
+  {
+    "code": "300477",
+    "name": "合纵科技",
+    "market": "sz"
+  },
+  {
+    "code": "300478",
+    "name": "杭州高新",
+    "market": "sz"
+  },
+  {
+    "code": "300479",
+    "name": "神思电子",
+    "market": "sz"
+  },
+  {
+    "code": "300480",
+    "name": "光力科技",
+    "market": "sz"
+  },
+  {
+    "code": "300481",
+    "name": "濮阳惠成",
+    "market": "sz"
+  },
+  {
+    "code": "300482",
+    "name": "万孚生物",
+    "market": "sz"
+  },
+  {
+    "code": "300483",
+    "name": "首华燃气",
+    "market": "sz"
+  },
+  {
+    "code": "300484",
+    "name": "蓝海华腾",
+    "market": "sz"
+  },
+  {
+    "code": "300485",
+    "name": "赛升药业",
+    "market": "sz"
+  },
+  {
+    "code": "300486",
+    "name": "东杰智能",
+    "market": "sz"
+  },
+  {
+    "code": "300487",
+    "name": "蓝晓科技",
+    "market": "sz"
+  },
+  {
+    "code": "300488",
+    "name": "恒锋工具",
+    "market": "sz"
+  },
+  {
+    "code": "300489",
+    "name": "ST光一",
+    "market": "sz"
+  },
+  {
+    "code": "300490",
+    "name": "华自科技",
+    "market": "sz"
+  },
+  {
+    "code": "300491",
+    "name": "通合科技",
+    "market": "sz"
+  },
+  {
+    "code": "300492",
+    "name": "华图山鼎",
+    "market": "sz"
+  },
+  {
+    "code": "300493",
+    "name": "润欣科技",
+    "market": "sz"
+  },
+  {
+    "code": "300494",
+    "name": "盛天网络",
+    "market": "sz"
+  },
+  {
+    "code": "300495",
+    "name": "美尚生态",
+    "market": "sz"
+  },
+  {
+    "code": "300496",
+    "name": "中科创达",
+    "market": "sz"
+  },
+  {
+    "code": "300497",
+    "name": "富祥药业",
+    "market": "sz"
+  },
+  {
+    "code": "300498",
+    "name": "温氏股份",
+    "market": "sz"
+  },
+  {
+    "code": "300499",
+    "name": "高澜股份",
+    "market": "sz"
+  },
+  {
+    "code": "300500",
+    "name": "启迪设计",
+    "market": "sz"
+  },
+  {
+    "code": "300501",
+    "name": "海顺新材",
+    "market": "sz"
+  },
+  {
+    "code": "300502",
+    "name": "新易盛",
+    "market": "sz"
+  },
+  {
+    "code": "300503",
+    "name": "昊志机电",
+    "market": "sz"
+  },
+  {
+    "code": "300504",
+    "name": "天邑股份",
+    "market": "sz"
+  },
+  {
+    "code": "300505",
+    "name": "川金诺",
+    "market": "sz"
+  },
+  {
+    "code": "300506",
+    "name": "名家汇",
+    "market": "sz"
+  },
+  {
+    "code": "300507",
+    "name": "苏奥传感",
+    "market": "sz"
+  },
+  {
+    "code": "300508",
+    "name": "维宏股份",
+    "market": "sz"
+  },
+  {
+    "code": "300509",
+    "name": "新美星",
+    "market": "sz"
+  },
+  {
+    "code": "300510",
+    "name": "金冠股份",
+    "market": "sz"
+  },
+  {
+    "code": "300511",
+    "name": "雪榕生物",
+    "market": "sz"
+  },
+  {
+    "code": "300512",
+    "name": "中亚股份",
+    "market": "sz"
+  },
+  {
+    "code": "300513",
+    "name": "恒实科技",
+    "market": "sz"
+  },
+  {
+    "code": "300514",
+    "name": "友讯达",
+    "market": "sz"
+  },
+  {
+    "code": "300515",
+    "name": "三德科技",
+    "market": "sz"
+  },
+  {
+    "code": "300516",
+    "name": "久之洋",
+    "market": "sz"
+  },
+  {
+    "code": "300517",
+    "name": "海波重科",
+    "market": "sz"
+  },
+  {
+    "code": "300518",
+    "name": "盛讯达",
+    "market": "sz"
+  },
+  {
+    "code": "300519",
+    "name": "新光药业",
+    "market": "sz"
+  },
+  {
+    "code": "300520",
+    "name": "科大国创",
+    "market": "sz"
+  },
+  {
+    "code": "300521",
+    "name": "爱司凯",
+    "market": "sz"
+  },
+  {
+    "code": "300522",
+    "name": "世名科技",
+    "market": "sz"
+  },
+  {
+    "code": "300523",
+    "name": "辰安科技",
+    "market": "sz"
+  },
+  {
+    "code": "300525",
+    "name": "博思软件",
+    "market": "sz"
+  },
+  {
+    "code": "300526",
+    "name": "中潜股份",
+    "market": "sz"
+  },
+  {
+    "code": "300527",
+    "name": "中船应急",
+    "market": "sz"
+  },
+  {
+    "code": "300528",
+    "name": "幸福蓝海",
+    "market": "sz"
+  },
+  {
+    "code": "300529",
+    "name": "健帆生物",
+    "market": "sz"
+  },
+  {
+    "code": "300530",
+    "name": "达志科技",
+    "market": "sz"
+  },
+  {
+    "code": "300531",
+    "name": "优博讯",
+    "market": "sz"
+  },
+  {
+    "code": "300532",
+    "name": "今天国际",
+    "market": "sz"
+  },
+  {
+    "code": "300533",
+    "name": "冰川网络",
+    "market": "sz"
+  },
+  {
+    "code": "300534",
+    "name": "陇神戎发",
+    "market": "sz"
+  },
+  {
+    "code": "300535",
+    "name": "达威股份",
+    "market": "sz"
+  },
+  {
+    "code": "300536",
+    "name": "朗科智能",
+    "market": "sz"
+  },
+  {
+    "code": "300537",
+    "name": "广信材料",
+    "market": "sz"
+  },
+  {
+    "code": "300538",
+    "name": "同益股份",
+    "market": "sz"
+  },
+  {
+    "code": "300539",
+    "name": "横河精密",
+    "market": "sz"
+  },
+  {
+    "code": "300540",
+    "name": "蜀道装备",
+    "market": "sz"
+  },
+  {
+    "code": "300541",
+    "name": "先进数通",
+    "market": "sz"
+  },
+  {
+    "code": "300542",
+    "name": "新晨科技",
+    "market": "sz"
+  },
+  {
+    "code": "300543",
+    "name": "朗科智能",
+    "market": "sz"
+  },
+  {
+    "code": "300545",
+    "name": "联得装备",
+    "market": "sz"
+  },
+  {
+    "code": "300546",
+    "name": "雄帝科技",
+    "market": "sz"
+  },
+  {
+    "code": "300547",
+    "name": "川环科技",
+    "market": "sz"
+  },
+  {
+    "code": "300548",
+    "name": "博创科技",
+    "market": "sz"
+  },
+  {
+    "code": "300549",
+    "name": "优德精密",
+    "market": "sz"
+  },
+  {
+    "code": "300550",
+    "name": "和仁科技",
+    "market": "sz"
+  },
+  {
+    "code": "300551",
+    "name": "古鳌科技",
+    "market": "sz"
+  },
+  {
+    "code": "300552",
+    "name": "万集科技",
+    "market": "sz"
+  },
+  {
+    "code": "300553",
+    "name": "集智股份",
+    "market": "sz"
+  },
+  {
+    "code": "300554",
+    "name": "三超新材",
+    "market": "sz"
+  },
+  {
+    "code": "300555",
+    "name": "路通视信",
+    "market": "sz"
+  },
+  {
+    "code": "300556",
+    "name": "丝路视觉",
+    "market": "sz"
+  },
+  {
+    "code": "300557",
+    "name": "理工光科",
+    "market": "sz"
+  },
+  {
+    "code": "300558",
+    "name": "贝达药业",
+    "market": "sz"
+  },
+  {
+    "code": "300559",
+    "name": "佳发教育",
+    "market": "sz"
+  },
+  {
+    "code": "300560",
+    "name": "中富通",
+    "market": "sz"
+  },
+  {
+    "code": "300561",
+    "name": "汇金科技",
+    "market": "sz"
+  },
+  {
+    "code": "300562",
+    "name": "乐心医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300563",
+    "name": "神宇股份",
+    "market": "sz"
+  },
+  {
+    "code": "300564",
+    "name": "筑博设计",
+    "market": "sz"
+  },
+  {
+    "code": "300565",
+    "name": "科信技术",
+    "market": "sz"
+  },
+  {
+    "code": "300566",
+    "name": "激智科技",
+    "market": "sz"
+  },
+  {
+    "code": "300567",
+    "name": "精测电子",
+    "market": "sz"
+  },
+  {
+    "code": "300568",
+    "name": "星源材质",
+    "market": "sz"
+  },
+  {
+    "code": "300569",
+    "name": "天能重工",
+    "market": "sz"
+  },
+  {
+    "code": "300570",
+    "name": "太辰光",
+    "market": "sz"
+  },
+  {
+    "code": "300571",
+    "name": "平治信息",
+    "market": "sz"
+  },
+  {
+    "code": "300572",
+    "name": "安车检测",
+    "market": "sz"
+  },
+  {
+    "code": "300573",
+    "name": "兴齐眼药",
+    "market": "sz"
+  },
+  {
+    "code": "300575",
+    "name": "中旗股份",
+    "market": "sz"
+  },
+  {
+    "code": "300576",
+    "name": "容大感光",
+    "market": "sz"
+  },
+  {
+    "code": "300577",
+    "name": "开润股份",
+    "market": "sz"
+  },
+  {
+    "code": "300578",
+    "name": "会畅通讯",
+    "market": "sz"
+  },
+  {
+    "code": "300579",
+    "name": "数字认证",
+    "market": "sz"
+  },
+  {
+    "code": "300580",
+    "name": "贝斯特",
+    "market": "sz"
+  },
+  {
+    "code": "300581",
+    "name": "晨曦航空",
+    "market": "sz"
+  },
+  {
+    "code": "300582",
+    "name": "英飞特",
+    "market": "sz"
+  },
+  {
+    "code": "300583",
+    "name": "赛托生物",
+    "market": "sz"
+  },
+  {
+    "code": "300584",
+    "name": "海辰药业",
+    "market": "sz"
+  },
+  {
+    "code": "300585",
+    "name": "奥联电子",
+    "market": "sz"
+  },
+  {
+    "code": "300586",
+    "name": "美联新材",
+    "market": "sz"
+  },
+  {
+    "code": "300587",
+    "name": "天铁股份",
+    "market": "sz"
+  },
+  {
+    "code": "300588",
+    "name": "熙菱信息",
+    "market": "sz"
+  },
+  {
+    "code": "300589",
+    "name": "江龙船艇",
+    "market": "sz"
+  },
+  {
+    "code": "300590",
+    "name": "移为通信",
+    "market": "sz"
+  },
+  {
+    "code": "300591",
+    "name": "万里马",
+    "market": "sz"
+  },
+  {
+    "code": "300592",
+    "name": "华凯易佰",
+    "market": "sz"
+  },
+  {
+    "code": "300593",
+    "name": "新雷能",
+    "market": "sz"
+  },
+  {
+    "code": "300594",
+    "name": "朗进科技",
+    "market": "sz"
+  },
+  {
+    "code": "300595",
+    "name": "欧普康视",
+    "market": "sz"
+  },
+  {
+    "code": "300596",
+    "name": "利安隆",
+    "market": "sz"
+  },
+  {
+    "code": "300597",
+    "name": "吉大通信",
+    "market": "sz"
+  },
+  {
+    "code": "300598",
+    "name": "诚迈科技",
+    "market": "sz"
+  },
+  {
+    "code": "300599",
+    "name": "雄塑科技",
+    "market": "sz"
+  },
+  {
+    "code": "300600",
+    "name": "国瑞科技",
+    "market": "sz"
+  },
+  {
+    "code": "300601",
+    "name": "康泰生物",
+    "market": "sz"
+  },
+  {
+    "code": "300602",
+    "name": "飞荣达",
+    "market": "sz"
+  },
+  {
+    "code": "300603",
+    "name": "立昂技术",
+    "market": "sz"
+  },
+  {
+    "code": "300604",
+    "name": "长川科技",
+    "market": "sz"
+  },
+  {
+    "code": "300605",
+    "name": "恒锋信息",
+    "market": "sz"
+  },
+  {
+    "code": "300606",
+    "name": "金太阳",
+    "market": "sz"
+  },
+  {
+    "code": "300607",
+    "name": "拓斯达",
+    "market": "sz"
+  },
+  {
+    "code": "300608",
+    "name": "思特奇",
+    "market": "sz"
+  },
+  {
+    "code": "300609",
+    "name": "汇纳科技",
+    "market": "sz"
+  },
+  {
+    "code": "300610",
+    "name": "晨化股份",
+    "market": "sz"
+  },
+  {
+    "code": "300611",
+    "name": "美力科技",
+    "market": "sz"
+  },
+  {
+    "code": "300612",
+    "name": "宣亚国际",
+    "market": "sz"
+  },
+  {
+    "code": "300613",
+    "name": "富瀚微",
+    "market": "sz"
+  },
+  {
+    "code": "300614",
+    "name": "百川畅银",
+    "market": "sz"
+  },
+  {
+    "code": "300615",
+    "name": "欣天科技",
+    "market": "sz"
+  },
+  {
+    "code": "300616",
+    "name": "尚品宅配",
+    "market": "sz"
+  },
+  {
+    "code": "300617",
+    "name": "安靠智电",
+    "market": "sz"
+  },
+  {
+    "code": "300618",
+    "name": "寒锐钴业",
+    "market": "sz"
+  },
+  {
+    "code": "300619",
+    "name": "金银河",
+    "market": "sz"
+  },
+  {
+    "code": "300620",
+    "name": "光库科技",
+    "market": "sz"
+  },
+  {
+    "code": "300621",
+    "name": "维业股份",
+    "market": "sz"
+  },
+  {
+    "code": "300622",
+    "name": "博士眼镜",
+    "market": "sz"
+  },
+  {
+    "code": "300623",
+    "name": "捷捷微电",
+    "market": "sz"
+  },
+  {
+    "code": "300624",
+    "name": "万兴科技",
+    "market": "sz"
+  },
+  {
+    "code": "300625",
+    "name": "三雄极光",
+    "market": "sz"
+  },
+  {
+    "code": "300626",
+    "name": "华瑞股份",
+    "market": "sz"
+  },
+  {
+    "code": "300627",
+    "name": "华测导航",
+    "market": "sz"
+  },
+  {
+    "code": "300628",
+    "name": "亿联网络",
+    "market": "sz"
+  },
+  {
+    "code": "300629",
+    "name": "新劲刚",
+    "market": "sz"
+  },
+  {
+    "code": "300630",
+    "name": "普利制药",
+    "market": "sz"
+  },
+  {
+    "code": "300631",
+    "name": "久吾高科",
+    "market": "sz"
+  },
+  {
+    "code": "300632",
+    "name": "光莆股份",
+    "market": "sz"
+  },
+  {
+    "code": "300633",
+    "name": "开立医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300634",
+    "name": "彩讯股份",
+    "market": "sz"
+  },
+  {
+    "code": "300635",
+    "name": "中达安",
+    "market": "sz"
+  },
+  {
+    "code": "300636",
+    "name": "同和药业",
+    "market": "sz"
+  },
+  {
+    "code": "300637",
+    "name": "扬帆新材",
+    "market": "sz"
+  },
+  {
+    "code": "300638",
+    "name": "广和通",
+    "market": "sz"
+  },
+  {
+    "code": "300639",
+    "name": "凯普生物",
+    "market": "sz"
+  },
+  {
+    "code": "300640",
+    "name": "德艺文创",
+    "market": "sz"
+  },
+  {
+    "code": "300641",
+    "name": "正丹股份",
+    "market": "sz"
+  },
+  {
+    "code": "300642",
+    "name": "透景生命",
+    "market": "sz"
+  },
+  {
+    "code": "300643",
+    "name": "万通智控",
+    "market": "sz"
+  },
+  {
+    "code": "300644",
+    "name": "南京聚隆",
+    "market": "sz"
+  },
+  {
+    "code": "300645",
+    "name": "正元智慧",
+    "market": "sz"
+  },
+  {
+    "code": "300646",
+    "name": "侨源股份",
+    "market": "sz"
+  },
+  {
+    "code": "300647",
+    "name": "超频三",
+    "market": "sz"
+  },
+  {
+    "code": "300648",
+    "name": "星云股份",
+    "market": "sz"
+  },
+  {
+    "code": "300649",
+    "name": "杭州园林",
+    "market": "sz"
+  },
+  {
+    "code": "300650",
+    "name": "太龙股份",
+    "market": "sz"
+  },
+  {
+    "code": "300651",
+    "name": "金陵体育",
+    "market": "sz"
+  },
+  {
+    "code": "300652",
+    "name": "雷迪克",
+    "market": "sz"
+  },
+  {
+    "code": "300653",
+    "name": "正海生物",
+    "market": "sz"
+  },
+  {
+    "code": "300654",
+    "name": "世纪天鸿",
+    "market": "sz"
+  },
+  {
+    "code": "300655",
+    "name": "晶瑞电材",
+    "market": "sz"
+  },
+  {
+    "code": "300656",
+    "name": "民德电子",
+    "market": "sz"
+  },
+  {
+    "code": "300657",
+    "name": "弘信电子",
+    "market": "sz"
+  },
+  {
+    "code": "300658",
+    "name": "延江股份",
+    "market": "sz"
+  },
+  {
+    "code": "300659",
+    "name": "中孚信息",
+    "market": "sz"
+  },
+  {
+    "code": "300660",
+    "name": "江苏雷利",
+    "market": "sz"
+  },
+  {
+    "code": "300661",
+    "name": "圣邦股份",
+    "market": "sz"
+  },
+  {
+    "code": "300662",
+    "name": "科锐国际",
+    "market": "sz"
+  },
+  {
+    "code": "300663",
+    "name": "科蓝软件",
+    "market": "sz"
+  },
+  {
+    "code": "300664",
+    "name": "鹏鹞环保",
+    "market": "sz"
+  },
+  {
+    "code": "300665",
+    "name": "飞鹿股份",
+    "market": "sz"
+  },
+  {
+    "code": "300666",
+    "name": "江丰电子",
+    "market": "sz"
+  },
+  {
+    "code": "300667",
+    "name": "必创科技",
+    "market": "sz"
+  },
+  {
+    "code": "300668",
+    "name": "杰恩设计",
+    "market": "sz"
+  },
+  {
+    "code": "300669",
+    "name": "沪宁股份",
+    "market": "sz"
+  },
+  {
+    "code": "300670",
+    "name": "大烨智能",
+    "market": "sz"
+  },
+  {
+    "code": "300671",
+    "name": "富满电子",
+    "market": "sz"
+  },
+  {
+    "code": "300672",
+    "name": "国科微",
+    "market": "sz"
+  },
+  {
+    "code": "300673",
+    "name": "佩蒂股份",
+    "market": "sz"
+  },
+  {
+    "code": "300674",
+    "name": "宇信科技",
+    "market": "sz"
+  },
+  {
+    "code": "300675",
+    "name": "建科院",
+    "market": "sz"
+  },
+  {
+    "code": "300676",
+    "name": "华大基因",
+    "market": "sz"
+  },
+  {
+    "code": "300677",
+    "name": "英科医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300678",
+    "name": "中科信息",
+    "market": "sz"
+  },
+  {
+    "code": "300679",
+    "name": "电连技术",
+    "market": "sz"
+  },
+  {
+    "code": "300680",
+    "name": "隆盛科技",
+    "market": "sz"
+  },
+  {
+    "code": "300681",
+    "name": "英搏尔",
+    "market": "sz"
+  },
+  {
+    "code": "300682",
+    "name": "朗新科技",
+    "market": "sz"
+  },
+  {
+    "code": "300683",
+    "name": "海特生物",
+    "market": "sz"
+  },
+  {
+    "code": "300684",
+    "name": "中石科技",
+    "market": "sz"
+  },
+  {
+    "code": "300685",
+    "name": "艾德生物",
+    "market": "sz"
+  },
+  {
+    "code": "300686",
+    "name": "智动力",
+    "market": "sz"
+  },
+  {
+    "code": "300687",
+    "name": "赛意信息",
+    "market": "sz"
+  },
+  {
+    "code": "300688",
+    "name": "创业黑马",
+    "market": "sz"
+  },
+  {
+    "code": "300689",
+    "name": "澄天伟业",
+    "market": "sz"
+  },
+  {
+    "code": "300690",
+    "name": "双一科技",
+    "market": "sz"
+  },
+  {
+    "code": "300691",
+    "name": "联合光电",
+    "market": "sz"
+  },
+  {
+    "code": "300692",
+    "name": "中环环保",
+    "market": "sz"
+  },
+  {
+    "code": "300693",
+    "name": "盛弘股份",
+    "market": "sz"
+  },
+  {
+    "code": "300694",
+    "name": "蠡湖股份",
+    "market": "sz"
+  },
+  {
+    "code": "300695",
+    "name": "兆丰股份",
+    "market": "sz"
+  },
+  {
+    "code": "300696",
+    "name": "爱乐达",
+    "market": "sz"
+  },
+  {
+    "code": "300697",
+    "name": "电工合金",
+    "market": "sz"
+  },
+  {
+    "code": "300698",
+    "name": "万马科技",
+    "market": "sz"
+  },
+  {
+    "code": "300699",
+    "name": "光威复材",
+    "market": "sz"
+  },
+  {
+    "code": "300700",
+    "name": "岱勒新材",
+    "market": "sz"
+  },
+  {
+    "code": "300701",
+    "name": "森霸传感",
+    "market": "sz"
+  },
+  {
+    "code": "300702",
+    "name": "天宇股份",
+    "market": "sz"
+  },
+  {
+    "code": "300703",
+    "name": "创源股份",
+    "market": "sz"
+  },
+  {
+    "code": "300705",
+    "name": "九典制药",
+    "market": "sz"
+  },
+  {
+    "code": "300706",
+    "name": "阿石创",
+    "market": "sz"
+  },
+  {
+    "code": "300707",
+    "name": "威唐工业",
+    "market": "sz"
+  },
+  {
+    "code": "300708",
+    "name": "聚灿光电",
+    "market": "sz"
+  },
+  {
+    "code": "300709",
+    "name": "精研科技",
+    "market": "sz"
+  },
+  {
+    "code": "300710",
+    "name": "万隆光电",
+    "market": "sz"
+  },
+  {
+    "code": "300711",
+    "name": "广哈通信",
+    "market": "sz"
+  },
+  {
+    "code": "300712",
+    "name": "永福股份",
+    "market": "sz"
+  },
+  {
+    "code": "300713",
+    "name": "英可瑞",
+    "market": "sz"
+  },
+  {
+    "code": "300715",
+    "name": "凯伦股份",
+    "market": "sz"
+  },
+  {
+    "code": "300716",
+    "name": "国立科技",
+    "market": "sz"
+  },
+  {
+    "code": "300717",
+    "name": "华信新材",
+    "market": "sz"
+  },
+  {
+    "code": "300718",
+    "name": "长盛轴承",
+    "market": "sz"
+  },
+  {
+    "code": "300719",
+    "name": "安达维尔",
+    "market": "sz"
+  },
+  {
+    "code": "300720",
+    "name": "海川智能",
+    "market": "sz"
+  },
+  {
+    "code": "300721",
+    "name": "怡达股份",
+    "market": "sz"
+  },
+  {
+    "code": "300722",
+    "name": "新余国科",
+    "market": "sz"
+  },
+  {
+    "code": "300723",
+    "name": "一品红",
+    "market": "sz"
+  },
+  {
+    "code": "300724",
+    "name": "捷佳伟创",
+    "market": "sz"
+  },
+  {
+    "code": "300725",
+    "name": "药石科技",
+    "market": "sz"
+  },
+  {
+    "code": "300726",
+    "name": "宏达电子",
+    "market": "sz"
+  },
+  {
+    "code": "300727",
+    "name": "润禾材料",
+    "market": "sz"
+  },
+  {
+    "code": "300729",
+    "name": "乐歌股份",
+    "market": "sz"
+  },
+  {
+    "code": "300730",
+    "name": "科创信息",
+    "market": "sz"
+  },
+  {
+    "code": "300731",
+    "name": "科创新源",
+    "market": "sz"
+  },
+  {
+    "code": "300732",
+    "name": "设研院",
+    "market": "sz"
+  },
+  {
+    "code": "300733",
+    "name": "西菱动力",
+    "market": "sz"
+  },
+  {
+    "code": "300735",
+    "name": "光弘科技",
+    "market": "sz"
+  },
+  {
+    "code": "300736",
+    "name": "百邦科技",
+    "market": "sz"
+  },
+  {
+    "code": "300737",
+    "name": "科顺股份",
+    "market": "sz"
+  },
+  {
+    "code": "300738",
+    "name": "奥飞数据",
+    "market": "sz"
+  },
+  {
+    "code": "300739",
+    "name": "明阳电路",
+    "market": "sz"
+  },
+  {
+    "code": "300740",
+    "name": "水羊股份",
+    "market": "sz"
+  },
+  {
+    "code": "300741",
+    "name": "华宝股份",
+    "market": "sz"
+  },
+  {
+    "code": "300742",
+    "name": "越博动力",
+    "market": "sz"
+  },
+  {
+    "code": "300743",
+    "name": "天地数码",
+    "market": "sz"
+  },
+  {
+    "code": "300745",
+    "name": "欣锐科技",
+    "market": "sz"
+  },
+  {
+    "code": "300746",
+    "name": "汉嘉设计",
+    "market": "sz"
+  },
+  {
+    "code": "300747",
+    "name": "锐科激光",
+    "market": "sz"
+  },
+  {
+    "code": "300748",
+    "name": "金力永磁",
+    "market": "sz"
+  },
+  {
+    "code": "300749",
+    "name": "顶固集创",
+    "market": "sz"
+  },
+  {
+    "code": "300750",
+    "name": "宁德时代",
+    "market": "sz"
+  },
+  {
+    "code": "300751",
+    "name": "迈为股份",
+    "market": "sz"
+  },
+  {
+    "code": "300752",
+    "name": "隆利科技",
+    "market": "sz"
+  },
+  {
+    "code": "300753",
+    "name": "爱朋医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300755",
+    "name": "华致酒行",
+    "market": "sz"
+  },
+  {
+    "code": "300756",
+    "name": "中山金马",
+    "market": "sz"
+  },
+  {
+    "code": "300757",
+    "name": "罗博特科",
+    "market": "sz"
+  },
+  {
+    "code": "300758",
+    "name": "七彩化学",
+    "market": "sz"
+  },
+  {
+    "code": "300759",
+    "name": "康龙化成",
+    "market": "sz"
+  },
+  {
+    "code": "300760",
+    "name": "迈瑞医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300761",
+    "name": "立华股份",
+    "market": "sz"
+  },
+  {
+    "code": "300762",
+    "name": "上海瀚讯",
+    "market": "sz"
+  },
+  {
+    "code": "300763",
+    "name": "锦浪科技",
+    "market": "sz"
+  },
+  {
+    "code": "300765",
+    "name": "新诺威",
+    "market": "sz"
+  },
+  {
+    "code": "300766",
+    "name": "每日互动",
+    "market": "sz"
+  },
+  {
+    "code": "300767",
+    "name": "震安科技",
+    "market": "sz"
+  },
+  {
+    "code": "300768",
+    "name": "迪普科技",
+    "market": "sz"
+  },
+  {
+    "code": "300769",
+    "name": "德方纳米",
+    "market": "sz"
+  },
+  {
+    "code": "300770",
+    "name": "新媒股份",
+    "market": "sz"
+  },
+  {
+    "code": "300771",
+    "name": "智莱科技",
+    "market": "sz"
+  },
+  {
+    "code": "300772",
+    "name": "运达股份",
+    "market": "sz"
+  },
+  {
+    "code": "300773",
+    "name": "拉卡拉",
+    "market": "sz"
+  },
+  {
+    "code": "300774",
+    "name": "倍杰特",
+    "market": "sz"
+  },
+  {
+    "code": "300775",
+    "name": "三角防务",
+    "market": "sz"
+  },
+  {
+    "code": "300776",
+    "name": "帝尔激光",
+    "market": "sz"
+  },
+  {
+    "code": "300777",
+    "name": "中简科技",
+    "market": "sz"
+  },
+  {
+    "code": "300778",
+    "name": "新城市",
+    "market": "sz"
+  },
+  {
+    "code": "300779",
+    "name": "惠城环保",
+    "market": "sz"
+  },
+  {
+    "code": "300780",
+    "name": "德恩精工",
+    "market": "sz"
+  },
+  {
+    "code": "300781",
+    "name": "因赛集团",
+    "market": "sz"
+  },
+  {
+    "code": "300782",
+    "name": "卓胜微",
+    "market": "sz"
+  },
+  {
+    "code": "300783",
+    "name": "三只松鼠",
+    "market": "sz"
+  },
+  {
+    "code": "300785",
+    "name": "值得买",
+    "market": "sz"
+  },
+  {
+    "code": "300786",
+    "name": "国林科技",
+    "market": "sz"
+  },
+  {
+    "code": "300787",
+    "name": "海能实业",
+    "market": "sz"
+  },
+  {
+    "code": "300788",
+    "name": "中信出版",
+    "market": "sz"
+  },
+  {
+    "code": "300789",
+    "name": "唐源电气",
+    "market": "sz"
+  },
+  {
+    "code": "300790",
+    "name": "宇瞳光学",
+    "market": "sz"
+  },
+  {
+    "code": "300791",
+    "name": "仙乐健康",
+    "market": "sz"
+  },
+  {
+    "code": "300792",
+    "name": "壹网壹创",
+    "market": "sz"
+  },
+  {
+    "code": "300793",
+    "name": "佳禾智能",
+    "market": "sz"
+  },
+  {
+    "code": "300795",
+    "name": "米奥会展",
+    "market": "sz"
+  },
+  {
+    "code": "300796",
+    "name": "贝斯美",
+    "market": "sz"
+  },
+  {
+    "code": "300797",
+    "name": "钢研纳克",
+    "market": "sz"
+  },
+  {
+    "code": "300798",
+    "name": "锦鸡股份",
+    "market": "sz"
+  },
+  {
+    "code": "300799",
+    "name": "左江科技",
+    "market": "sz"
+  },
+  {
+    "code": "300800",
+    "name": "力合科技",
+    "market": "sz"
+  },
+  {
+    "code": "300801",
+    "name": "泰和科技",
+    "market": "sz"
+  },
+  {
+    "code": "300802",
+    "name": "矩子科技",
+    "market": "sz"
+  },
+  {
+    "code": "300803",
+    "name": "指南针",
+    "market": "sz"
+  },
+  {
+    "code": "300805",
+    "name": "电声股份",
+    "market": "sz"
+  },
+  {
+    "code": "300806",
+    "name": "斯迪克",
+    "market": "sz"
+  },
+  {
+    "code": "300807",
+    "name": "天迈科技",
+    "market": "sz"
+  },
+  {
+    "code": "300808",
+    "name": "久量股份",
+    "market": "sz"
+  },
+  {
+    "code": "300809",
+    "name": "华辰装备",
+    "market": "sz"
+  },
+  {
+    "code": "300810",
+    "name": "中科海讯",
+    "market": "sz"
+  },
+  {
+    "code": "300811",
+    "name": "铂科新材",
+    "market": "sz"
+  },
+  {
+    "code": "300812",
+    "name": "易天股份",
+    "market": "sz"
+  },
+  {
+    "code": "300813",
+    "name": "泰林生物",
+    "market": "sz"
+  },
+  {
+    "code": "300814",
+    "name": "中富电路",
+    "market": "sz"
+  },
+  {
+    "code": "300815",
+    "name": "玉禾田",
+    "market": "sz"
+  },
+  {
+    "code": "300816",
+    "name": "艾可蓝",
+    "market": "sz"
+  },
+  {
+    "code": "300817",
+    "name": "双飞股份",
+    "market": "sz"
+  },
+  {
+    "code": "300818",
+    "name": "耐普矿机",
+    "market": "sz"
+  },
+  {
+    "code": "300819",
+    "name": "聚杰微纤",
+    "market": "sz"
+  },
+  {
+    "code": "300820",
+    "name": "英杰电气",
+    "market": "sz"
+  },
+  {
+    "code": "300821",
+    "name": "东岳硅材",
+    "market": "sz"
+  },
+  {
+    "code": "300822",
+    "name": "贝仕达克",
+    "market": "sz"
+  },
+  {
+    "code": "300823",
+    "name": "建科机械",
+    "market": "sz"
+  },
+  {
+    "code": "300824",
+    "name": "北鼎股份",
+    "market": "sz"
+  },
+  {
+    "code": "300825",
+    "name": "阿尔特",
+    "market": "sz"
+  },
+  {
+    "code": "300826",
+    "name": "测绘股份",
+    "market": "sz"
+  },
+  {
+    "code": "300827",
+    "name": "上能电气",
+    "market": "sz"
+  },
+  {
+    "code": "300828",
+    "name": "锐新科技",
+    "market": "sz"
+  },
+  {
+    "code": "300829",
+    "name": "金丹科技",
+    "market": "sz"
+  },
+  {
+    "code": "300830",
+    "name": "金现代",
+    "market": "sz"
+  },
+  {
+    "code": "300831",
+    "name": "派瑞股份",
+    "market": "sz"
+  },
+  {
+    "code": "300832",
+    "name": "新产业",
+    "market": "sz"
+  },
+  {
+    "code": "300833",
+    "name": "浩洋股份",
+    "market": "sz"
+  },
+  {
+    "code": "300834",
+    "name": "星辉环材",
+    "market": "sz"
+  },
+  {
+    "code": "300835",
+    "name": "龙磁科技",
+    "market": "sz"
+  },
+  {
+    "code": "300836",
+    "name": "佰奥智能",
+    "market": "sz"
+  },
+  {
+    "code": "300837",
+    "name": "浙矿股份",
+    "market": "sz"
+  },
+  {
+    "code": "300838",
+    "name": "浙江力诺",
+    "market": "sz"
+  },
+  {
+    "code": "300839",
+    "name": "博汇股份",
+    "market": "sz"
+  },
+  {
+    "code": "300840",
+    "name": "酷特智能",
+    "market": "sz"
+  },
+  {
+    "code": "300841",
+    "name": "康华生物",
+    "market": "sz"
+  },
+  {
+    "code": "300842",
+    "name": "帝科股份",
+    "market": "sz"
+  },
+  {
+    "code": "300843",
+    "name": "胜蓝股份",
+    "market": "sz"
+  },
+  {
+    "code": "300844",
+    "name": "山水比德",
+    "market": "sz"
+  },
+  {
+    "code": "300845",
+    "name": "捷安高科",
+    "market": "sz"
+  },
+  {
+    "code": "300846",
+    "name": "首都在线",
+    "market": "sz"
+  },
+  {
+    "code": "300847",
+    "name": "中船汉光",
+    "market": "sz"
+  },
+  {
+    "code": "300848",
+    "name": "美瑞新材",
+    "market": "sz"
+  },
+  {
+    "code": "300849",
+    "name": "锦盛新材",
+    "market": "sz"
+  },
+  {
+    "code": "300850",
+    "name": "新强联",
+    "market": "sz"
+  },
+  {
+    "code": "300851",
+    "name": "交大思诺",
+    "market": "sz"
+  },
+  {
+    "code": "300852",
+    "name": "四会富仕",
+    "market": "sz"
+  },
+  {
+    "code": "300853",
+    "name": "申昊科技",
+    "market": "sz"
+  },
+  {
+    "code": "300854",
+    "name": "中兰环保",
+    "market": "sz"
+  },
+  {
+    "code": "300855",
+    "name": "图南股份",
+    "market": "sz"
+  },
+  {
+    "code": "300856",
+    "name": "科思股份",
+    "market": "sz"
+  },
+  {
+    "code": "300857",
+    "name": "协创数据",
+    "market": "sz"
+  },
+  {
+    "code": "300858",
+    "name": "科拓生物",
+    "market": "sz"
+  },
+  {
+    "code": "300859",
+    "name": "西域旅游",
+    "market": "sz"
+  },
+  {
+    "code": "300860",
+    "name": "锋尚文化",
+    "market": "sz"
+  },
+  {
+    "code": "300861",
+    "name": "美畅股份",
+    "market": "sz"
+  },
+  {
+    "code": "300862",
+    "name": "蓝盾光电",
+    "market": "sz"
+  },
+  {
+    "code": "300863",
+    "name": "卡倍亿",
+    "market": "sz"
+  },
+  {
+    "code": "300864",
+    "name": "南大环境",
+    "market": "sz"
+  },
+  {
+    "code": "300865",
+    "name": "大宏立",
+    "market": "sz"
+  },
+  {
+    "code": "300866",
+    "name": "安克创新",
+    "market": "sz"
+  },
+  {
+    "code": "300867",
+    "name": "圣元环保",
+    "market": "sz"
+  },
+  {
+    "code": "300868",
+    "name": "杰美特",
+    "market": "sz"
+  },
+  {
+    "code": "300869",
+    "name": "康泰医学",
+    "market": "sz"
+  },
+  {
+    "code": "300870",
+    "name": "欧陆通",
+    "market": "sz"
+  },
+  {
+    "code": "300871",
+    "name": "回盛生物",
+    "market": "sz"
+  },
+  {
+    "code": "300872",
+    "name": "天阳科技",
+    "market": "sz"
+  },
+  {
+    "code": "300873",
+    "name": "海晨股份",
+    "market": "sz"
+  },
+  {
+    "code": "300875",
+    "name": "捷强装备",
+    "market": "sz"
+  },
+  {
+    "code": "300876",
+    "name": "蒙泰高新",
+    "market": "sz"
+  },
+  {
+    "code": "300877",
+    "name": "金春股份",
+    "market": "sz"
+  },
+  {
+    "code": "300878",
+    "name": "维康药业",
+    "market": "sz"
+  },
+  {
+    "code": "300879",
+    "name": "大叶股份",
+    "market": "sz"
+  },
+  {
+    "code": "300880",
+    "name": "迦南智能",
+    "market": "sz"
+  },
+  {
+    "code": "300881",
+    "name": "盛德鑫泰",
+    "market": "sz"
+  },
+  {
+    "code": "300882",
+    "name": "万胜智能",
+    "market": "sz"
+  },
+  {
+    "code": "300883",
+    "name": "龙利得",
+    "market": "sz"
+  },
+  {
+    "code": "300884",
+    "name": "狄耐克",
+    "market": "sz"
+  },
+  {
+    "code": "300885",
+    "name": "海昌新材",
+    "market": "sz"
+  },
+  {
+    "code": "300886",
+    "name": "华业香料",
+    "market": "sz"
+  },
+  {
+    "code": "300887",
+    "name": "谱尼测试",
+    "market": "sz"
+  },
+  {
+    "code": "300888",
+    "name": "稳健医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300889",
+    "name": "爱克股份",
+    "market": "sz"
+  },
+  {
+    "code": "300890",
+    "name": "翔丰华",
+    "market": "sz"
+  },
+  {
+    "code": "300891",
+    "name": "惠云钛业",
+    "market": "sz"
+  },
+  {
+    "code": "300892",
+    "name": "品渥食品",
+    "market": "sz"
+  },
+  {
+    "code": "300893",
+    "name": "松原股份",
+    "market": "sz"
+  },
+  {
+    "code": "300894",
+    "name": "火星人",
+    "market": "sz"
+  },
+  {
+    "code": "300895",
+    "name": "铜牛信息",
+    "market": "sz"
+  },
+  {
+    "code": "300896",
+    "name": "爱美客",
+    "market": "sz"
+  },
+  {
+    "code": "300897",
+    "name": "山科智能",
+    "market": "sz"
+  },
+  {
+    "code": "300898",
+    "name": "熊猫乳品",
+    "market": "sz"
+  },
+  {
+    "code": "300900",
+    "name": "广联航空",
+    "market": "sz"
+  },
+  {
+    "code": "300901",
+    "name": "中胤时尚",
+    "market": "sz"
+  },
+  {
+    "code": "300902",
+    "name": "国安达",
+    "market": "sz"
+  },
+  {
+    "code": "300903",
+    "name": "科翔股份",
+    "market": "sz"
+  },
+  {
+    "code": "300904",
+    "name": "喜悦智行",
+    "market": "sz"
+  },
+  {
+    "code": "300905",
+    "name": "宝丽迪",
+    "market": "sz"
+  },
+  {
+    "code": "300906",
+    "name": "日月明",
+    "market": "sz"
+  },
+  {
+    "code": "300907",
+    "name": "康平科技",
+    "market": "sz"
+  },
+  {
+    "code": "300908",
+    "name": "仲景食品",
+    "market": "sz"
+  },
+  {
+    "code": "300909",
+    "name": "汇创达",
+    "market": "sz"
+  },
+  {
+    "code": "300910",
+    "name": "瑞丰新材",
+    "market": "sz"
+  },
+  {
+    "code": "300911",
+    "name": "亿田智能",
+    "market": "sz"
+  },
+  {
+    "code": "300912",
+    "name": "凯龙高科",
+    "market": "sz"
+  },
+  {
+    "code": "300913",
+    "name": "兆龙互连",
+    "market": "sz"
+  },
+  {
+    "code": "300915",
+    "name": "海融科技",
+    "market": "sz"
+  },
+  {
+    "code": "300916",
+    "name": "朗特智能",
+    "market": "sz"
+  },
+  {
+    "code": "300917",
+    "name": "特发服务",
+    "market": "sz"
+  },
+  {
+    "code": "300918",
+    "name": "南山智尚",
+    "market": "sz"
+  },
+  {
+    "code": "300919",
+    "name": "中伟股份",
+    "market": "sz"
+  },
+  {
+    "code": "300920",
+    "name": "润阳科技",
+    "market": "sz"
+  },
+  {
+    "code": "300921",
+    "name": "南凌科技",
+    "market": "sz"
+  },
+  {
+    "code": "300922",
+    "name": "天秦装备",
+    "market": "sz"
+  },
+  {
+    "code": "300923",
+    "name": "研奥股份",
+    "market": "sz"
+  },
+  {
+    "code": "300925",
+    "name": "法本信息",
+    "market": "sz"
+  },
+  {
+    "code": "300926",
+    "name": "博俊科技",
+    "market": "sz"
+  },
+  {
+    "code": "300927",
+    "name": "江天化学",
+    "market": "sz"
+  },
+  {
+    "code": "300928",
+    "name": "华安鑫创",
+    "market": "sz"
+  },
+  {
+    "code": "300929",
+    "name": "华骐环保",
+    "market": "sz"
+  },
+  {
+    "code": "300930",
+    "name": "屹通新材",
+    "market": "sz"
+  },
+  {
+    "code": "300931",
+    "name": "通用电梯",
+    "market": "sz"
+  },
+  {
+    "code": "300932",
+    "name": "三友联众",
+    "market": "sz"
+  },
+  {
+    "code": "300933",
+    "name": "中辰股份",
+    "market": "sz"
+  },
+  {
+    "code": "300934",
+    "name": "中英科技",
+    "market": "sz"
+  },
+  {
+    "code": "300935",
+    "name": "盈建科",
+    "market": "sz"
+  },
+  {
+    "code": "300936",
+    "name": "中英科技",
+    "market": "sz"
+  },
+  {
+    "code": "300937",
+    "name": "药易购",
+    "market": "sz"
+  },
+  {
+    "code": "300938",
+    "name": "信测标准",
+    "market": "sz"
+  },
+  {
+    "code": "300939",
+    "name": "秋田微",
+    "market": "sz"
+  },
+  {
+    "code": "300940",
+    "name": "南极光",
+    "market": "sz"
+  },
+  {
+    "code": "300941",
+    "name": "创识科技",
+    "market": "sz"
+  },
+  {
+    "code": "300942",
+    "name": "易瑞生物",
+    "market": "sz"
+  },
+  {
+    "code": "300943",
+    "name": "春晖智控",
+    "market": "sz"
+  },
+  {
+    "code": "300945",
+    "name": "曼卡龙",
+    "market": "sz"
+  },
+  {
+    "code": "300946",
+    "name": "恒而达",
+    "market": "sz"
+  },
+  {
+    "code": "300947",
+    "name": "德必集团",
+    "market": "sz"
+  },
+  {
+    "code": "300948",
+    "name": "冠中生态",
+    "market": "sz"
+  },
+  {
+    "code": "300949",
+    "name": "奥雅设计",
+    "market": "sz"
+  },
+  {
+    "code": "300950",
+    "name": "德固特",
+    "market": "sz"
+  },
+  {
+    "code": "300951",
+    "name": "博硕科技",
+    "market": "sz"
+  },
+  {
+    "code": "300952",
+    "name": "恒辉安防",
+    "market": "sz"
+  },
+  {
+    "code": "300953",
+    "name": "震裕科技",
+    "market": "sz"
+  },
+  {
+    "code": "300954",
+    "name": "华行天下",
+    "market": "sz"
+  },
+  {
+    "code": "300955",
+    "name": "嘉亨家化",
+    "market": "sz"
+  },
+  {
+    "code": "300956",
+    "name": "英力股份",
+    "market": "sz"
+  },
+  {
+    "code": "300957",
+    "name": "贝泰妮",
+    "market": "sz"
+  },
+  {
+    "code": "300958",
+    "name": "建工修复",
+    "market": "sz"
+  },
+  {
+    "code": "300959",
+    "name": "线上线下",
+    "market": "sz"
+  },
+  {
+    "code": "300960",
+    "name": "通业科技",
+    "market": "sz"
+  },
+  {
+    "code": "300961",
+    "name": "深水海纳",
+    "market": "sz"
+  },
+  {
+    "code": "300962",
+    "name": "中金辐照",
+    "market": "sz"
+  },
+  {
+    "code": "300963",
+    "name": "中洲特材",
+    "market": "sz"
+  },
+  {
+    "code": "300964",
+    "name": "本川智能",
+    "market": "sz"
+  },
+  {
+    "code": "300965",
+    "name": "恒宇信通",
+    "market": "sz"
+  },
+  {
+    "code": "300966",
+    "name": "共同药业",
+    "market": "sz"
+  },
+  {
+    "code": "300967",
+    "name": "晓鸣股份",
+    "market": "sz"
+  },
+  {
+    "code": "300968",
+    "name": "格林精密",
+    "market": "sz"
+  },
+  {
+    "code": "300969",
+    "name": "恒帅股份",
+    "market": "sz"
+  },
+  {
+    "code": "300970",
+    "name": "华绿生物",
+    "market": "sz"
+  },
+  {
+    "code": "300971",
+    "name": "博亚精工",
+    "market": "sz"
+  },
+  {
+    "code": "300972",
+    "name": "万辰生物",
+    "market": "sz"
+  },
+  {
+    "code": "300973",
+    "name": "立高食品",
+    "market": "sz"
+  },
+  {
+    "code": "300975",
+    "name": "商络电子",
+    "market": "sz"
+  },
+  {
+    "code": "300976",
+    "name": "达瑞电子",
+    "market": "sz"
+  },
+  {
+    "code": "300977",
+    "name": "深圳瑞捷",
+    "market": "sz"
+  },
+  {
+    "code": "300978",
+    "name": "东箭科技",
+    "market": "sz"
+  },
+  {
+    "code": "300979",
+    "name": "华利集团",
+    "market": "sz"
+  },
+  {
+    "code": "300980",
+    "name": "祥源新材",
+    "market": "sz"
+  },
+  {
+    "code": "300981",
+    "name": "中红医疗",
+    "market": "sz"
+  },
+  {
+    "code": "300982",
+    "name": "苏文电能",
+    "market": "sz"
+  },
+  {
+    "code": "300983",
+    "name": "尤安设计",
+    "market": "sz"
+  },
+  {
+    "code": "300984",
+    "name": "金沃股份",
+    "market": "sz"
+  },
+  {
+    "code": "300985",
+    "name": "致远新能",
+    "market": "sz"
+  },
+  {
+    "code": "300986",
+    "name": "志特新材",
+    "market": "sz"
+  },
+  {
+    "code": "300987",
+    "name": "川网传媒",
+    "market": "sz"
+  },
+  {
+    "code": "300988",
+    "name": "津荣天宇",
+    "market": "sz"
+  },
+  {
+    "code": "300989",
+    "name": "蕾奥规划",
+    "market": "sz"
+  },
+  {
+    "code": "300990",
+    "name": "同飞股份",
+    "market": "sz"
+  },
+  {
+    "code": "300991",
+    "name": "创益通",
+    "market": "sz"
+  },
+  {
+    "code": "300992",
+    "name": "泰福泵业",
+    "market": "sz"
+  },
+  {
+    "code": "300993",
+    "name": "玉马遮阳",
+    "market": "sz"
+  },
+  {
+    "code": "300994",
+    "name": "久祺股份",
+    "market": "sz"
+  },
+  {
+    "code": "300995",
+    "name": "奇德新材",
+    "market": "sz"
+  },
+  {
+    "code": "300996",
+    "name": "普联软件",
+    "market": "sz"
+  },
+  {
+    "code": "300997",
+    "name": "欢乐家",
+    "market": "sz"
+  },
+  {
+    "code": "300998",
+    "name": "宁波方正",
+    "market": "sz"
+  },
+  {
+    "code": "300999",
+    "name": "金龙鱼",
+    "market": "sz"
+  },
+  {
+    "code": "301000",
+    "name": "肇民科技",
+    "market": "sz"
+  },
+  {
+    "code": "301001",
+    "name": "凯淳股份",
+    "market": "sz"
+  },
+  {
+    "code": "301002",
+    "name": "崧盛股份",
+    "market": "sz"
+  },
+  {
+    "code": "301003",
+    "name": "江苏博云",
+    "market": "sz"
+  },
+  {
+    "code": "301004",
+    "name": "嘉益股份",
+    "market": "sz"
+  },
+  {
+    "code": "301005",
+    "name": "超捷股份",
+    "market": "sz"
+  },
+  {
+    "code": "301006",
+    "name": "迈拓股份",
+    "market": "sz"
+  },
+  {
+    "code": "301007",
+    "name": "德迈仕",
+    "market": "sz"
+  },
+  {
+    "code": "301008",
+    "name": "宏昌科技",
+    "market": "sz"
+  },
+  {
+    "code": "301009",
+    "name": "可靠股份",
+    "market": "sz"
+  },
+  {
+    "code": "301010",
+    "name": "晶雪节能",
+    "market": "sz"
+  },
+  {
+    "code": "301011",
+    "name": "华立科技",
+    "market": "sz"
+  },
+  {
+    "code": "301012",
+    "name": "扬电科技",
+    "market": "sz"
+  },
+  {
+    "code": "301013",
+    "name": "利和兴",
+    "market": "sz"
+  },
+  {
+    "code": "301015",
+    "name": "百洋医药",
+    "market": "sz"
+  },
+  {
+    "code": "301016",
+    "name": "雷尔伟",
+    "market": "sz"
+  },
+  {
+    "code": "301017",
+    "name": "漱玉平民",
+    "market": "sz"
+  },
+  {
+    "code": "301018",
+    "name": "申菱环境",
+    "market": "sz"
+  },
+  {
+    "code": "301019",
+    "name": "宁波色母",
+    "market": "sz"
+  },
+  {
+    "code": "301020",
+    "name": "密封科技",
+    "market": "sz"
+  },
+  {
+    "code": "301021",
+    "name": "英诺激光",
+    "market": "sz"
+  },
+  {
+    "code": "301022",
+    "name": "海泰科",
+    "market": "sz"
+  },
+  {
+    "code": "301023",
+    "name": "江南奕帆",
+    "market": "sz"
+  },
+  {
+    "code": "301024",
+    "name": "霍普股份",
+    "market": "sz"
+  },
+  {
+    "code": "301025",
+    "name": "读客文化",
+    "market": "sz"
+  },
+  {
+    "code": "301026",
+    "name": "浩通科技",
+    "market": "sz"
+  },
+  {
+    "code": "301027",
+    "name": "华蓝集团",
+    "market": "sz"
+  },
+  {
+    "code": "301028",
+    "name": "东亚机械",
+    "market": "sz"
+  },
+  {
+    "code": "301029",
+    "name": "怡合达",
+    "market": "sz"
+  },
+  {
+    "code": "301030",
+    "name": "仕净科技",
+    "market": "sz"
+  },
+  {
+    "code": "301031",
+    "name": "中熔电气",
+    "market": "sz"
+  },
+  {
+    "code": "301032",
+    "name": "新柴股份",
+    "market": "sz"
+  },
+  {
+    "code": "301033",
+    "name": "迈普医学",
+    "market": "sz"
+  },
+  {
+    "code": "301035",
+    "name": "润丰股份",
+    "market": "sz"
+  },
+  {
+    "code": "301036",
+    "name": "双乐股份",
+    "market": "sz"
+  },
+  {
+    "code": "301037",
+    "name": "保立佳",
+    "market": "sz"
+  },
+  {
+    "code": "301038",
+    "name": "深水规院",
+    "market": "sz"
+  },
+  {
+    "code": "301039",
+    "name": "中集车辆",
+    "market": "sz"
+  },
+  {
+    "code": "301040",
+    "name": "中环海陆",
+    "market": "sz"
+  },
+  {
+    "code": "301041",
+    "name": "金百泽",
+    "market": "sz"
+  },
+  {
+    "code": "301042",
+    "name": "安联锐视",
+    "market": "sz"
+  },
+  {
+    "code": "301043",
+    "name": "绿岛风",
+    "market": "sz"
+  },
+  {
+    "code": "301044",
+    "name": "运机集团",
+    "market": "sz"
+  },
+  {
+    "code": "301045",
+    "name": "天禄科技",
+    "market": "sz"
+  },
+  {
+    "code": "301046",
+    "name": "能辉科技",
+    "market": "sz"
+  },
+  {
+    "code": "301047",
+    "name": "义翘神州",
+    "market": "sz"
+  },
+  {
+    "code": "301048",
+    "name": "金鹰重工",
+    "market": "sz"
+  },
+  {
+    "code": "301049",
+    "name": "超越科技",
+    "market": "sz"
+  },
+  {
+    "code": "301050",
+    "name": "雷电微力",
+    "market": "sz"
+  },
+  {
+    "code": "301051",
+    "name": "信濠光电",
+    "market": "sz"
+  },
+  {
+    "code": "301052",
+    "name": "果麦文化",
+    "market": "sz"
+  },
+  {
+    "code": "301053",
+    "name": "远信工业",
+    "market": "sz"
+  },
+  {
+    "code": "301055",
+    "name": "张小泉",
+    "market": "sz"
+  },
+  {
+    "code": "301056",
+    "name": "森赫股份",
+    "market": "sz"
+  },
+  {
+    "code": "301057",
+    "name": "汇隆新材",
+    "market": "sz"
+  },
+  {
+    "code": "301058",
+    "name": "中粮工科",
+    "market": "sz"
+  },
+  {
+    "code": "301059",
+    "name": "金三江",
+    "market": "sz"
+  },
+  {
+    "code": "301060",
+    "name": "兰卫医学",
+    "market": "sz"
+  },
+  {
+    "code": "301061",
+    "name": "匠心家居",
+    "market": "sz"
+  },
+  {
+    "code": "301062",
+    "name": "上海艾录",
+    "market": "sz"
+  },
+  {
+    "code": "301063",
+    "name": "海锅股份",
+    "market": "sz"
+  },
+  {
+    "code": "301065",
+    "name": "本立科技",
+    "market": "sz"
+  },
+  {
+    "code": "301066",
+    "name": "万事利",
+    "market": "sz"
+  },
+  {
+    "code": "301067",
+    "name": "显盈科技",
+    "market": "sz"
+  },
+  {
+    "code": "301068",
+    "name": "大地海洋",
+    "market": "sz"
+  },
+  {
+    "code": "301069",
+    "name": "凯盛新材",
+    "market": "sz"
+  },
+  {
+    "code": "301070",
+    "name": "开勒股份",
+    "market": "sz"
+  },
+  {
+    "code": "301071",
+    "name": "力量钻石",
+    "market": "sz"
+  },
+  {
+    "code": "301072",
+    "name": "中捷精工",
+    "market": "sz"
+  },
+  {
+    "code": "301073",
+    "name": "君亭酒店",
+    "market": "sz"
+  },
+  {
+    "code": "301075",
+    "name": "多瑞医药",
+    "market": "sz"
+  },
+  {
+    "code": "301076",
+    "name": "新瀚新材",
+    "market": "sz"
+  },
+  {
+    "code": "301077",
+    "name": "星华反光",
+    "market": "sz"
+  },
+  {
+    "code": "301078",
+    "name": "孩子王",
+    "market": "sz"
+  },
+  {
+    "code": "301079",
+    "name": "邵阳液压",
+    "market": "sz"
+  },
+  {
+    "code": "301080",
+    "name": "百普赛斯",
+    "market": "sz"
+  },
+  {
+    "code": "301081",
+    "name": "严牌股份",
+    "market": "sz"
+  },
+  {
+    "code": "301082",
+    "name": "久盛电气",
+    "market": "sz"
+  },
+  {
+    "code": "301083",
+    "name": "百胜智能",
+    "market": "sz"
+  },
+  {
+    "code": "301085",
+    "name": "亚康股份",
+    "market": "sz"
+  },
+  {
+    "code": "301086",
+    "name": "鸿富瀚",
+    "market": "sz"
+  },
+  {
+    "code": "301087",
+    "name": "可孚医疗",
+    "market": "sz"
+  },
+  {
+    "code": "301088",
+    "name": "戎美股份",
+    "market": "sz"
+  },
+  {
+    "code": "301089",
+    "name": "拓新药业",
+    "market": "sz"
+  },
+  {
+    "code": "301090",
+    "name": "华润材料",
+    "market": "sz"
+  },
+  {
+    "code": "301091",
+    "name": "深城交",
+    "market": "sz"
+  },
+  {
+    "code": "301092",
+    "name": "争光股份",
+    "market": "sz"
+  },
+  {
+    "code": "301093",
+    "name": "华兰股份",
+    "market": "sz"
+  },
+  {
+    "code": "301095",
+    "name": "广脉科技",
+    "market": "sz"
+  },
+  {
+    "code": "301096",
+    "name": "百诚医药",
+    "market": "sz"
+  },
+  {
+    "code": "301097",
+    "name": "天益医疗",
+    "market": "sz"
+  },
+  {
+    "code": "301098",
+    "name": "金埔园林",
+    "market": "sz"
+  },
+  {
+    "code": "301099",
+    "name": "雅艺科技",
+    "market": "sz"
+  },
+  {
+    "code": "301100",
+    "name": "风光股份",
+    "market": "sz"
+  },
+  {
+    "code": "301101",
+    "name": "明月镜片",
+    "market": "sz"
+  },
+  {
+    "code": "301102",
+    "name": "兆讯传媒",
+    "market": "sz"
+  },
+  {
+    "code": "301103",
+    "name": "何氏眼科",
+    "market": "sz"
+  },
+  {
+    "code": "301105",
+    "name": "鸿铭股份",
+    "market": "sz"
+  },
+  {
+    "code": "301106",
+    "name": "骏成科技",
+    "market": "sz"
+  },
+  {
+    "code": "301107",
+    "name": "瑜欣电子",
+    "market": "sz"
+  },
+  {
+    "code": "301108",
+    "name": "洁雅股份",
+    "market": "sz"
+  },
+  {
+    "code": "301109",
+    "name": "军信股份",
+    "market": "sz"
+  },
+  {
+    "code": "301110",
+    "name": "青木股份",
+    "market": "sz"
+  },
+  {
+    "code": "301111",
+    "name": "粤万年青",
+    "market": "sz"
+  },
+  {
+    "code": "301112",
+    "name": "信邦智能",
+    "market": "sz"
+  },
+  {
+    "code": "301113",
+    "name": "雅艺科技",
+    "market": "sz"
+  },
+  {
+    "code": "301115",
+    "name": "建科股份",
+    "market": "sz"
+  },
+  {
+    "code": "301116",
+    "name": "益客食品",
+    "market": "sz"
+  },
+  {
+    "code": "301117",
+    "name": "佳缘科技",
+    "market": "sz"
+  },
+  {
+    "code": "301118",
+    "name": "恒光股份",
+    "market": "sz"
+  },
+  {
+    "code": "301119",
+    "name": "正强股份",
+    "market": "sz"
+  },
+  {
+    "code": "301120",
+    "name": "新特电气",
+    "market": "sz"
+  },
+  {
+    "code": "301121",
+    "name": "紫建电子",
+    "market": "sz"
+  },
+  {
+    "code": "301122",
+    "name": "采纳股份",
+    "market": "sz"
+  },
+  {
+    "code": "301123",
+    "name": "奕东电子",
+    "market": "sz"
+  },
+  {
+    "code": "301125",
+    "name": "腾亚精工",
+    "market": "sz"
+  },
+  {
+    "code": "301126",
+    "name": "达嘉维康",
+    "market": "sz"
+  },
+  {
+    "code": "301127",
+    "name": "天源环保",
+    "market": "sz"
+  },
+  {
+    "code": "301128",
+    "name": "强瑞技术",
+    "market": "sz"
+  },
+  {
+    "code": "301129",
+    "name": "瑞纳智能",
+    "market": "sz"
+  },
+  {
+    "code": "301130",
+    "name": "西点药业",
+    "market": "sz"
+  },
+  {
+    "code": "301131",
+    "name": "聚赛龙",
+    "market": "sz"
+  },
+  {
+    "code": "301132",
+    "name": "满坤科技",
+    "market": "sz"
+  },
+  {
+    "code": "301133",
+    "name": "金钟股份",
+    "market": "sz"
+  },
+  {
+    "code": "301135",
+    "name": "瑞德智能",
+    "market": "sz"
+  },
+  {
+    "code": "301136",
+    "name": "招标股份",
+    "market": "sz"
+  },
+  {
+    "code": "301137",
+    "name": "哈焊华通",
+    "market": "sz"
+  },
+  {
+    "code": "301138",
+    "name": "华研精机",
+    "market": "sz"
+  },
+  {
+    "code": "301139",
+    "name": "元道通信",
+    "market": "sz"
+  },
+  {
+    "code": "301141",
+    "name": "中科磁业",
+    "market": "sz"
+  },
+  {
+    "code": "301148",
+    "name": "嘉戎技术",
+    "market": "sz"
+  },
+  {
+    "code": "301149",
+    "name": "隆华新材",
+    "market": "sz"
+  },
+  {
+    "code": "301150",
+    "name": "中一科技",
+    "market": "sz"
+  },
+  {
+    "code": "301151",
+    "name": "冠龙节能",
+    "market": "sz"
+  },
+  {
+    "code": "301152",
+    "name": "天力锂能",
+    "market": "sz"
+  },
+  {
+    "code": "301153",
+    "name": "中科江南",
+    "market": "sz"
+  },
+  {
+    "code": "301155",
+    "name": "海力风电",
+    "market": "sz"
+  },
+  {
+    "code": "301156",
+    "name": "美农生物",
+    "market": "sz"
+  },
+  {
+    "code": "301157",
+    "name": "华塑科技",
+    "market": "sz"
+  },
+  {
+    "code": "301158",
+    "name": "德石股份",
+    "market": "sz"
+  },
+  {
+    "code": "301159",
+    "name": "三维天地",
+    "market": "sz"
+  },
+  {
+    "code": "301160",
+    "name": "翔楼新材",
+    "market": "sz"
+  },
+  {
+    "code": "301161",
+    "name": "唯万密封",
+    "market": "sz"
+  },
+  {
+    "code": "301162",
+    "name": "国能日新",
+    "market": "sz"
+  },
+  {
+    "code": "301163",
+    "name": "宏德股份",
+    "market": "sz"
+  },
+  {
+    "code": "301165",
+    "name": "锐捷网络",
+    "market": "sz"
+  },
+  {
+    "code": "301166",
+    "name": "优宁维",
+    "market": "sz"
+  },
+  {
+    "code": "301167",
+    "name": "建研设计",
+    "market": "sz"
+  },
+  {
+    "code": "301168",
+    "name": "通灵股份",
+    "market": "sz"
+  },
+  {
+    "code": "301169",
+    "name": "零点有数",
+    "market": "sz"
+  },
+  {
+    "code": "301170",
+    "name": "锡南科技",
+    "market": "sz"
+  },
+  {
+    "code": "301171",
+    "name": "易点天下",
+    "market": "sz"
+  },
+  {
+    "code": "301172",
+    "name": "君逸数码",
+    "market": "sz"
+  },
+  {
+    "code": "301175",
+    "name": "中科环保",
+    "market": "sz"
+  },
+  {
+    "code": "301176",
+    "name": "逸豪新材",
+    "market": "sz"
+  },
+  {
+    "code": "301177",
+    "name": "迪阿股份",
+    "market": "sz"
+  },
+  {
+    "code": "301178",
+    "name": "天亿马",
+    "market": "sz"
+  },
+  {
+    "code": "301179",
+    "name": "泽宇智能",
+    "market": "sz"
+  },
+  {
+    "code": "301180",
+    "name": "万祥科技",
+    "market": "sz"
+  },
+  {
+    "code": "301181",
+    "name": "标榜股份",
+    "market": "sz"
+  },
+  {
+    "code": "301182",
+    "name": "凯旺科技",
+    "market": "sz"
+  },
+  {
+    "code": "301183",
+    "name": "东田微",
+    "market": "sz"
+  },
+  {
+    "code": "301185",
+    "name": "鸥玛软件",
+    "market": "sz"
+  },
+  {
+    "code": "301186",
+    "name": "超达装备",
+    "market": "sz"
+  },
+  {
+    "code": "301187",
+    "name": "欧圣电气",
+    "market": "sz"
+  },
+  {
+    "code": "301188",
+    "name": "力诺特玻",
+    "market": "sz"
+  },
+  {
+    "code": "301189",
+    "name": "奥尼电子",
+    "market": "sz"
+  },
+  {
+    "code": "301190",
+    "name": "善水科技",
+    "market": "sz"
+  },
+  {
+    "code": "301191",
+    "name": "菲菱科思",
+    "market": "sz"
+  },
+  {
+    "code": "301192",
+    "name": "泰祥股份",
+    "market": "sz"
+  },
+  {
+    "code": "301193",
+    "name": "家联科技",
+    "market": "sz"
+  },
+  {
+    "code": "301195",
+    "name": "北路智控",
+    "market": "sz"
+  },
+  {
+    "code": "301196",
+    "name": "唯科科技",
+    "market": "sz"
+  },
+  {
+    "code": "301197",
+    "name": "工大科雅",
+    "market": "sz"
+  },
+  {
+    "code": "301198",
+    "name": "喜悦智行",
+    "market": "sz"
+  },
+  {
+    "code": "301199",
+    "name": "迈赫股份",
+    "market": "sz"
+  },
+  {
+    "code": "301200",
+    "name": "大族数控",
+    "market": "sz"
+  },
+  {
+    "code": "301201",
+    "name": "诚达药业",
+    "market": "sz"
+  },
+  {
+    "code": "301202",
+    "name": "朗威股份",
+    "market": "sz"
+  },
+  {
+    "code": "301203",
+    "name": "国泰环保",
+    "market": "sz"
+  },
+  {
+    "code": "301205",
+    "name": "联特科技",
+    "market": "sz"
+  },
+  {
+    "code": "301206",
+    "name": "三元生物",
+    "market": "sz"
+  },
+  {
+    "code": "301207",
+    "name": "华兰疫苗",
+    "market": "sz"
+  },
+  {
+    "code": "301208",
+    "name": "中亦科技",
+    "market": "sz"
+  },
+  {
+    "code": "301209",
+    "name": "联合化学",
+    "market": "sz"
+  },
+  {
+    "code": "301210",
+    "name": "金杨股份",
+    "market": "sz"
+  },
+  {
+    "code": "301211",
+    "name": "亨迪药业",
+    "market": "sz"
+  },
+  {
+    "code": "301212",
+    "name": "联盛化学",
+    "market": "sz"
+  },
+  {
+    "code": "301213",
+    "name": "观想科技",
+    "market": "sz"
+  },
+  {
+    "code": "301215",
+    "name": "中汽股份",
+    "market": "sz"
+  },
+  {
+    "code": "301216",
+    "name": "万凯新材",
+    "market": "sz"
+  },
+  {
+    "code": "301217",
+    "name": "铜冠铜箔",
+    "market": "sz"
+  },
+  {
+    "code": "301218",
+    "name": "华是科技",
+    "market": "sz"
+  },
+  {
+    "code": "301219",
+    "name": "腾远钴业",
+    "market": "sz"
+  },
+  {
+    "code": "301220",
+    "name": "亚香股份",
+    "market": "sz"
+  },
+  {
+    "code": "301221",
+    "name": "光庭信息",
+    "market": "sz"
+  },
+  {
+    "code": "301222",
+    "name": "浙江恒威",
+    "market": "sz"
+  },
+  {
+    "code": "301223",
+    "name": "中荣股份",
+    "market": "sz"
+  },
+  {
+    "code": "301225",
+    "name": "恒勃股份",
+    "market": "sz"
+  },
+  {
+    "code": "301226",
+    "name": "祥明智能",
+    "market": "sz"
+  },
+  {
+    "code": "301227",
+    "name": "森鹰窗业",
+    "market": "sz"
+  },
+  {
+    "code": "301228",
+    "name": "实朴检测",
+    "market": "sz"
+  },
+  {
+    "code": "301229",
+    "name": "纽泰格",
+    "market": "sz"
+  },
+  {
+    "code": "301230",
+    "name": "泓博医药",
+    "market": "sz"
+  },
+  {
+    "code": "301231",
+    "name": "荣信文化",
+    "market": "sz"
+  },
+  {
+    "code": "301232",
+    "name": "飞沃科技",
+    "market": "sz"
+  },
+  {
+    "code": "301233",
+    "name": "盛帮股份",
+    "market": "sz"
+  },
+  {
+    "code": "301234",
+    "name": "五洲医疗",
+    "market": "sz"
+  },
+  {
+    "code": "301235",
+    "name": "华康医疗",
+    "market": "sz"
+  },
+  {
+    "code": "301236",
+    "name": "软通动力",
+    "market": "sz"
+  },
+  {
+    "code": "301237",
+    "name": "和顺科技",
+    "market": "sz"
+  },
+  {
+    "code": "301238",
+    "name": "瑞泰新材",
+    "market": "sz"
+  },
+  {
+    "code": "301239",
+    "name": "普瑞眼科",
+    "market": "sz"
+  },
+  {
+    "code": "301246",
+    "name": "宏源药业",
+    "market": "sz"
+  },
+  {
+    "code": "301248",
+    "name": "杰创智能",
+    "market": "sz"
+  },
+  {
+    "code": "301256",
+    "name": "华融化学",
+    "market": "sz"
+  },
+  {
+    "code": "301258",
+    "name": "富士莱",
+    "market": "sz"
+  },
+  {
+    "code": "301259",
+    "name": "艾布鲁",
+    "market": "sz"
+  },
+  {
+    "code": "301260",
+    "name": "格力博",
+    "market": "sz"
+  },
+  {
+    "code": "301261",
+    "name": "恒工精密",
+    "market": "sz"
+  },
+  {
+    "code": "301262",
+    "name": "海看股份",
+    "market": "sz"
+  },
+  {
+    "code": "301263",
+    "name": "泰恩康",
+    "market": "sz"
+  },
+  {
+    "code": "301265",
+    "name": "华大九天",
+    "market": "sz"
+  },
+  {
+    "code": "301266",
+    "name": "宇邦新材",
+    "market": "sz"
+  },
+  {
+    "code": "301267",
+    "name": "华厦眼科",
+    "market": "sz"
+  },
+  {
+    "code": "301268",
+    "name": "铭利达",
+    "market": "sz"
+  },
+  {
+    "code": "301269",
+    "name": "华大九天",
+    "market": "sz"
+  },
+  {
+    "code": "301270",
+    "name": "汉仪股份",
+    "market": "sz"
+  },
+  {
+    "code": "301272",
+    "name": "英华特",
+    "market": "sz"
+  },
+  {
+    "code": "301273",
+    "name": "瑞晨环保",
+    "market": "sz"
+  },
+  {
+    "code": "301276",
+    "name": "嘉曼服饰",
+    "market": "sz"
+  },
+  {
+    "code": "301277",
+    "name": "新天地",
+    "market": "sz"
+  },
+  {
+    "code": "301278",
+    "name": "快可电子",
+    "market": "sz"
+  },
+  {
+    "code": "301279",
+    "name": "金道科技",
+    "market": "sz"
+  },
+  {
+    "code": "301280",
+    "name": "珠城科技",
+    "market": "sz"
+  },
+  {
+    "code": "301281",
+    "name": "科源制药",
+    "market": "sz"
+  },
+  {
+    "code": "301282",
+    "name": "华盛锂电",
+    "market": "sz"
+  },
+  {
+    "code": "301283",
+    "name": "聚胶股份",
+    "market": "sz"
+  },
+  {
+    "code": "301285",
+    "name": "鸿日达",
+    "market": "sz"
+  },
+  {
+    "code": "301286",
+    "name": "侨源股份",
+    "market": "sz"
+  },
+  {
+    "code": "301287",
+    "name": "康力源",
+    "market": "sz"
+  },
+  {
+    "code": "301288",
+    "name": "清研环境",
+    "market": "sz"
+  },
+  {
+    "code": "301289",
+    "name": "建研设计",
+    "market": "sz"
+  },
+  {
+    "code": "301290",
+    "name": "东星医疗",
+    "market": "sz"
+  },
+  {
+    "code": "301291",
+    "name": "明阳电气",
+    "market": "sz"
+  },
+  {
+    "code": "301292",
+    "name": "海科新源",
+    "market": "sz"
+  },
+  {
+    "code": "301293",
+    "name": "三博脑科",
+    "market": "sz"
+  },
+  {
+    "code": "301295",
+    "name": "美硕科技",
+    "market": "sz"
+  },
+  {
+    "code": "301296",
+    "name": "新巨丰",
+    "market": "sz"
+  },
+  {
+    "code": "301297",
+    "name": "富乐德",
+    "market": "sz"
+  },
+  {
+    "code": "301298",
+    "name": "东利机械",
+    "market": "sz"
+  },
+  {
+    "code": "301299",
+    "name": "卓创资讯",
+    "market": "sz"
+  },
+  {
+    "code": "301300",
+    "name": "远翔新材",
+    "market": "sz"
+  },
+  {
+    "code": "301301",
+    "name": "川宁生物",
+    "market": "sz"
+  },
+  {
+    "code": "301302",
+    "name": "华如科技",
+    "market": "sz"
+  },
+  {
+    "code": "301303",
+    "name": "真兰仪表",
+    "market": "sz"
+  },
+  {
+    "code": "301305",
+    "name": "朗坤环境",
+    "market": "sz"
+  },
+  {
+    "code": "301306",
+    "name": "西测测试",
+    "market": "sz"
+  },
+  {
+    "code": "301307",
+    "name": "美利信",
+    "market": "sz"
+  },
+  {
+    "code": "301308",
+    "name": "江波龙",
+    "market": "sz"
+  },
+  {
+    "code": "301309",
+    "name": "万得凯",
+    "market": "sz"
+  },
+  {
+    "code": "301310",
+    "name": "鑫宏业",
+    "market": "sz"
+  },
+  {
+    "code": "301311",
+    "name": "昆船智能",
+    "market": "sz"
+  },
+  {
+    "code": "301312",
+    "name": "智立方",
+    "market": "sz"
+  },
+  {
+    "code": "301313",
+    "name": "凡拓数创",
+    "market": "sz"
+  },
+  {
+    "code": "301314",
+    "name": "科瑞思",
+    "market": "sz"
+  },
+  {
+    "code": "301315",
+    "name": "威士顿",
+    "market": "sz"
+  },
+  {
+    "code": "301316",
+    "name": "慧博云通",
+    "market": "sz"
+  },
+  {
+    "code": "301317",
+    "name": "鑫磊股份",
+    "market": "sz"
+  },
+  {
+    "code": "301318",
+    "name": "维海德",
+    "market": "sz"
+  },
+  {
+    "code": "301319",
+    "name": "唯特偶",
+    "market": "sz"
+  },
+  {
+    "code": "301320",
+    "name": "豪江智能",
+    "market": "sz"
+  },
+  {
+    "code": "301321",
+    "name": "翰博高新",
+    "market": "sz"
+  },
+  {
+    "code": "301322",
+    "name": "绿通科技",
+    "market": "sz"
+  },
+  {
+    "code": "301323",
+    "name": "蓝天燃气",
+    "market": "sz"
+  },
+  {
+    "code": "301325",
+    "name": "曼恩斯特",
+    "market": "sz"
+  },
+  {
+    "code": "301326",
+    "name": "捷邦科技",
+    "market": "sz"
+  },
+  {
+    "code": "301327",
+    "name": "华宝新能",
+    "market": "sz"
+  },
+  {
+    "code": "301328",
+    "name": "维峰电子",
+    "market": "sz"
+  },
+  {
+    "code": "301329",
+    "name": "信音电子",
+    "market": "sz"
+  },
+  {
+    "code": "301330",
+    "name": "熵基科技",
+    "market": "sz"
+  },
+  {
+    "code": "301331",
+    "name": "恩威医药",
+    "market": "sz"
+  },
+  {
+    "code": "301332",
+    "name": "德尔玛",
+    "market": "sz"
+  },
+  {
+    "code": "301333",
+    "name": "诺思格",
+    "market": "sz"
+  },
+  {
+    "code": "301335",
+    "name": "天元宠物",
+    "market": "sz"
+  },
+  {
+    "code": "301336",
+    "name": "趣睡科技",
+    "market": "sz"
+  },
+  {
+    "code": "301337",
+    "name": "亚华电子",
+    "market": "sz"
+  },
+  {
+    "code": "301338",
+    "name": "凯格精机",
+    "market": "sz"
+  },
+  {
+    "code": "301339",
+    "name": "通行宝",
+    "market": "sz"
+  },
+  {
+    "code": "301345",
+    "name": "涛涛车业",
+    "market": "sz"
+  },
+  {
+    "code": "301348",
+    "name": "蓝箭电子",
+    "market": "sz"
+  },
+  {
+    "code": "301349",
+    "name": "信德新材",
+    "market": "sz"
+  },
+  {
+    "code": "301353",
+    "name": "普莱得",
+    "market": "sz"
+  },
+  {
+    "code": "301355",
+    "name": "南王科技",
+    "market": "sz"
+  },
+  {
+    "code": "301356",
+    "name": "天振股份",
+    "market": "sz"
+  },
+  {
+    "code": "301357",
+    "name": "北方长龙",
+    "market": "sz"
+  },
+  {
+    "code": "301358",
+    "name": "湖南裕能",
+    "market": "sz"
+  },
+  {
+    "code": "301359",
+    "name": "东南电子",
+    "market": "sz"
+  },
+  {
+    "code": "301360",
+    "name": "荣旗科技",
+    "market": "sz"
+  },
+  {
+    "code": "301361",
+    "name": "众智科技",
+    "market": "sz"
+  },
+  {
+    "code": "301362",
+    "name": "国泰环保",
+    "market": "sz"
+  },
+  {
+    "code": "301363",
+    "name": "美好医疗",
+    "market": "sz"
+  },
+  {
+    "code": "301365",
+    "name": "矩阵股份",
+    "market": "sz"
+  },
+  {
+    "code": "301366",
+    "name": "一博科技",
+    "market": "sz"
+  },
+  {
+    "code": "301367",
+    "name": "怡和嘉业",
+    "market": "sz"
+  },
+  {
+    "code": "301368",
+    "name": "丰立智能",
+    "market": "sz"
+  },
+  {
+    "code": "301369",
+    "name": "联动科技",
+    "market": "sz"
+  },
+  {
+    "code": "301371",
+    "name": "敷尔佳",
+    "market": "sz"
+  },
+  {
+    "code": "301372",
+    "name": "通达海",
+    "market": "sz"
+  },
+  {
+    "code": "301373",
+    "name": "凌玮科技",
+    "market": "sz"
+  },
+  {
+    "code": "301376",
+    "name": "致欧科技",
+    "market": "sz"
+  },
+  {
+    "code": "301377",
+    "name": "鼎泰高科",
+    "market": "sz"
+  },
+  {
+    "code": "301378",
+    "name": "通达海",
+    "market": "sz"
+  },
+  {
+    "code": "301379",
+    "name": "天山电子",
+    "market": "sz"
+  },
+  {
+    "code": "301380",
+    "name": "挖金客",
+    "market": "sz"
+  },
+  {
+    "code": "301381",
+    "name": "赛维时代",
+    "market": "sz"
+  },
+  {
+    "code": "301382",
+    "name": "蜂助手",
+    "market": "sz"
+  },
+  {
+    "code": "301383",
+    "name": "天键股份",
+    "market": "sz"
+  },
+  {
+    "code": "301386",
+    "name": "未来电器",
+    "market": "sz"
+  },
+  {
+    "code": "301387",
+    "name": "光大同创",
+    "market": "sz"
+  },
+  {
+    "code": "301388",
+    "name": "恒伟科技",
+    "market": "sz"
+  },
+  {
+    "code": "301389",
+    "name": "隆扬电子",
+    "market": "sz"
+  },
+  {
+    "code": "301390",
+    "name": "经纬股份",
+    "market": "sz"
+  },
+  {
+    "code": "301391",
+    "name": "卡莱特",
+    "market": "sz"
+  },
+  {
+    "code": "301393",
+    "name": "昊帆生物",
+    "market": "sz"
+  },
+  {
+    "code": "301395",
+    "name": "仁信新材",
+    "market": "sz"
+  },
+  {
+    "code": "301396",
+    "name": "宏景科技",
+    "market": "sz"
+  },
+  {
+    "code": "301397",
+    "name": "溯联股份",
+    "market": "sz"
+  },
+  {
+    "code": "301398",
+    "name": "星源卓镁",
+    "market": "sz"
+  },
+  {
+    "code": "301399",
+    "name": "英特科技",
+    "market": "sz"
+  },
+  {
+    "code": "301408",
+    "name": "华虹计通",
+    "market": "sz"
+  },
+  {
+    "code": "301418",
+    "name": "协昌科技",
+    "market": "sz"
+  },
+  {
+    "code": "301419",
+    "name": "阿莱德",
+    "market": "sz"
+  },
+  {
+    "code": "301421",
+    "name": "波长光电",
+    "market": "sz"
+  },
+  {
+    "code": "301428",
+    "name": "世纪恒通",
+    "market": "sz"
+  },
+  {
+    "code": "301429",
+    "name": "森泰股份",
+    "market": "sz"
+  },
+  {
+    "code": "301439",
+    "name": "泓淋电力",
+    "market": "sz"
+  },
+  {
+    "code": "301446",
+    "name": "福事特",
+    "market": "sz"
+  },
+  {
+    "code": "301448",
+    "name": "开创电气",
+    "market": "sz"
+  },
+  {
+    "code": "301456",
+    "name": "盘古智能",
+    "market": "sz"
+  },
+  {
+    "code": "301486",
+    "name": "致尚科技",
+    "market": "sz"
+  },
+  {
+    "code": "301487",
+    "name": "盟固利",
+    "market": "sz"
+  },
+  {
+    "code": "301488",
+    "name": "豪恩汽电",
+    "market": "sz"
+  },
+  {
+    "code": "301498",
+    "name": "乖宝宠物",
+    "market": "sz"
+  },
+  {
+    "code": "301499",
+    "name": "维科精密",
+    "market": "sz"
+  },
+  {
+    "code": "301500",
+    "name": "飞南资源",
+    "market": "sz"
+  },
+  {
+    "code": "301502",
+    "name": "华阳智能",
+    "market": "sz"
+  },
+  {
+    "code": "301503",
+    "name": "智迪科技",
+    "market": "sz"
+  },
+  {
+    "code": "301505",
+    "name": "苏州规划",
+    "market": "sz"
+  },
+  {
+    "code": "301507",
+    "name": "民生健康",
+    "market": "sz"
+  },
+  {
+    "code": "301508",
+    "name": "中机认检",
+    "market": "sz"
+  },
+  {
+    "code": "301509",
+    "name": "金凯生科",
+    "market": "sz"
+  },
+  {
+    "code": "301510",
+    "name": "固高科技",
+    "market": "sz"
+  },
+  {
+    "code": "301511",
+    "name": "德福科技",
+    "market": "sz"
+  },
+  {
+    "code": "301512",
+    "name": "智能控制",
+    "market": "sz"
+  },
+  {
+    "code": "301515",
+    "name": "港通医疗",
+    "market": "sz"
+  },
+  {
+    "code": "301516",
+    "name": "中远通",
+    "market": "sz"
+  },
+  {
+    "code": "301517",
+    "name": "陕西华达",
+    "market": "sz"
+  },
+  {
+    "code": "301518",
+    "name": "长华化学",
+    "market": "sz"
+  },
+  {
+    "code": "301519",
+    "name": "舜禹股份",
+    "market": "sz"
+  },
+  {
+    "code": "301520",
+    "name": "万邦医药",
+    "market": "sz"
+  },
+  {
+    "code": "301525",
+    "name": "儒竞科技",
+    "market": "sz"
+  },
+  {
+    "code": "301526",
+    "name": "国际复材",
+    "market": "sz"
+  },
+  {
+    "code": "301528",
+    "name": "多浦乐",
+    "market": "sz"
+  },
+  {
+    "code": "301529",
+    "name": "福赛科技",
+    "market": "sz"
+  },
+  {
+    "code": "301533",
+    "name": "威马农机",
+    "market": "sz"
+  },
+  {
+    "code": "301538",
+    "name": "骏鼎达",
+    "market": "sz"
+  },
+  {
+    "code": "301539",
+    "name": "宏鑫科技",
+    "market": "sz"
+  },
+  {
+    "code": "301548",
+    "name": "崇德科技",
+    "market": "sz"
+  },
+  {
+    "code": "301550",
+    "name": "斯菱股份",
+    "market": "sz"
+  },
+  {
+    "code": "301555",
+    "name": "惠柏新材",
+    "market": "sz"
+  },
+  {
+    "code": "301558",
+    "name": "三态股份",
+    "market": "sz"
+  },
+  {
+    "code": "301559",
+    "name": "中集环科",
+    "market": "sz"
+  },
+  {
+    "code": "301565",
+    "name": "中仑新材",
+    "market": "sz"
+  },
+  {
+    "code": "301566",
+    "name": "达利凯普",
+    "market": "sz"
+  },
+  {
+    "code": "301567",
+    "name": "贝隆精密",
+    "market": "sz"
+  },
+  {
+    "code": "301568",
+    "name": "思泰克",
+    "market": "sz"
+  },
+  {
+    "code": "301577",
+    "name": "美信科技",
+    "market": "sz"
+  },
+  {
+    "code": "301578",
+    "name": "辰奕智能",
+    "market": "sz"
+  },
+  {
+    "code": "301580",
+    "name": "爱迪特",
+    "market": "sz"
+  },
+  {
+    "code": "301586",
+    "name": "佳力奇",
+    "market": "sz"
+  },
+  {
+    "code": "301587",
+    "name": "中瑞股份",
+    "market": "sz"
+  },
+  {
+    "code": "301588",
+    "name": "新特电气",
+    "market": "sz"
+  },
+  {
+    "code": "301589",
+    "name": "诺瓦星云",
+    "market": "sz"
+  },
+  {
+    "code": "301591",
+    "name": "肯特股份",
+    "market": "sz"
+  },
+  {
+    "code": "301596",
+    "name": "瑞迪智驱",
+    "market": "sz"
+  },
+  {
+    "code": "301600",
+    "name": "慧翰股份",
+    "market": "sz"
+  },
+  {
+    "code": "301601",
+    "name": "朗鸿科技",
+    "market": "sz"
+  },
+  {
+    "code": "301602",
+    "name": "博实结",
+    "market": "sz"
+  },
+  {
+    "code": "301603",
+    "name": "乔锋智能",
+    "market": "sz"
+  },
+  {
+    "code": "301606",
+    "name": "绿联科技",
+    "market": "sz"
+  },
+  {
+    "code": "301607",
+    "name": "富特科技",
+    "market": "sz"
+  },
+  {
+    "code": "301608",
+    "name": "博实结",
+    "market": "sz"
+  },
+  {
+    "code": "301611",
+    "name": "珂玛科技",
+    "market": "sz"
+  },
+  {
+    "code": "301613",
+    "name": "新铝时代",
+    "market": "sz"
+  },
+  {
+    "code": "301618",
+    "name": "长联科技",
+    "market": "sz"
+  },
+  {
+    "code": "301622",
+    "name": "瑞华技术",
+    "market": "sz"
+  },
+  {
+    "code": "301625",
+    "name": "金禄电子",
+    "market": "sz"
+  },
+  {
+    "code": "301626",
+    "name": "苏州天脉",
+    "market": "sz"
+  },
+  {
+    "code": "301628",
+    "name": "强达电路",
+    "market": "sz"
+  },
+  {
+    "code": "301631",
+    "name": "壹连科技",
+    "market": "sz"
+  },
+  {
+    "code": "301633",
+    "name": "港迪技术",
+    "market": "sz"
+  },
+  {
+    "code": "301636",
+    "name": "音飞储存",
+    "market": "sz"
+  },
+  {
+    "code": "301637",
+    "name": "宁波华翔",
+    "market": "sz"
+  },
+  {
+    "code": "688001",
+    "name": "华兴源创",
+    "market": "sh"
+  },
+  {
+    "code": "688002",
+    "name": "睿创微纳",
+    "market": "sh"
+  },
+  {
+    "code": "688003",
+    "name": "天准科技",
+    "market": "sh"
+  },
+  {
+    "code": "688005",
+    "name": "容百科技",
+    "market": "sh"
+  },
+  {
+    "code": "688006",
+    "name": "杭可科技",
+    "market": "sh"
+  },
+  {
+    "code": "688007",
+    "name": "光峰科技",
+    "market": "sh"
+  },
+  {
+    "code": "688008",
+    "name": "澜起科技",
+    "market": "sh"
+  },
+  {
+    "code": "688009",
+    "name": "中国通号",
+    "market": "sh"
+  },
+  {
+    "code": "688010",
+    "name": "福光股份",
+    "market": "sh"
+  },
+  {
+    "code": "688011",
+    "name": "新光光电",
+    "market": "sh"
+  },
+  {
+    "code": "688012",
+    "name": "中微公司",
+    "market": "sh"
+  },
+  {
+    "code": "688013",
+    "name": "天奈科技",
+    "market": "sh"
+  },
+  {
+    "code": "688015",
+    "name": "交控科技",
+    "market": "sh"
+  },
+  {
+    "code": "688016",
+    "name": "心脉医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688017",
+    "name": "绿的谐波",
+    "market": "sh"
+  },
+  {
+    "code": "688018",
+    "name": "乐鑫科技",
+    "market": "sh"
+  },
+  {
+    "code": "688019",
+    "name": "安集科技",
+    "market": "sh"
+  },
+  {
+    "code": "688020",
+    "name": "方邦股份",
+    "market": "sh"
+  },
+  {
+    "code": "688021",
+    "name": "奥福环保",
+    "market": "sh"
+  },
+  {
+    "code": "688022",
+    "name": "瀚川智能",
+    "market": "sh"
+  },
+  {
+    "code": "688023",
+    "name": "安恒信息",
+    "market": "sh"
+  },
+  {
+    "code": "688025",
+    "name": "杰普特",
+    "market": "sh"
+  },
+  {
+    "code": "688026",
+    "name": "洁特生物",
+    "market": "sh"
+  },
+  {
+    "code": "688027",
+    "name": "国盾量子",
+    "market": "sh"
+  },
+  {
+    "code": "688028",
+    "name": "沃尔德",
+    "market": "sh"
+  },
+  {
+    "code": "688029",
+    "name": "南微医学",
+    "market": "sh"
+  },
+  {
+    "code": "688030",
+    "name": "山石网科",
+    "market": "sh"
+  },
+  {
+    "code": "688033",
+    "name": "天宜上佳",
+    "market": "sh"
+  },
+  {
+    "code": "688036",
+    "name": "传音控股",
+    "market": "sh"
+  },
+  {
+    "code": "688037",
+    "name": "芯源微",
+    "market": "sh"
+  },
+  {
+    "code": "688039",
+    "name": "当虹科技",
+    "market": "sh"
+  },
+  {
+    "code": "688050",
+    "name": "爱博医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688051",
+    "name": "佳华科技",
+    "market": "sh"
+  },
+  {
+    "code": "688055",
+    "name": "龙腾光电",
+    "market": "sh"
+  },
+  {
+    "code": "688056",
+    "name": "莱伯泰科",
+    "market": "sh"
+  },
+  {
+    "code": "688058",
+    "name": "宝兰德",
+    "market": "sh"
+  },
+  {
+    "code": "688063",
+    "name": "派能科技",
+    "market": "sh"
+  },
+  {
+    "code": "688065",
+    "name": "凯赛生物",
+    "market": "sh"
+  },
+  {
+    "code": "688066",
+    "name": "吉贝尔",
+    "market": "sh"
+  },
+  {
+    "code": "688068",
+    "name": "热景生物",
+    "market": "sh"
+  },
+  {
+    "code": "688069",
+    "name": "德林海",
+    "market": "sh"
+  },
+  {
+    "code": "688070",
+    "name": "纵横股份",
+    "market": "sh"
+  },
+  {
+    "code": "688071",
+    "name": "华依科技",
+    "market": "sh"
+  },
+  {
+    "code": "688072",
+    "name": "拓荆科技",
+    "market": "sh"
+  },
+  {
+    "code": "688073",
+    "name": "毕得医药",
+    "market": "sh"
+  },
+  {
+    "code": "688075",
+    "name": "安旭生物",
+    "market": "sh"
+  },
+  {
+    "code": "688076",
+    "name": "诺泰生物",
+    "market": "sh"
+  },
+  {
+    "code": "688077",
+    "name": "大地熊",
+    "market": "sh"
+  },
+  {
+    "code": "688078",
+    "name": "龙软科技",
+    "market": "sh"
+  },
+  {
+    "code": "688079",
+    "name": "美狄丝",
+    "market": "sh"
+  },
+  {
+    "code": "688080",
+    "name": "映翰通",
+    "market": "sh"
+  },
+  {
+    "code": "688081",
+    "name": "兴图新科",
+    "market": "sh"
+  },
+  {
+    "code": "688082",
+    "name": "盛美上海",
+    "market": "sh"
+  },
+  {
+    "code": "688083",
+    "name": "中望软件",
+    "market": "sh"
+  },
+  {
+    "code": "688085",
+    "name": "三友医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688086",
+    "name": "紫晶存储",
+    "market": "sh"
+  },
+  {
+    "code": "688087",
+    "name": "英科再生",
+    "market": "sh"
+  },
+  {
+    "code": "688088",
+    "name": "虹软科技",
+    "market": "sh"
+  },
+  {
+    "code": "688089",
+    "name": "嘉必优",
+    "market": "sh"
+  },
+  {
+    "code": "688090",
+    "name": "瑞松科技",
+    "market": "sh"
+  },
+  {
+    "code": "688091",
+    "name": "上海谊众",
+    "market": "sh"
+  },
+  {
+    "code": "688092",
+    "name": "爱科科技",
+    "market": "sh"
+  },
+  {
+    "code": "688093",
+    "name": "世华科技",
+    "market": "sh"
+  },
+  {
+    "code": "688095",
+    "name": "福昕软件",
+    "market": "sh"
+  },
+  {
+    "code": "688096",
+    "name": "京源环保",
+    "market": "sh"
+  },
+  {
+    "code": "688097",
+    "name": "博众精工",
+    "market": "sh"
+  },
+  {
+    "code": "688098",
+    "name": "申联生物",
+    "market": "sh"
+  },
+  {
+    "code": "688099",
+    "name": "晶晨股份",
+    "market": "sh"
+  },
+  {
+    "code": "688100",
+    "name": "威胜信息",
+    "market": "sh"
+  },
+  {
+    "code": "688101",
+    "name": "三达膜",
+    "market": "sh"
+  },
+  {
+    "code": "688102",
+    "name": "斯瑞新材",
+    "market": "sh"
+  },
+  {
+    "code": "688103",
+    "name": "国力股份",
+    "market": "sh"
+  },
+  {
+    "code": "688105",
+    "name": "诺唯赞",
+    "market": "sh"
+  },
+  {
+    "code": "688106",
+    "name": "金宏气体",
+    "market": "sh"
+  },
+  {
+    "code": "688107",
+    "name": "安路科技",
+    "market": "sh"
+  },
+  {
+    "code": "688108",
+    "name": "赛诺医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688109",
+    "name": "品茗科技",
+    "market": "sh"
+  },
+  {
+    "code": "688110",
+    "name": "东芯股份",
+    "market": "sh"
+  },
+  {
+    "code": "688111",
+    "name": "金山办公",
+    "market": "sh"
+  },
+  {
+    "code": "688112",
+    "name": "鼎阳科技",
+    "market": "sh"
+  },
+  {
+    "code": "688113",
+    "name": "联测科技",
+    "market": "sh"
+  },
+  {
+    "code": "688114",
+    "name": "华大智造",
+    "market": "sh"
+  },
+  {
+    "code": "688115",
+    "name": "思林杰",
+    "market": "sh"
+  },
+  {
+    "code": "688116",
+    "name": "天奈科技",
+    "market": "sh"
+  },
+  {
+    "code": "688117",
+    "name": "圣诺生物",
+    "market": "sh"
+  },
+  {
+    "code": "688118",
+    "name": "普瑞金",
+    "market": "sh"
+  },
+  {
+    "code": "688119",
+    "name": "中钢洛耐",
+    "market": "sh"
+  },
+  {
+    "code": "688120",
+    "name": "华海清科",
+    "market": "sh"
+  },
+  {
+    "code": "688121",
+    "name": "卓然股份",
+    "market": "sh"
+  },
+  {
+    "code": "688122",
+    "name": "西部超导",
+    "market": "sh"
+  },
+  {
+    "code": "688123",
+    "name": "聚辰股份",
+    "market": "sh"
+  },
+  {
+    "code": "688125",
+    "name": "安达智能",
+    "market": "sh"
+  },
+  {
+    "code": "688126",
+    "name": "沪硅产业",
+    "market": "sh"
+  },
+  {
+    "code": "688127",
+    "name": "蓝特光学",
+    "market": "sh"
+  },
+  {
+    "code": "688128",
+    "name": "中国电研",
+    "market": "sh"
+  },
+  {
+    "code": "688129",
+    "name": "东来技术",
+    "market": "sh"
+  },
+  {
+    "code": "688130",
+    "name": "晶华微",
+    "market": "sh"
+  },
+  {
+    "code": "688131",
+    "name": "皓元医药",
+    "market": "sh"
+  },
+  {
+    "code": "688132",
+    "name": "邦彦技术",
+    "market": "sh"
+  },
+  {
+    "code": "688133",
+    "name": "泰坦科技",
+    "market": "sh"
+  },
+  {
+    "code": "688135",
+    "name": "利扬芯片",
+    "market": "sh"
+  },
+  {
+    "code": "688136",
+    "name": "科兴制药",
+    "market": "sh"
+  },
+  {
+    "code": "688137",
+    "name": "近岸蛋白",
+    "market": "sh"
+  },
+  {
+    "code": "688138",
+    "name": "清溢光电",
+    "market": "sh"
+  },
+  {
+    "code": "688139",
+    "name": "海尔生物",
+    "market": "sh"
+  },
+  {
+    "code": "688141",
+    "name": "华勤技术",
+    "market": "sh"
+  },
+  {
+    "code": "688143",
+    "name": "长盈通",
+    "market": "sh"
+  },
+  {
+    "code": "688146",
+    "name": "中船特气",
+    "market": "sh"
+  },
+  {
+    "code": "688147",
+    "name": "微导纳米",
+    "market": "sh"
+  },
+  {
+    "code": "688148",
+    "name": "芳源股份",
+    "market": "sh"
+  },
+  {
+    "code": "688150",
+    "name": "莱特光电",
+    "market": "sh"
+  },
+  {
+    "code": "688151",
+    "name": "华强科技",
+    "market": "sh"
+  },
+  {
+    "code": "688152",
+    "name": "麒麟信安",
+    "market": "sh"
+  },
+  {
+    "code": "688153",
+    "name": "唯捷创芯",
+    "market": "sh"
+  },
+  {
+    "code": "688155",
+    "name": "先惠技术",
+    "market": "sh"
+  },
+  {
+    "code": "688156",
+    "name": "路德环境",
+    "market": "sh"
+  },
+  {
+    "code": "688157",
+    "name": "松井股份",
+    "market": "sh"
+  },
+  {
+    "code": "688158",
+    "name": "优刻得",
+    "market": "sh"
+  },
+  {
+    "code": "688159",
+    "name": "有方科技",
+    "market": "sh"
+  },
+  {
+    "code": "688160",
+    "name": "步科股份",
+    "market": "sh"
+  },
+  {
+    "code": "688161",
+    "name": "威高骨科",
+    "market": "sh"
+  },
+  {
+    "code": "688162",
+    "name": "巨一科技",
+    "market": "sh"
+  },
+  {
+    "code": "688163",
+    "name": "赛伦生物",
+    "market": "sh"
+  },
+  {
+    "code": "688165",
+    "name": "埃夫特",
+    "market": "sh"
+  },
+  {
+    "code": "688166",
+    "name": "博瑞医药",
+    "market": "sh"
+  },
+  {
+    "code": "688167",
+    "name": "炬光科技",
+    "market": "sh"
+  },
+  {
+    "code": "688168",
+    "name": "安博通",
+    "market": "sh"
+  },
+  {
+    "code": "688169",
+    "name": "石头科技",
+    "market": "sh"
+  },
+  {
+    "code": "688170",
+    "name": "德龙激光",
+    "market": "sh"
+  },
+  {
+    "code": "688171",
+    "name": "纬德信息",
+    "market": "sh"
+  },
+  {
+    "code": "688172",
+    "name": "燕东微",
+    "market": "sh"
+  },
+  {
+    "code": "688173",
+    "name": "希荻微",
+    "market": "sh"
+  },
+  {
+    "code": "688175",
+    "name": "高凌信息",
+    "market": "sh"
+  },
+  {
+    "code": "688176",
+    "name": "亚虹医药",
+    "market": "sh"
+  },
+  {
+    "code": "688177",
+    "name": "百奥泰",
+    "market": "sh"
+  },
+  {
+    "code": "688178",
+    "name": "万德斯",
+    "market": "sh"
+  },
+  {
+    "code": "688179",
+    "name": "阿拉丁",
+    "market": "sh"
+  },
+  {
+    "code": "688180",
+    "name": "君实生物",
+    "market": "sh"
+  },
+  {
+    "code": "688181",
+    "name": "八亿时空",
+    "market": "sh"
+  },
+  {
+    "code": "688182",
+    "name": "灿勤科技",
+    "market": "sh"
+  },
+  {
+    "code": "688183",
+    "name": "生益电子",
+    "market": "sh"
+  },
+  {
+    "code": "688184",
+    "name": "帕瓦股份",
+    "market": "sh"
+  },
+  {
+    "code": "688185",
+    "name": "康希诺",
+    "market": "sh"
+  },
+  {
+    "code": "688186",
+    "name": "广大特材",
+    "market": "sh"
+  },
+  {
+    "code": "688187",
+    "name": "时代电气",
+    "market": "sh"
+  },
+  {
+    "code": "688188",
+    "name": "柏楚电子",
+    "market": "sh"
+  },
+  {
+    "code": "688189",
+    "name": "南新制药",
+    "market": "sh"
+  },
+  {
+    "code": "688190",
+    "name": "云路股份",
+    "market": "sh"
+  },
+  {
+    "code": "688191",
+    "name": "智洋创新",
+    "market": "sh"
+  },
+  {
+    "code": "688192",
+    "name": "迪哲医药",
+    "market": "sh"
+  },
+  {
+    "code": "688193",
+    "name": "仁度生物",
+    "market": "sh"
+  },
+  {
+    "code": "688195",
+    "name": "腾景科技",
+    "market": "sh"
+  },
+  {
+    "code": "688196",
+    "name": "卓越新能",
+    "market": "sh"
+  },
+  {
+    "code": "688197",
+    "name": "首药控股",
+    "market": "sh"
+  },
+  {
+    "code": "688198",
+    "name": "佰仁医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688199",
+    "name": "久日新材",
+    "market": "sh"
+  },
+  {
+    "code": "688200",
+    "name": "华峰测控",
+    "market": "sh"
+  },
+  {
+    "code": "688201",
+    "name": "信安世纪",
+    "market": "sh"
+  },
+  {
+    "code": "688202",
+    "name": "美迪西",
+    "market": "sh"
+  },
+  {
+    "code": "688203",
+    "name": "海正生材",
+    "market": "sh"
+  },
+  {
+    "code": "688205",
+    "name": "德科立",
+    "market": "sh"
+  },
+  {
+    "code": "688206",
+    "name": "概伦电子",
+    "market": "sh"
+  },
+  {
+    "code": "688207",
+    "name": "格灵深瞳",
+    "market": "sh"
+  },
+  {
+    "code": "688208",
+    "name": "道通科技",
+    "market": "sh"
+  },
+  {
+    "code": "688209",
+    "name": "英集芯",
+    "market": "sh"
+  },
+  {
+    "code": "688210",
+    "name": "统联精密",
+    "market": "sh"
+  },
+  {
+    "code": "688211",
+    "name": "中科微至",
+    "market": "sh"
+  },
+  {
+    "code": "688212",
+    "name": "澳华内镜",
+    "market": "sh"
+  },
+  {
+    "code": "688213",
+    "name": "思特威",
+    "market": "sh"
+  },
+  {
+    "code": "688215",
+    "name": "瑞晟智能",
+    "market": "sh"
+  },
+  {
+    "code": "688216",
+    "name": "气派科技",
+    "market": "sh"
+  },
+  {
+    "code": "688217",
+    "name": "睿昂基因",
+    "market": "sh"
+  },
+  {
+    "code": "688218",
+    "name": "江苏北人",
+    "market": "sh"
+  },
+  {
+    "code": "688220",
+    "name": "翱捷科技",
+    "market": "sh"
+  },
+  {
+    "code": "688221",
+    "name": "前沿生物",
+    "market": "sh"
+  },
+  {
+    "code": "688222",
+    "name": "成都先导",
+    "market": "sh"
+  },
+  {
+    "code": "688223",
+    "name": "晶科能源",
+    "market": "sh"
+  },
+  {
+    "code": "688225",
+    "name": "亚信安全",
+    "market": "sh"
+  },
+  {
+    "code": "688226",
+    "name": "威腾电气",
+    "market": "sh"
+  },
+  {
+    "code": "688227",
+    "name": "品高股份",
+    "market": "sh"
+  },
+  {
+    "code": "688228",
+    "name": "开普云",
+    "market": "sh"
+  },
+  {
+    "code": "688229",
+    "name": "博睿数据",
+    "market": "sh"
+  },
+  {
+    "code": "688230",
+    "name": "芯导科技",
+    "market": "sh"
+  },
+  {
+    "code": "688231",
+    "name": "隆达股份",
+    "market": "sh"
+  },
+  {
+    "code": "688232",
+    "name": "新点软件",
+    "market": "sh"
+  },
+  {
+    "code": "688233",
+    "name": "神工股份",
+    "market": "sh"
+  },
+  {
+    "code": "688234",
+    "name": "天岳先进",
+    "market": "sh"
+  },
+  {
+    "code": "688235",
+    "name": "百济神州",
+    "market": "sh"
+  },
+  {
+    "code": "688236",
+    "name": "春立医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688237",
+    "name": "超卓航科",
+    "market": "sh"
+  },
+  {
+    "code": "688238",
+    "name": "和元生物",
+    "market": "sh"
+  },
+  {
+    "code": "688239",
+    "name": "航宇科技",
+    "market": "sh"
+  },
+  {
+    "code": "688244",
+    "name": "永信至诚",
+    "market": "sh"
+  },
+  {
+    "code": "688246",
+    "name": "嘉和美康",
+    "market": "sh"
+  },
+  {
+    "code": "688247",
+    "name": "宣泰医药",
+    "market": "sh"
+  },
+  {
+    "code": "688248",
+    "name": "南网科技",
+    "market": "sh"
+  },
+  {
+    "code": "688249",
+    "name": "晶合集成",
+    "market": "sh"
+  },
+  {
+    "code": "688252",
+    "name": "天德钰",
+    "market": "sh"
+  },
+  {
+    "code": "688253",
+    "name": "英诺特",
+    "market": "sh"
+  },
+  {
+    "code": "688255",
+    "name": "凯尔达",
+    "market": "sh"
+  },
+  {
+    "code": "688256",
+    "name": "寒武纪",
+    "market": "sh"
+  },
+  {
+    "code": "688257",
+    "name": "新锐股份",
+    "market": "sh"
+  },
+  {
+    "code": "688258",
+    "name": "卓易信息",
+    "market": "sh"
+  },
+  {
+    "code": "688259",
+    "name": "创耀科技",
+    "market": "sh"
+  },
+  {
+    "code": "688260",
+    "name": "昀冢科技",
+    "market": "sh"
+  },
+  {
+    "code": "688261",
+    "name": "东微半导",
+    "market": "sh"
+  },
+  {
+    "code": "688262",
+    "name": "国芯科技",
+    "market": "sh"
+  },
+  {
+    "code": "688265",
+    "name": "南模生物",
+    "market": "sh"
+  },
+  {
+    "code": "688266",
+    "name": "泽璟制药",
+    "market": "sh"
+  },
+  {
+    "code": "688267",
+    "name": "中触媒",
+    "market": "sh"
+  },
+  {
+    "code": "688268",
+    "name": "华特气体",
+    "market": "sh"
+  },
+  {
+    "code": "688269",
+    "name": "凯立新材",
+    "market": "sh"
+  },
+  {
+    "code": "688270",
+    "name": "臻镭科技",
+    "market": "sh"
+  },
+  {
+    "code": "688271",
+    "name": "联影医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688272",
+    "name": "富吉瑞",
+    "market": "sh"
+  },
+  {
+    "code": "688273",
+    "name": "麦澜德",
+    "market": "sh"
+  },
+  {
+    "code": "688275",
+    "name": "万润新能",
+    "market": "sh"
+  },
+  {
+    "code": "688276",
+    "name": "百克生物",
+    "market": "sh"
+  },
+  {
+    "code": "688277",
+    "name": "天智航",
+    "market": "sh"
+  },
+  {
+    "code": "688278",
+    "name": "特宝生物",
+    "market": "sh"
+  },
+  {
+    "code": "688279",
+    "name": "华峰测控",
+    "market": "sh"
+  },
+  {
+    "code": "688280",
+    "name": "精进电动",
+    "market": "sh"
+  },
+  {
+    "code": "688281",
+    "name": "华秦科技",
+    "market": "sh"
+  },
+  {
+    "code": "688282",
+    "name": "理工导航",
+    "market": "sh"
+  },
+  {
+    "code": "688283",
+    "name": "坤恒顺维",
+    "market": "sh"
+  },
+  {
+    "code": "688285",
+    "name": "高铁电气",
+    "market": "sh"
+  },
+  {
+    "code": "688286",
+    "name": "敏芯股份",
+    "market": "sh"
+  },
+  {
+    "code": "688287",
+    "name": "ST观典",
+    "market": "sh"
+  },
+  {
+    "code": "688288",
+    "name": "鸿泉物联",
+    "market": "sh"
+  },
+  {
+    "code": "688289",
+    "name": "圣湘生物",
+    "market": "sh"
+  },
+  {
+    "code": "688290",
+    "name": "景业智能",
+    "market": "sh"
+  },
+  {
+    "code": "688291",
+    "name": "金橙子",
+    "market": "sh"
+  },
+  {
+    "code": "688292",
+    "name": "浩瀚深度",
+    "market": "sh"
+  },
+  {
+    "code": "688293",
+    "name": "奥浦迈",
+    "market": "sh"
+  },
+  {
+    "code": "688295",
+    "name": "中复神鹰",
+    "market": "sh"
+  },
+  {
+    "code": "688296",
+    "name": "和达科技",
+    "market": "sh"
+  },
+  {
+    "code": "688297",
+    "name": "中无人机",
+    "market": "sh"
+  },
+  {
+    "code": "688298",
+    "name": "东方生物",
+    "market": "sh"
+  },
+  {
+    "code": "688299",
+    "name": "长阳科技",
+    "market": "sh"
+  },
+  {
+    "code": "688300",
+    "name": "联瑞新材",
+    "market": "sh"
+  },
+  {
+    "code": "688301",
+    "name": "奕瑞科技",
+    "market": "sh"
+  },
+  {
+    "code": "688302",
+    "name": "海创药业",
+    "market": "sh"
+  },
+  {
+    "code": "688303",
+    "name": "大全能源",
+    "market": "sh"
+  },
+  {
+    "code": "688305",
+    "name": "科德数控",
+    "market": "sh"
+  },
+  {
+    "code": "688306",
+    "name": "均普智能",
+    "market": "sh"
+  },
+  {
+    "code": "688307",
+    "name": "中润光学",
+    "market": "sh"
+  },
+  {
+    "code": "688308",
+    "name": "欧科亿",
+    "market": "sh"
+  },
+  {
+    "code": "688309",
+    "name": "恒誉环保",
+    "market": "sh"
+  },
+  {
+    "code": "688310",
+    "name": "迈得医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688311",
+    "name": "盟升电子",
+    "market": "sh"
+  },
+  {
+    "code": "688312",
+    "name": "燕麦科技",
+    "market": "sh"
+  },
+  {
+    "code": "688313",
+    "name": "仕佳光子",
+    "market": "sh"
+  },
+  {
+    "code": "688314",
+    "name": "康拓医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688315",
+    "name": "诺禾致源",
+    "market": "sh"
+  },
+  {
+    "code": "688316",
+    "name": "青云科技",
+    "market": "sh"
+  },
+  {
+    "code": "688317",
+    "name": "之江生物",
+    "market": "sh"
+  },
+  {
+    "code": "688318",
+    "name": "财富趋势",
+    "market": "sh"
+  },
+  {
+    "code": "688319",
+    "name": "欧林生物",
+    "market": "sh"
+  },
+  {
+    "code": "688320",
+    "name": "禾川科技",
+    "market": "sh"
+  },
+  {
+    "code": "688321",
+    "name": "微芯生物",
+    "market": "sh"
+  },
+  {
+    "code": "688322",
+    "name": "奥比中光",
+    "market": "sh"
+  },
+  {
+    "code": "688323",
+    "name": "瑞华泰",
+    "market": "sh"
+  },
+  {
+    "code": "688325",
+    "name": "赛微微电",
+    "market": "sh"
+  },
+  {
+    "code": "688326",
+    "name": "经纬恒润",
+    "market": "sh"
+  },
+  {
+    "code": "688327",
+    "name": "云从科技",
+    "market": "sh"
+  },
+  {
+    "code": "688328",
+    "name": "深科达",
+    "market": "sh"
+  },
+  {
+    "code": "688329",
+    "name": "艾隆科技",
+    "market": "sh"
+  },
+  {
+    "code": "688330",
+    "name": "宏力达",
+    "market": "sh"
+  },
+  {
+    "code": "688331",
+    "name": "荣昌生物",
+    "market": "sh"
+  },
+  {
+    "code": "688332",
+    "name": "中科蓝讯",
+    "market": "sh"
+  },
+  {
+    "code": "688333",
+    "name": "铂力特",
+    "market": "sh"
+  },
+  {
+    "code": "688334",
+    "name": "西高院",
+    "market": "sh"
+  },
+  {
+    "code": "688335",
+    "name": "复洁环保",
+    "market": "sh"
+  },
+  {
+    "code": "688336",
+    "name": "三生国健",
+    "market": "sh"
+  },
+  {
+    "code": "688337",
+    "name": "普源精电",
+    "market": "sh"
+  },
+  {
+    "code": "688338",
+    "name": "赛科希德",
+    "market": "sh"
+  },
+  {
+    "code": "688339",
+    "name": "亿华通",
+    "market": "sh"
+  },
+  {
+    "code": "688345",
+    "name": "博力威",
+    "market": "sh"
+  },
+  {
+    "code": "688347",
+    "name": "华虹公司",
+    "market": "sh"
+  },
+  {
+    "code": "688348",
+    "name": "昱能科技",
+    "market": "sh"
+  },
+  {
+    "code": "688349",
+    "name": "三一重能",
+    "market": "sh"
+  },
+  {
+    "code": "688350",
+    "name": "富淼科技",
+    "market": "sh"
+  },
+  {
+    "code": "688351",
+    "name": "微电生理",
+    "market": "sh"
+  },
+  {
+    "code": "688352",
+    "name": "颀中科技",
+    "market": "sh"
+  },
+  {
+    "code": "688353",
+    "name": "华盛锂电",
+    "market": "sh"
+  },
+  {
+    "code": "688355",
+    "name": "明志科技",
+    "market": "sh"
+  },
+  {
+    "code": "688356",
+    "name": "键凯科技",
+    "market": "sh"
+  },
+  {
+    "code": "688357",
+    "name": "建龙微纳",
+    "market": "sh"
+  },
+  {
+    "code": "688358",
+    "name": "祥生医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688359",
+    "name": "三孚新科",
+    "market": "sh"
+  },
+  {
+    "code": "688360",
+    "name": "德马科技",
+    "market": "sh"
+  },
+  {
+    "code": "688361",
+    "name": "中科飞测",
+    "market": "sh"
+  },
+  {
+    "code": "688362",
+    "name": "甬矽电子",
+    "market": "sh"
+  },
+  {
+    "code": "688363",
+    "name": "华熙生物",
+    "market": "sh"
+  },
+  {
+    "code": "688365",
+    "name": "光云科技",
+    "market": "sh"
+  },
+  {
+    "code": "688366",
+    "name": "昊海生科",
+    "market": "sh"
+  },
+  {
+    "code": "688367",
+    "name": "工大高科",
+    "market": "sh"
+  },
+  {
+    "code": "688368",
+    "name": "晶丰明源",
+    "market": "sh"
+  },
+  {
+    "code": "688369",
+    "name": "致远互联",
+    "market": "sh"
+  },
+  {
+    "code": "688370",
+    "name": "丛麟科技",
+    "market": "sh"
+  },
+  {
+    "code": "688371",
+    "name": "菲沃泰",
+    "market": "sh"
+  },
+  {
+    "code": "688372",
+    "name": "伟测科技",
+    "market": "sh"
+  },
+  {
+    "code": "688373",
+    "name": "盟科药业",
+    "market": "sh"
+  },
+  {
+    "code": "688375",
+    "name": "国博电子",
+    "market": "sh"
+  },
+  {
+    "code": "688376",
+    "name": "美埃科技",
+    "market": "sh"
+  },
+  {
+    "code": "688377",
+    "name": "迪威尔",
+    "market": "sh"
+  },
+  {
+    "code": "688378",
+    "name": "奥来德",
+    "market": "sh"
+  },
+  {
+    "code": "688379",
+    "name": "华光新材",
+    "market": "sh"
+  },
+  {
+    "code": "688380",
+    "name": "中微半导",
+    "market": "sh"
+  },
+  {
+    "code": "688381",
+    "name": "帝奥微",
+    "market": "sh"
+  },
+  {
+    "code": "688382",
+    "name": "益方生物",
+    "market": "sh"
+  },
+  {
+    "code": "688383",
+    "name": "新益昌",
+    "market": "sh"
+  },
+  {
+    "code": "688385",
+    "name": "复旦微电",
+    "market": "sh"
+  },
+  {
+    "code": "688386",
+    "name": "泛亚微透",
+    "market": "sh"
+  },
+  {
+    "code": "688387",
+    "name": "信科移动",
+    "market": "sh"
+  },
+  {
+    "code": "688388",
+    "name": "嘉元科技",
+    "market": "sh"
+  },
+  {
+    "code": "688389",
+    "name": "普门科技",
+    "market": "sh"
+  },
+  {
+    "code": "688390",
+    "name": "固德威",
+    "market": "sh"
+  },
+  {
+    "code": "688391",
+    "name": "钜泉科技",
+    "market": "sh"
+  },
+  {
+    "code": "688392",
+    "name": "太级股份",
+    "market": "sh"
+  },
+  {
+    "code": "688393",
+    "name": "安必平",
+    "market": "sh"
+  },
+  {
+    "code": "688395",
+    "name": "正弦电气",
+    "market": "sh"
+  },
+  {
+    "code": "688396",
+    "name": "华润微",
+    "market": "sh"
+  },
+  {
+    "code": "688398",
+    "name": "赛特新材",
+    "market": "sh"
+  },
+  {
+    "code": "688399",
+    "name": "硕世生物",
+    "market": "sh"
+  },
+  {
+    "code": "688400",
+    "name": "凌云光",
+    "market": "sh"
+  },
+  {
+    "code": "688401",
+    "name": "路维光电",
+    "market": "sh"
+  },
+  {
+    "code": "688403",
+    "name": "汇成股份",
+    "market": "sh"
+  },
+  {
+    "code": "688408",
+    "name": "中信博",
+    "market": "sh"
+  },
+  {
+    "code": "688409",
+    "name": "富创精密",
+    "market": "sh"
+  },
+  {
+    "code": "688410",
+    "name": "山外山",
+    "market": "sh"
+  },
+  {
+    "code": "688416",
+    "name": "恒烁股份",
+    "market": "sh"
+  },
+  {
+    "code": "688418",
+    "name": "震有科技",
+    "market": "sh"
+  },
+  {
+    "code": "688419",
+    "name": "耐科装备",
+    "market": "sh"
+  },
+  {
+    "code": "688420",
+    "name": "美腾科技",
+    "market": "sh"
+  },
+  {
+    "code": "688425",
+    "name": "铁建重工",
+    "market": "sh"
+  },
+  {
+    "code": "688426",
+    "name": "康为世纪",
+    "market": "sh"
+  },
+  {
+    "code": "688428",
+    "name": "诺诚健华",
+    "market": "sh"
+  },
+  {
+    "code": "688429",
+    "name": "时创能源",
+    "market": "sh"
+  },
+  {
+    "code": "688432",
+    "name": "有研硅",
+    "market": "sh"
+  },
+  {
+    "code": "688433",
+    "name": "华曙高科",
+    "market": "sh"
+  },
+  {
+    "code": "688435",
+    "name": "英方软件",
+    "market": "sh"
+  },
+  {
+    "code": "688439",
+    "name": "振华风光",
+    "market": "sh"
+  },
+  {
+    "code": "688443",
+    "name": "智翔金泰",
+    "market": "sh"
+  },
+  {
+    "code": "688448",
+    "name": "磁谷科技",
+    "market": "sh"
+  },
+  {
+    "code": "688449",
+    "name": "联芸科技",
+    "market": "sh"
+  },
+  {
+    "code": "688450",
+    "name": "光格科技",
+    "market": "sh"
+  },
+  {
+    "code": "688455",
+    "name": "科捷智能",
+    "market": "sh"
+  },
+  {
+    "code": "688456",
+    "name": "有研粉材",
+    "market": "sh"
+  },
+  {
+    "code": "688458",
+    "name": "美芯晟",
+    "market": "sh"
+  },
+  {
+    "code": "688459",
+    "name": "哈铁科技",
+    "market": "sh"
+  },
+  {
+    "code": "688460",
+    "name": "中科飞测",
+    "market": "sh"
+  },
+  {
+    "code": "688466",
+    "name": "金鹰重工",
+    "market": "sh"
+  },
+  {
+    "code": "688468",
+    "name": "科美诊断",
+    "market": "sh"
+  },
+  {
+    "code": "688469",
+    "name": "芯联集成",
+    "market": "sh"
+  },
+  {
+    "code": "688472",
+    "name": "阿特斯",
+    "market": "sh"
+  },
+  {
+    "code": "688475",
+    "name": "萤石网络",
+    "market": "sh"
+  },
+  {
+    "code": "688478",
+    "name": "晶升股份",
+    "market": "sh"
+  },
+  {
+    "code": "688479",
+    "name": "友车科技",
+    "market": "sh"
+  },
+  {
+    "code": "688480",
+    "name": "赛恩斯",
+    "market": "sh"
+  },
+  {
+    "code": "688484",
+    "name": "南芯科技",
+    "market": "sh"
+  },
+  {
+    "code": "688485",
+    "name": "九州一轨",
+    "market": "sh"
+  },
+  {
+    "code": "688486",
+    "name": "龙迅股份",
+    "market": "sh"
+  },
+  {
+    "code": "688488",
+    "name": "艾迪药业",
+    "market": "sh"
+  },
+  {
+    "code": "688489",
+    "name": "三未信安",
+    "market": "sh"
+  },
+  {
+    "code": "688496",
+    "name": "清越科技",
+    "market": "sh"
+  },
+  {
+    "code": "688498",
+    "name": "源杰科技",
+    "market": "sh"
+  },
+  {
+    "code": "688499",
+    "name": "利元亨",
+    "market": "sh"
+  },
+  {
+    "code": "688500",
+    "name": "慧辰股份",
+    "market": "sh"
+  },
+  {
+    "code": "688501",
+    "name": "青达环保",
+    "market": "sh"
+  },
+  {
+    "code": "688502",
+    "name": "茂莱光学",
+    "market": "sh"
+  },
+  {
+    "code": "688503",
+    "name": "聚和材料",
+    "market": "sh"
+  },
+  {
+    "code": "688505",
+    "name": "复旦张江",
+    "market": "sh"
+  },
+  {
+    "code": "688506",
+    "name": "百利天恒",
+    "market": "sh"
+  },
+  {
+    "code": "688507",
+    "name": "索辰科技",
+    "market": "sh"
+  },
+  {
+    "code": "688508",
+    "name": "芯朋微",
+    "market": "sh"
+  },
+  {
+    "code": "688509",
+    "name": "正元地信",
+    "market": "sh"
+  },
+  {
+    "code": "688510",
+    "name": "航亚科技",
+    "market": "sh"
+  },
+  {
+    "code": "688511",
+    "name": "天微电子",
+    "market": "sh"
+  },
+  {
+    "code": "688512",
+    "name": "慧智微",
+    "market": "sh"
+  },
+  {
+    "code": "688513",
+    "name": "苑东生物",
+    "market": "sh"
+  },
+  {
+    "code": "688515",
+    "name": "裕太微",
+    "market": "sh"
+  },
+  {
+    "code": "688516",
+    "name": "奥特维",
+    "market": "sh"
+  },
+  {
+    "code": "688517",
+    "name": "金冠电气",
+    "market": "sh"
+  },
+  {
+    "code": "688518",
+    "name": "联赢激光",
+    "market": "sh"
+  },
+  {
+    "code": "688519",
+    "name": "南亚新材",
+    "market": "sh"
+  },
+  {
+    "code": "688520",
+    "name": "神州细胞",
+    "market": "sh"
+  },
+  {
+    "code": "688521",
+    "name": "芯原股份",
+    "market": "sh"
+  },
+  {
+    "code": "688522",
+    "name": "纳睿雷达",
+    "market": "sh"
+  },
+  {
+    "code": "688523",
+    "name": "航天环宇",
+    "market": "sh"
+  },
+  {
+    "code": "688525",
+    "name": "佰维存储",
+    "market": "sh"
+  },
+  {
+    "code": "688526",
+    "name": "科前生物",
+    "market": "sh"
+  },
+  {
+    "code": "688527",
+    "name": "蓝箭电子",
+    "market": "sh"
+  },
+  {
+    "code": "688528",
+    "name": "秦川物联",
+    "market": "sh"
+  },
+  {
+    "code": "688529",
+    "name": "豪森股份",
+    "market": "sh"
+  },
+  {
+    "code": "688530",
+    "name": "欧莱新材",
+    "market": "sh"
+  },
+  {
+    "code": "688531",
+    "name": "日联科技",
+    "market": "sh"
+  },
+  {
+    "code": "688533",
+    "name": "上声电子",
+    "market": "sh"
+  },
+  {
+    "code": "688535",
+    "name": "华海诚科",
+    "market": "sh"
+  },
+  {
+    "code": "688536",
+    "name": "思瑞浦",
+    "market": "sh"
+  },
+  {
+    "code": "688538",
+    "name": "和辉光电",
+    "market": "sh"
+  },
+  {
+    "code": "688539",
+    "name": "高华科技",
+    "market": "sh"
+  },
+  {
+    "code": "688543",
+    "name": "国科军工",
+    "market": "sh"
+  },
+  {
+    "code": "688545",
+    "name": "兴福电子",
+    "market": "sh"
+  },
+  {
+    "code": "688548",
+    "name": "广钢气体",
+    "market": "sh"
+  },
+  {
+    "code": "688549",
+    "name": "中巨芯",
+    "market": "sh"
+  },
+  {
+    "code": "688550",
+    "name": "瑞联新材",
+    "market": "sh"
+  },
+  {
+    "code": "688551",
+    "name": "科威尔",
+    "market": "sh"
+  },
+  {
+    "code": "688552",
+    "name": "航天南湖",
+    "market": "sh"
+  },
+  {
+    "code": "688553",
+    "name": "汇宇制药",
+    "market": "sh"
+  },
+  {
+    "code": "688556",
+    "name": "高测股份",
+    "market": "sh"
+  },
+  {
+    "code": "688557",
+    "name": "兰剑智能",
+    "market": "sh"
+  },
+  {
+    "code": "688558",
+    "name": "国盛智科",
+    "market": "sh"
+  },
+  {
+    "code": "688559",
+    "name": "海目星",
+    "market": "sh"
+  },
+  {
+    "code": "688560",
+    "name": "明冠新材",
+    "market": "sh"
+  },
+  {
+    "code": "688561",
+    "name": "奇安信",
+    "market": "sh"
+  },
+  {
+    "code": "688562",
+    "name": "航天软件",
+    "market": "sh"
+  },
+  {
+    "code": "688563",
+    "name": "航材股份",
+    "market": "sh"
+  },
+  {
+    "code": "688565",
+    "name": "力源科技",
+    "market": "sh"
+  },
+  {
+    "code": "688566",
+    "name": "吉贝尔",
+    "market": "sh"
+  },
+  {
+    "code": "688567",
+    "name": "孚能科技",
+    "market": "sh"
+  },
+  {
+    "code": "688568",
+    "name": "中科星图",
+    "market": "sh"
+  },
+  {
+    "code": "688569",
+    "name": "铁科轨道",
+    "market": "sh"
+  },
+  {
+    "code": "688570",
+    "name": "天玛智控",
+    "market": "sh"
+  },
+  {
+    "code": "688571",
+    "name": "杭华股份",
+    "market": "sh"
+  },
+  {
+    "code": "688573",
+    "name": "信宇人",
+    "market": "sh"
+  },
+  {
+    "code": "688575",
+    "name": "亚辉龙",
+    "market": "sh"
+  },
+  {
+    "code": "688576",
+    "name": "西山科技",
+    "market": "sh"
+  },
+  {
+    "code": "688577",
+    "name": "浙海德曼",
+    "market": "sh"
+  },
+  {
+    "code": "688578",
+    "name": "艾力斯",
+    "market": "sh"
+  },
+  {
+    "code": "688579",
+    "name": "山大地纬",
+    "market": "sh"
+  },
+  {
+    "code": "688580",
+    "name": "伟思医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688581",
+    "name": "安杰思",
+    "market": "sh"
+  },
+  {
+    "code": "688582",
+    "name": "芯动联科",
+    "market": "sh"
+  },
+  {
+    "code": "688585",
+    "name": "上纬新材",
+    "market": "sh"
+  },
+  {
+    "code": "688586",
+    "name": "江航装备",
+    "market": "sh"
+  },
+  {
+    "code": "688587",
+    "name": "伟思医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688588",
+    "name": "凌志软件",
+    "market": "sh"
+  },
+  {
+    "code": "688589",
+    "name": "力合微",
+    "market": "sh"
+  },
+  {
+    "code": "688590",
+    "name": "新致软件",
+    "market": "sh"
+  },
+  {
+    "code": "688591",
+    "name": "泰凌微",
+    "market": "sh"
+  },
+  {
+    "code": "688592",
+    "name": "司南导航",
+    "market": "sh"
+  },
+  {
+    "code": "688593",
+    "name": "新相微",
+    "market": "sh"
+  },
+  {
+    "code": "688595",
+    "name": "芯海科技",
+    "market": "sh"
+  },
+  {
+    "code": "688596",
+    "name": "正帆科技",
+    "market": "sh"
+  },
+  {
+    "code": "688597",
+    "name": "煜邦电力",
+    "market": "sh"
+  },
+  {
+    "code": "688598",
+    "name": "金博股份",
+    "market": "sh"
+  },
+  {
+    "code": "688599",
+    "name": "天合光能",
+    "market": "sh"
+  },
+  {
+    "code": "688600",
+    "name": "皖仪科技",
+    "market": "sh"
+  },
+  {
+    "code": "688601",
+    "name": "力芯微",
+    "market": "sh"
+  },
+  {
+    "code": "688602",
+    "name": "康鹏科技",
+    "market": "sh"
+  },
+  {
+    "code": "688603",
+    "name": "天承科技",
+    "market": "sh"
+  },
+  {
+    "code": "688605",
+    "name": "先锋精科",
+    "market": "sh"
+  },
+  {
+    "code": "688606",
+    "name": "奥泰生物",
+    "market": "sh"
+  },
+  {
+    "code": "688607",
+    "name": "康众医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688608",
+    "name": "恒玄科技",
+    "market": "sh"
+  },
+  {
+    "code": "688609",
+    "name": "九联科技",
+    "market": "sh"
+  },
+  {
+    "code": "688610",
+    "name": "埃科光电",
+    "market": "sh"
+  },
+  {
+    "code": "688611",
+    "name": "浙江荣泰",
+    "market": "sh"
+  },
+  {
+    "code": "688612",
+    "name": "威迈斯",
+    "market": "sh"
+  },
+  {
+    "code": "688613",
+    "name": "奥精医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688616",
+    "name": "西力科技",
+    "market": "sh"
+  },
+  {
+    "code": "688617",
+    "name": "惠泰医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688618",
+    "name": "三旺通信",
+    "market": "sh"
+  },
+  {
+    "code": "688619",
+    "name": "罗普特",
+    "market": "sh"
+  },
+  {
+    "code": "688620",
+    "name": "安凯微",
+    "market": "sh"
+  },
+  {
+    "code": "688621",
+    "name": "阳光诺和",
+    "market": "sh"
+  },
+  {
+    "code": "688622",
+    "name": "禾信仪器",
+    "market": "sh"
+  },
+  {
+    "code": "688623",
+    "name": "双元科技",
+    "market": "sh"
+  },
+  {
+    "code": "688625",
+    "name": "呈和科技",
+    "market": "sh"
+  },
+  {
+    "code": "688626",
+    "name": "翔宇医疗",
+    "market": "sh"
+  },
+  {
+    "code": "688627",
+    "name": "精智达",
+    "market": "sh"
+  },
+  {
+    "code": "688628",
+    "name": "优利德",
+    "market": "sh"
+  },
+  {
+    "code": "688629",
+    "name": "华丰科技",
+    "market": "sh"
+  },
+  {
+    "code": "688630",
+    "name": "芯碁微装",
+    "market": "sh"
+  },
+  {
+    "code": "688631",
+    "name": "莱斯信息",
+    "market": "sh"
+  },
+  {
+    "code": "688633",
+    "name": "星球石墨",
+    "market": "sh"
+  },
+  {
+    "code": "688636",
+    "name": "智明达",
+    "market": "sh"
+  },
+  {
+    "code": "688638",
+    "name": "誉辰智能",
+    "market": "sh"
+  },
+  {
+    "code": "688639",
+    "name": "华恒生物",
+    "market": "sh"
+  },
+  {
+    "code": "688646",
+    "name": "逸飞激光",
+    "market": "sh"
+  },
+  {
+    "code": "688648",
+    "name": "中邮科技",
+    "market": "sh"
+  },
+  {
+    "code": "688651",
+    "name": "盛邦安全",
+    "market": "sh"
+  },
+  {
+    "code": "688652",
+    "name": "京仪装备",
+    "market": "sh"
+  },
+  {
+    "code": "688653",
+    "name": "康希通信",
+    "market": "sh"
+  },
+  {
+    "code": "688655",
+    "name": "隆达股份",
+    "market": "sh"
+  },
+  {
+    "code": "688656",
+    "name": "浩欧博",
+    "market": "sh"
+  },
+  {
+    "code": "688657",
+    "name": "浩辰软件",
+    "market": "sh"
+  },
+  {
+    "code": "688658",
+    "name": "悦康药业",
+    "market": "sh"
+  },
+  {
+    "code": "688659",
+    "name": "元琛科技",
+    "market": "sh"
+  },
+  {
+    "code": "688660",
+    "name": "电气风电",
+    "market": "sh"
+  },
+  {
+    "code": "688661",
+    "name": "和林微纳",
+    "market": "sh"
+  },
+  {
+    "code": "688662",
+    "name": "富信科技",
+    "market": "sh"
+  },
+  {
+    "code": "688663",
+    "name": "新风光",
+    "market": "sh"
+  },
+  {
+    "code": "688665",
+    "name": "四方光电",
+    "market": "sh"
+  },
+  {
+    "code": "688666",
+    "name": "吉星新材料",
+    "market": "sh"
+  },
+  {
+    "code": "688667",
+    "name": "菱电电控",
+    "market": "sh"
+  },
+  {
+    "code": "688668",
+    "name": "鼎通科技",
+    "market": "sh"
+  },
+  {
+    "code": "688669",
+    "name": "聚石化学",
+    "market": "sh"
+  },
+  {
+    "code": "688670",
+    "name": "金迪克",
+    "market": "sh"
+  },
+  {
+    "code": "688671",
+    "name": "碧兴科技",
+    "market": "sh"
+  },
+  {
+    "code": "688676",
+    "name": "金盘科技",
+    "market": "sh"
+  },
+  {
+    "code": "688677",
+    "name": "海泰新光",
+    "market": "sh"
+  },
+  {
+    "code": "688678",
+    "name": "福立旺",
+    "market": "sh"
+  },
+  {
+    "code": "688679",
+    "name": "通源环境",
+    "market": "sh"
+  },
+  {
+    "code": "688680",
+    "name": "海优新材",
+    "market": "sh"
+  },
+  {
+    "code": "688681",
+    "name": "科汇股份",
+    "market": "sh"
+  },
+  {
+    "code": "688682",
+    "name": "霍莱沃",
+    "market": "sh"
+  },
+  {
+    "code": "688683",
+    "name": "莱尔科技",
+    "market": "sh"
+  },
+  {
+    "code": "688685",
+    "name": "迈信林",
+    "market": "sh"
+  },
+  {
+    "code": "688686",
+    "name": "奥普特",
+    "market": "sh"
+  },
+  {
+    "code": "688687",
+    "name": "凯因科技",
+    "market": "sh"
+  },
+  {
+    "code": "688689",
+    "name": "银河微电",
+    "market": "sh"
+  },
+  {
+    "code": "688690",
+    "name": "纳微科技",
+    "market": "sh"
+  },
+  {
+    "code": "688691",
+    "name": "灿芯股份",
+    "market": "sh"
+  },
+  {
+    "code": "688692",
+    "name": "达梦数据",
+    "market": "sh"
+  },
+  {
+    "code": "688693",
+    "name": "锴威特",
+    "market": "sh"
+  },
+  {
+    "code": "688695",
+    "name": "中创股份",
+    "market": "sh"
+  },
+  {
+    "code": "688696",
+    "name": "极米科技",
+    "market": "sh"
+  },
+  {
+    "code": "688697",
+    "name": "纽威数控",
+    "market": "sh"
+  },
+  {
+    "code": "688698",
+    "name": "伟创电气",
+    "market": "sh"
+  },
+  {
+    "code": "688699",
+    "name": "明微电子",
+    "market": "sh"
+  },
+  {
+    "code": "688700",
+    "name": "东威科技",
+    "market": "sh"
+  },
+  {
+    "code": "688701",
+    "name": "卓锦股份",
+    "market": "sh"
+  },
+  {
+    "code": "688702",
+    "name": "盛科通信",
+    "market": "sh"
+  },
+  {
+    "code": "688711",
+    "name": "宏微科技",
+    "market": "sh"
+  },
+  {
+    "code": "688716",
+    "name": "中研股份",
+    "market": "sh"
+  },
+  {
+    "code": "688717",
+    "name": "艾罗能源",
+    "market": "sh"
+  },
+  {
+    "code": "688718",
+    "name": "唯赛勃",
+    "market": "sh"
+  },
+  {
+    "code": "688719",
+    "name": "爱科赛博",
+    "market": "sh"
+  },
+  {
+    "code": "688720",
+    "name": "艾森股份",
+    "market": "sh"
+  },
+  {
+    "code": "688721",
+    "name": "龙图光罩",
+    "market": "sh"
+  },
+  {
+    "code": "688722",
+    "name": "同益中",
+    "market": "sh"
+  },
+  {
+    "code": "688726",
+    "name": "拉普拉斯",
+    "market": "sh"
+  },
+  {
+    "code": "688728",
+    "name": "格科微",
+    "market": "sh"
+  },
+  {
+    "code": "688733",
+    "name": "壹石通",
+    "market": "sh"
+  },
+  {
+    "code": "688737",
+    "name": "中自科技",
+    "market": "sh"
+  },
+  {
+    "code": "688738",
+    "name": "中研股份",
+    "market": "sh"
+  },
+  {
+    "code": "688739",
+    "name": "成大生物",
+    "market": "sh"
+  },
+  {
+    "code": "688766",
+    "name": "普冉股份",
+    "market": "sh"
+  },
+  {
+    "code": "688767",
+    "name": "博拓生物",
+    "market": "sh"
+  },
+  {
+    "code": "688768",
+    "name": "容知日新",
+    "market": "sh"
+  },
+  {
+    "code": "688772",
+    "name": "珠海冠宇",
+    "market": "sh"
+  },
+  {
+    "code": "688776",
+    "name": "国光电气",
+    "market": "sh"
+  },
+  {
+    "code": "688777",
+    "name": "中控技术",
+    "market": "sh"
+  },
+  {
+    "code": "688778",
+    "name": "厦钨新能",
+    "market": "sh"
+  },
+  {
+    "code": "688779",
+    "name": "长远锂科",
+    "market": "sh"
+  },
+  {
+    "code": "688781",
+    "name": "悦康药业",
+    "market": "sh"
+  },
+  {
+    "code": "688786",
+    "name": "悦安新材",
+    "market": "sh"
+  },
+  {
+    "code": "688787",
+    "name": "海天瑞声",
+    "market": "sh"
+  },
+  {
+    "code": "688788",
+    "name": "科思科技",
+    "market": "sh"
+  },
+  {
+    "code": "688789",
+    "name": "宏华数科",
+    "market": "sh"
+  },
+  {
+    "code": "688793",
+    "name": "倍轻松",
+    "market": "sh"
+  },
+  {
+    "code": "688798",
+    "name": "艾为电子",
+    "market": "sh"
+  },
+  {
+    "code": "688799",
+    "name": "华纳药厂",
+    "market": "sh"
+  },
+  {
+    "code": "688800",
+    "name": "瑞可达",
+    "market": "sh"
+  },
+  {
+    "code": "688819",
+    "name": "天能股份",
+    "market": "sh"
+  },
+  {
+    "code": "688981",
+    "name": "中芯国际",
+    "market": "sh"
+  },
+  {
+    "code": "688982",
+    "name": "晶合集成",
+    "market": "sh"
+  },
+  {
+    "code": "688998",
+    "name": "东方生物",
+    "market": "sh"
+  },
+  {
+    "code": "830799",
+    "name": "艾融软件",
+    "market": "bj"
+  },
+  {
+    "code": "830964",
+    "name": "润农节水",
+    "market": "bj"
+  },
+  {
+    "code": "831152",
+    "name": "昆工科技",
+    "market": "bj"
+  },
+  {
+    "code": "831304",
+    "name": "迪尔化工",
+    "market": "bj"
+  },
+  {
+    "code": "831305",
+    "name": "海希通讯",
+    "market": "bj"
+  },
+  {
+    "code": "831370",
+    "name": "新安洁",
+    "market": "bj"
+  },
+  {
+    "code": "831396",
+    "name": "许昌智能",
+    "market": "bj"
+  },
+  {
+    "code": "831445",
+    "name": "龙竹科技",
+    "market": "bj"
+  },
+  {
+    "code": "831641",
+    "name": "格利尔",
+    "market": "bj"
+  },
+  {
+    "code": "831689",
+    "name": "克莱特",
+    "market": "bj"
+  },
+  {
+    "code": "831726",
+    "name": "朱老六",
+    "market": "bj"
+  },
+  {
+    "code": "831768",
+    "name": "拾比佰",
+    "market": "bj"
+  },
+  {
+    "code": "831832",
+    "name": "科达自控",
+    "market": "bj"
+  },
+  {
+    "code": "831855",
+    "name": "浙江大农",
+    "market": "bj"
+  },
+  {
+    "code": "831856",
+    "name": "浩淼科技",
+    "market": "bj"
+  },
+  {
+    "code": "831961",
+    "name": "创远信科",
+    "market": "bj"
+  },
+  {
+    "code": "832000",
+    "name": "安徽凤凰",
+    "market": "bj"
+  },
+  {
+    "code": "832023",
+    "name": "田野股份",
+    "market": "bj"
+  },
+  {
+    "code": "832089",
+    "name": "禾昌聚合",
+    "market": "bj"
+  },
+  {
+    "code": "832110",
+    "name": "雷特科技",
+    "market": "bj"
+  },
+  {
+    "code": "832149",
+    "name": "利尔达",
+    "market": "bj"
+  },
+  {
+    "code": "832171",
+    "name": "志晟信息",
+    "market": "bj"
+  },
+  {
+    "code": "832225",
+    "name": "利通科技",
+    "market": "bj"
+  },
+  {
+    "code": "832278",
+    "name": "鹿得医疗",
+    "market": "bj"
+  },
+  {
+    "code": "832419",
+    "name": "路斯股份",
+    "market": "bj"
+  },
+  {
+    "code": "832471",
+    "name": "三维股份",
+    "market": "bj"
+  },
+  {
+    "code": "832491",
+    "name": "奥迪威",
+    "market": "bj"
+  },
+  {
+    "code": "832566",
+    "name": "梓橦宫",
+    "market": "bj"
+  },
+  {
+    "code": "832651",
+    "name": "天罡股份",
+    "market": "bj"
+  },
+  {
+    "code": "832662",
+    "name": "方盛股份",
+    "market": "bj"
+  },
+  {
+    "code": "832735",
+    "name": "德源药业",
+    "market": "bj"
+  },
+  {
+    "code": "832786",
+    "name": "骑士乳业",
+    "market": "bj"
+  },
+  {
+    "code": "832802",
+    "name": "保丽洁",
+    "market": "bj"
+  },
+  {
+    "code": "832885",
+    "name": "星辰科技",
+    "market": "bj"
+  },
+  {
+    "code": "832978",
+    "name": "开特股份",
+    "market": "bj"
+  },
+  {
+    "code": "833030",
+    "name": "立方控股",
+    "market": "bj"
+  },
+  {
+    "code": "833075",
+    "name": "柏星龙",
+    "market": "bj"
+  },
+  {
+    "code": "833171",
+    "name": "国航远洋",
+    "market": "bj"
+  },
+  {
+    "code": "833230",
+    "name": "欧康医药",
+    "market": "bj"
+  },
+  {
+    "code": "833266",
+    "name": "生物谷",
+    "market": "bj"
+  },
+  {
+    "code": "833346",
+    "name": "威贸电子",
+    "market": "bj"
+  },
+  {
+    "code": "833394",
+    "name": "民士达",
+    "market": "bj"
+  },
+  {
+    "code": "833427",
+    "name": "华维设计",
+    "market": "bj"
+  },
+  {
+    "code": "833429",
+    "name": "康比特",
+    "market": "bj"
+  },
+  {
+    "code": "833454",
+    "name": "同心传动",
+    "market": "bj"
+  },
+  {
+    "code": "833509",
+    "name": "同惠电子",
+    "market": "bj"
+  },
+  {
+    "code": "833523",
+    "name": "德瑞锂电",
+    "market": "bj"
+  },
+  {
+    "code": "833533",
+    "name": "骏创科技",
+    "market": "bj"
+  },
+  {
+    "code": "833575",
+    "name": "康乐卫士",
+    "market": "bj"
+  },
+  {
+    "code": "833580",
+    "name": "科创新材",
+    "market": "bj"
+  },
+  {
+    "code": "833751",
+    "name": "惠同新材",
+    "market": "bj"
+  },
+  {
+    "code": "833781",
+    "name": "瑞奇智造",
+    "market": "bj"
+  },
+  {
+    "code": "833819",
+    "name": "颖泰生物",
+    "market": "bj"
+  },
+  {
+    "code": "833873",
+    "name": "中设咨询",
+    "market": "bj"
+  },
+  {
+    "code": "833914",
+    "name": "远航精密",
+    "market": "bj"
+  },
+  {
+    "code": "833943",
+    "name": "优机股份",
+    "market": "bj"
+  },
+  {
+    "code": "833994",
+    "name": "翰博高新",
+    "market": "bj"
+  },
+  {
+    "code": "834014",
+    "name": "特瑞斯",
+    "market": "bj"
+  },
+  {
+    "code": "834021",
+    "name": "流金科技",
+    "market": "bj"
+  },
+  {
+    "code": "834033",
+    "name": "康普化学",
+    "market": "bj"
+  },
+  {
+    "code": "834058",
+    "name": "华洋赛车",
+    "market": "bj"
+  },
+  {
+    "code": "834062",
+    "name": "科润智控",
+    "market": "bj"
+  },
+  {
+    "code": "834261",
+    "name": "一诺威",
+    "market": "bj"
+  },
+  {
+    "code": "834407",
+    "name": "驰诚股份",
+    "market": "bj"
+  },
+  {
+    "code": "834415",
+    "name": "恒拓开源",
+    "market": "bj"
+  },
+  {
+    "code": "834475",
+    "name": "三友科技",
+    "market": "bj"
+  },
+  {
+    "code": "834599",
+    "name": "同力股份",
+    "market": "bj"
+  },
+  {
+    "code": "834639",
+    "name": "晨光电缆",
+    "market": "bj"
+  },
+  {
+    "code": "834682",
+    "name": "球冠电缆",
+    "market": "bj"
+  },
+  {
+    "code": "834770",
+    "name": "艾能聚",
+    "market": "bj"
+  },
+  {
+    "code": "834950",
+    "name": "迅安科技",
+    "market": "bj"
+  },
+  {
+    "code": "835174",
+    "name": "天宏锂电",
+    "market": "bj"
+  },
+  {
+    "code": "835179",
+    "name": "凯德石英",
+    "market": "bj"
+  },
+  {
+    "code": "835184",
+    "name": "国源科技",
+    "market": "bj"
+  },
+  {
+    "code": "835237",
+    "name": "力佳科技",
+    "market": "bj"
+  },
+  {
+    "code": "835305",
+    "name": "云创数据",
+    "market": "bj"
+  },
+  {
+    "code": "835368",
+    "name": "连城数控",
+    "market": "bj"
+  },
+  {
+    "code": "835508",
+    "name": "殷图网联",
+    "market": "bj"
+  },
+  {
+    "code": "835579",
+    "name": "机科股份",
+    "market": "bj"
+  },
+  {
+    "code": "835640",
+    "name": "富士达",
+    "market": "bj"
+  },
+  {
+    "code": "835670",
+    "name": "数字人",
+    "market": "bj"
+  },
+  {
+    "code": "835857",
+    "name": "百甲科技",
+    "market": "bj"
+  },
+  {
+    "code": "835892",
+    "name": "中科美菱",
+    "market": "bj"
+  },
+  {
+    "code": "835985",
+    "name": "海泰新能",
+    "market": "bj"
+  },
+  {
+    "code": "836077",
+    "name": "吉林碳谷",
+    "market": "bj"
+  },
+  {
+    "code": "836149",
+    "name": "旭杰科技",
+    "market": "bj"
+  },
+  {
+    "code": "836208",
+    "name": "青矩技术",
+    "market": "bj"
+  },
+  {
+    "code": "836239",
+    "name": "长虹能源",
+    "market": "bj"
+  },
+  {
+    "code": "836247",
+    "name": "华密新材",
+    "market": "bj"
+  },
+  {
+    "code": "836260",
+    "name": "中寰股份",
+    "market": "bj"
+  },
+  {
+    "code": "836270",
+    "name": "天铭科技",
+    "market": "bj"
+  },
+  {
+    "code": "836414",
+    "name": "欧普泰",
+    "market": "bj"
+  },
+  {
+    "code": "836422",
+    "name": "常辅股份",
+    "market": "bj"
+  },
+  {
+    "code": "836504",
+    "name": "博迅医疗",
+    "market": "bj"
+  },
+  {
+    "code": "836699",
+    "name": "海达尔",
+    "market": "bj"
+  },
+  {
+    "code": "836717",
+    "name": "瑞星股份",
+    "market": "bj"
+  },
+  {
+    "code": "836720",
+    "name": "吉冈精密",
+    "market": "bj"
+  },
+  {
+    "code": "836807",
+    "name": "奔朗新材",
+    "market": "bj"
+  },
+  {
+    "code": "836826",
+    "name": "盖世食品",
+    "market": "bj"
+  },
+  {
+    "code": "836871",
+    "name": "派特尔",
+    "market": "bj"
+  },
+  {
+    "code": "836892",
+    "name": "广咨国际",
+    "market": "bj"
+  },
+  {
+    "code": "836942",
+    "name": "恒立钻具",
+    "market": "bj"
+  },
+  {
+    "code": "836957",
+    "name": "汉维科技",
+    "market": "bj"
+  },
+  {
+    "code": "836961",
+    "name": "西磁科技",
+    "market": "bj"
+  },
+  {
+    "code": "837006",
+    "name": "晟楠科技",
+    "market": "bj"
+  },
+  {
+    "code": "837046",
+    "name": "亿能电力",
+    "market": "bj"
+  },
+  {
+    "code": "837092",
+    "name": "汉鑫科技",
+    "market": "bj"
+  },
+  {
+    "code": "837174",
+    "name": "宏裕包材",
+    "market": "bj"
+  },
+  {
+    "code": "837212",
+    "name": "智新电子",
+    "market": "bj"
+  },
+  {
+    "code": "837242",
+    "name": "建邦科技",
+    "market": "bj"
+  },
+  {
+    "code": "837344",
+    "name": "三元基因",
+    "market": "bj"
+  },
+  {
+    "code": "837663",
+    "name": "明阳科技",
+    "market": "bj"
+  },
+  {
+    "code": "837748",
+    "name": "路桥信息",
+    "market": "bj"
+  },
+  {
+    "code": "837821",
+    "name": "则成电子",
+    "market": "bj"
+  },
+  {
+    "code": "837892",
+    "name": "号百控股",
+    "market": "bj"
+  },
+  {
+    "code": "838030",
+    "name": "德众汽车",
+    "market": "bj"
+  },
+  {
+    "code": "838163",
+    "name": "方大新材",
+    "market": "bj"
+  },
+  {
+    "code": "838171",
+    "name": "邦德股份",
+    "market": "bj"
+  },
+  {
+    "code": "838227",
+    "name": "美登科技",
+    "market": "bj"
+  },
+  {
+    "code": "838262",
+    "name": "太湖雪",
+    "market": "bj"
+  },
+  {
+    "code": "838275",
+    "name": "驱动力",
+    "market": "bj"
+  },
+  {
+    "code": "838402",
+    "name": "硅烷科技",
+    "market": "bj"
+  },
+  {
+    "code": "838670",
+    "name": "恒进感应",
+    "market": "bj"
+  },
+  {
+    "code": "838701",
+    "name": "豪声电子",
+    "market": "bj"
+  },
+  {
+    "code": "838810",
+    "name": "春光药装",
+    "market": "bj"
+  },
+  {
+    "code": "838837",
+    "name": "华原股份",
+    "market": "bj"
+  },
+  {
+    "code": "838924",
+    "name": "广脉科技",
+    "market": "bj"
+  },
+  {
+    "code": "838971",
+    "name": "天马新材",
+    "market": "bj"
+  },
+  {
+    "code": "839167",
+    "name": "同享科技",
+    "market": "bj"
+  },
+  {
+    "code": "839371",
+    "name": "欧福蛋业",
+    "market": "bj"
+  },
+  {
+    "code": "839680",
+    "name": "广道数字",
+    "market": "bj"
+  },
+  {
+    "code": "839719",
+    "name": "宁新新材",
+    "market": "bj"
+  },
+  {
+    "code": "839725",
+    "name": "惠丰钻石",
+    "market": "bj"
+  },
+  {
+    "code": "839729",
+    "name": "永顺生物",
+    "market": "bj"
+  },
+  {
+    "code": "839790",
+    "name": "联迪信息",
+    "market": "bj"
+  },
+  {
+    "code": "839792",
+    "name": "东和新材",
+    "market": "bj"
+  },
+  {
+    "code": "839946",
+    "name": "华阳变速",
+    "market": "bj"
+  },
+  {
+    "code": "870199",
+    "name": "倍益康",
+    "market": "bj"
+  },
+  {
+    "code": "870204",
+    "name": "沪江材料",
+    "market": "bj"
+  },
+  {
+    "code": "870299",
+    "name": "灿能电力",
+    "market": "bj"
+  },
+  {
+    "code": "870357",
+    "name": "雅葆轩",
+    "market": "bj"
+  },
+  {
+    "code": "870436",
+    "name": "大地电气",
+    "market": "bj"
+  },
+  {
+    "code": "870508",
+    "name": "丰安股份",
+    "market": "bj"
+  },
+  {
+    "code": "870656",
+    "name": "海昇药业",
+    "market": "bj"
+  },
+  {
+    "code": "870726",
+    "name": "鸿智科技",
+    "market": "bj"
+  },
+  {
+    "code": "870976",
+    "name": "视声智能",
+    "market": "bj"
+  },
+  {
+    "code": "871245",
+    "name": "威博液压",
+    "market": "bj"
+  },
+  {
+    "code": "871263",
+    "name": "莱赛激光",
+    "market": "bj"
+  },
+  {
+    "code": "871396",
+    "name": "常辅股份",
+    "market": "bj"
+  },
+  {
+    "code": "871478",
+    "name": "巨能股份",
+    "market": "bj"
+  },
+  {
+    "code": "871553",
+    "name": "凯腾精工",
+    "market": "bj"
+  },
+  {
+    "code": "871634",
+    "name": "新威凌",
+    "market": "bj"
+  },
+  {
+    "code": "871642",
+    "name": "通易航天",
+    "market": "bj"
+  },
+  {
+    "code": "871694",
+    "name": "中裕科技",
+    "market": "bj"
+  },
+  {
+    "code": "871753",
+    "name": "天纺标",
+    "market": "bj"
+  },
+  {
+    "code": "871857",
+    "name": "泓禧科技",
+    "market": "bj"
+  },
+  {
+    "code": "871970",
+    "name": "大禹生物",
+    "market": "bj"
+  },
+  {
+    "code": "872190",
+    "name": "雷神科技",
+    "market": "bj"
+  },
+  {
+    "code": "872351",
+    "name": "华光源海",
+    "market": "bj"
+  },
+  {
+    "code": "872374",
+    "name": "云里物里",
+    "market": "bj"
+  },
+  {
+    "code": "872392",
+    "name": "佳合科技",
+    "market": "bj"
+  },
+  {
+    "code": "872541",
+    "name": "铁大科技",
+    "market": "bj"
+  },
+  {
+    "code": "872808",
+    "name": "曙光数创",
+    "market": "bj"
+  },
+  {
+    "code": "872895",
+    "name": "花溪科技",
+    "market": "bj"
+  },
+  {
+    "code": "872925",
+    "name": "锦好医疗",
+    "market": "bj"
+  },
+  {
+    "code": "872931",
+    "name": "无锡鼎邦",
+    "market": "bj"
+  },
+  {
+    "code": "872953",
+    "name": "国子软件",
+    "market": "bj"
+  },
+  {
+    "code": "873001",
+    "name": "纬达光电",
+    "market": "bj"
+  },
+  {
+    "code": "873122",
+    "name": "中纺标",
+    "market": "bj"
+  },
+  {
+    "code": "873132",
+    "name": "泰鹏智能",
+    "market": "bj"
+  },
+  {
+    "code": "873152",
+    "name": "天宏锂电",
+    "market": "bj"
+  },
+  {
+    "code": "873167",
+    "name": "新赣江",
+    "market": "bj"
+  },
+  {
+    "code": "873169",
+    "name": "七丰精工",
+    "market": "bj"
+  },
+  {
+    "code": "873223",
+    "name": "荣亿精密",
+    "market": "bj"
+  },
+  {
+    "code": "873305",
+    "name": "九菱科技",
+    "market": "bj"
+  },
+  {
+    "code": "873339",
+    "name": "恒太照明",
+    "market": "bj"
+  },
+  {
+    "code": "873527",
+    "name": "夜光明",
+    "market": "bj"
+  },
+  {
+    "code": "873570",
+    "name": "坤博精工",
+    "market": "bj"
+  },
+  {
+    "code": "873576",
+    "name": "天力复合",
+    "market": "bj"
+  },
+  {
+    "code": "873593",
+    "name": "鼎智科技",
+    "market": "bj"
+  },
+  {
+    "code": "873665",
+    "name": "科强股份",
+    "market": "bj"
+  },
+  {
+    "code": "873679",
+    "name": "前进科技",
+    "market": "bj"
+  },
+  {
+    "code": "873693",
+    "name": "阿为特",
+    "market": "bj"
+  },
+  {
+    "code": "873706",
+    "name": "铁拓机械",
+    "market": "bj"
+  },
+  {
+    "code": "873726",
+    "name": "卓兆点胶",
+    "market": "bj"
+  },
+  {
+    "code": "873806",
+    "name": "云星宇",
+    "market": "bj"
+  },
+  {
+    "code": "873833",
+    "name": "美心翼申",
+    "market": "bj"
+  },
+  {
+    "code": "873859",
+    "name": "吉必盛",
+    "market": "bj"
+  },
+  {
+    "code": "874030",
+    "name": "武汉蓝电",
+    "market": "bj"
+  },
+  {
+    "code": "874094",
+    "name": "鸿星科技",
+    "market": "bj"
+  },
+  {
+    "code": "874205",
+    "name": "飞宇科技",
+    "market": "bj"
+  },
+  {
+    "code": "00001.HK",
+    "name": "长和",
+    "market": "hk"
+  },
+  {
+    "code": "00002.HK",
+    "name": "中电控股",
+    "market": "hk"
+  },
+  {
+    "code": "00003.HK",
+    "name": "香港中华煤气",
+    "market": "hk"
+  },
+  {
+    "code": "00005.HK",
+    "name": "汇丰控股",
+    "market": "hk"
+  },
+  {
+    "code": "00006.HK",
+    "name": "电能实业",
+    "market": "hk"
+  },
+  {
+    "code": "00011.HK",
+    "name": "恒生银行",
+    "market": "hk"
+  },
+  {
+    "code": "00012.HK",
+    "name": "恒基地产",
+    "market": "hk"
+  },
+  {
+    "code": "00016.HK",
+    "name": "新鸿基地产",
+    "market": "hk"
+  },
+  {
+    "code": "00017.HK",
+    "name": "新世界发展",
+    "market": "hk"
+  },
+  {
+    "code": "00019.HK",
+    "name": "太古股份公司A",
+    "market": "hk"
+  },
+  {
+    "code": "00023.HK",
+    "name": "东亚银行",
+    "market": "hk"
+  },
+  {
+    "code": "00027.HK",
+    "name": "银河娱乐",
+    "market": "hk"
+  },
+  {
+    "code": "00066.HK",
+    "name": "港铁公司",
+    "market": "hk"
+  },
+  {
+    "code": "00083.HK",
+    "name": "信和置业",
+    "market": "hk"
+  },
+  {
+    "code": "00101.HK",
+    "name": "恒隆地产",
+    "market": "hk"
+  },
+  {
+    "code": "00175.HK",
+    "name": "吉利汽车",
+    "market": "hk"
+  },
+  {
+    "code": "00241.HK",
+    "name": "阿里健康",
+    "market": "hk"
+  },
+  {
+    "code": "00267.HK",
+    "name": "中信股份",
+    "market": "hk"
+  },
+  {
+    "code": "00268.HK",
+    "name": "金蝶国际",
+    "market": "hk"
+  },
+  {
+    "code": "00270.HK",
+    "name": "粤海投资",
+    "market": "hk"
+  },
+  {
+    "code": "00285.HK",
+    "name": "比亚迪电子",
+    "market": "hk"
+  },
+  {
+    "code": "00288.HK",
+    "name": "万洲国际",
+    "market": "hk"
+  },
+  {
+    "code": "00291.HK",
+    "name": "华润啤酒",
+    "market": "hk"
+  },
+  {
+    "code": "00316.HK",
+    "name": "东方海外国际",
+    "market": "hk"
+  },
+  {
+    "code": "00322.HK",
+    "name": "康师傅控股",
+    "market": "hk"
+  },
+  {
+    "code": "00345.HK",
+    "name": "维他奶国际",
+    "market": "hk"
+  },
+  {
+    "code": "00386.HK",
+    "name": "中国石油化工股份",
+    "market": "hk"
   },
   {
     "code": "00388.HK",
@@ -195,13 +22255,63 @@
     "market": "hk"
   },
   {
+    "code": "00762.HK",
+    "name": "中国联通",
+    "market": "hk"
+  },
+  {
+    "code": "00780.HK",
+    "name": "同程旅行",
+    "market": "hk"
+  },
+  {
+    "code": "00788.HK",
+    "name": "中国铁塔",
+    "market": "hk"
+  },
+  {
+    "code": "00823.HK",
+    "name": "领展房产基金",
+    "market": "hk"
+  },
+  {
+    "code": "00857.HK",
+    "name": "中国石油股份",
+    "market": "hk"
+  },
+  {
+    "code": "00868.HK",
+    "name": "信义光能",
+    "market": "hk"
+  },
+  {
+    "code": "00881.HK",
+    "name": "中升控股",
+    "market": "hk"
+  },
+  {
     "code": "00883.HK",
     "name": "中国海洋石油",
     "market": "hk"
   },
   {
+    "code": "00909.HK",
+    "name": "明源云",
+    "market": "hk"
+  },
+  {
+    "code": "00914.HK",
+    "name": "海螺水泥",
+    "market": "hk"
+  },
+  {
+    "code": "00916.HK",
+    "name": "龙源电力",
+    "market": "hk"
+  },
+  {
     "code": "00939.HK",
-    "name": "建设银行",
+    "name": "中国建设银行",
     "market": "hk"
   },
   {
@@ -210,8 +22320,108 @@
     "market": "hk"
   },
   {
+    "code": "00960.HK",
+    "name": "龙湖集团",
+    "market": "hk"
+  },
+  {
+    "code": "00968.HK",
+    "name": "信义玻璃",
+    "market": "hk"
+  },
+  {
+    "code": "00981.HK",
+    "name": "中芯国际",
+    "market": "hk"
+  },
+  {
+    "code": "00992.HK",
+    "name": "联想集团",
+    "market": "hk"
+  },
+  {
     "code": "01024.HK",
-    "name": "快手",
+    "name": "快手-W",
+    "market": "hk"
+  },
+  {
+    "code": "01038.HK",
+    "name": "长江基建集团",
+    "market": "hk"
+  },
+  {
+    "code": "01044.HK",
+    "name": "恒安国际",
+    "market": "hk"
+  },
+  {
+    "code": "01057.HK",
+    "name": "浙江沪杭甬",
+    "market": "hk"
+  },
+  {
+    "code": "01066.HK",
+    "name": "威高股份",
+    "market": "hk"
+  },
+  {
+    "code": "01071.HK",
+    "name": "华电国际电力股份",
+    "market": "hk"
+  },
+  {
+    "code": "01088.HK",
+    "name": "中国神华",
+    "market": "hk"
+  },
+  {
+    "code": "01093.HK",
+    "name": "石药集团",
+    "market": "hk"
+  },
+  {
+    "code": "01099.HK",
+    "name": "国药控股",
+    "market": "hk"
+  },
+  {
+    "code": "01109.HK",
+    "name": "华润置地",
+    "market": "hk"
+  },
+  {
+    "code": "01113.HK",
+    "name": "长实集团",
+    "market": "hk"
+  },
+  {
+    "code": "01171.HK",
+    "name": "兖矿能源",
+    "market": "hk"
+  },
+  {
+    "code": "01177.HK",
+    "name": "中国生物制药",
+    "market": "hk"
+  },
+  {
+    "code": "01193.HK",
+    "name": "华润燃气",
+    "market": "hk"
+  },
+  {
+    "code": "01209.HK",
+    "name": "华润万象生活",
+    "market": "hk"
+  },
+  {
+    "code": "01211.HK",
+    "name": "比亚迪股份",
+    "market": "hk"
+  },
+  {
+    "code": "01288.HK",
+    "name": "中国农业银行",
     "market": "hk"
   },
   {
@@ -220,18 +22430,153 @@
     "market": "hk"
   },
   {
+    "code": "01347.HK",
+    "name": "华虹半导体",
+    "market": "hk"
+  },
+  {
+    "code": "01357.HK",
+    "name": "美图公司",
+    "market": "hk"
+  },
+  {
+    "code": "01378.HK",
+    "name": "中国宏桥",
+    "market": "hk"
+  },
+  {
     "code": "01398.HK",
     "name": "工商银行",
     "market": "hk"
   },
   {
+    "code": "01448.HK",
+    "name": "福寿园",
+    "market": "hk"
+  },
+  {
+    "code": "01530.HK",
+    "name": "三生制药",
+    "market": "hk"
+  },
+  {
+    "code": "01548.HK",
+    "name": "金斯瑞生物科技",
+    "market": "hk"
+  },
+  {
+    "code": "01658.HK",
+    "name": "邮储银行",
+    "market": "hk"
+  },
+  {
+    "code": "01772.HK",
+    "name": "赣锋锂业",
+    "market": "hk"
+  },
+  {
+    "code": "01776.HK",
+    "name": "广发证券",
+    "market": "hk"
+  },
+  {
+    "code": "01787.HK",
+    "name": "山东黄金",
+    "market": "hk"
+  },
+  {
+    "code": "01797.HK",
+    "name": "东方甄选",
+    "market": "hk"
+  },
+  {
     "code": "01810.HK",
-    "name": "小米集团",
+    "name": "小米集团-W",
+    "market": "hk"
+  },
+  {
+    "code": "01818.HK",
+    "name": "招金矿业",
+    "market": "hk"
+  },
+  {
+    "code": "01833.HK",
+    "name": "平安好医生",
+    "market": "hk"
+  },
+  {
+    "code": "01876.HK",
+    "name": "百济神州",
+    "market": "hk"
+  },
+  {
+    "code": "01898.HK",
+    "name": "中煤能源",
+    "market": "hk"
+  },
+  {
+    "code": "01919.HK",
+    "name": "中远海控",
+    "market": "hk"
+  },
+  {
+    "code": "01928.HK",
+    "name": "金沙中国有限公司",
+    "market": "hk"
+  },
+  {
+    "code": "01929.HK",
+    "name": "周大福",
+    "market": "hk"
+  },
+  {
+    "code": "01951.HK",
+    "name": "锦欣生殖",
+    "market": "hk"
+  },
+  {
+    "code": "01997.HK",
+    "name": "九龙仓置业",
+    "market": "hk"
+  },
+  {
+    "code": "02007.HK",
+    "name": "碧桂园服务",
+    "market": "hk"
+  },
+  {
+    "code": "02013.HK",
+    "name": "微盟集团",
     "market": "hk"
   },
   {
     "code": "02015.HK",
-    "name": "理想汽车",
+    "name": "理想汽车-W",
+    "market": "hk"
+  },
+  {
+    "code": "02018.HK",
+    "name": "瑞声科技",
+    "market": "hk"
+  },
+  {
+    "code": "02020.HK",
+    "name": "安踏体育",
+    "market": "hk"
+  },
+  {
+    "code": "02057.HK",
+    "name": "中通快递-W",
+    "market": "hk"
+  },
+  {
+    "code": "02269.HK",
+    "name": "药明生物",
+    "market": "hk"
+  },
+  {
+    "code": "02313.HK",
+    "name": "申洲国际",
     "market": "hk"
   },
   {
@@ -240,13 +22585,113 @@
     "market": "hk"
   },
   {
-    "code": "02577.HK",
-    "name": "英诺赛科",
+    "code": "02319.HK",
+    "name": "蒙牛乳业",
+    "market": "hk"
+  },
+  {
+    "code": "02328.HK",
+    "name": "中国财险",
+    "market": "hk"
+  },
+  {
+    "code": "02331.HK",
+    "name": "李宁",
+    "market": "hk"
+  },
+  {
+    "code": "02333.HK",
+    "name": "长城汽车",
+    "market": "hk"
+  },
+  {
+    "code": "02338.HK",
+    "name": "潍柴动力",
+    "market": "hk"
+  },
+  {
+    "code": "02359.HK",
+    "name": "药明康德",
+    "market": "hk"
+  },
+  {
+    "code": "02382.HK",
+    "name": "舜宇光学科技",
+    "market": "hk"
+  },
+  {
+    "code": "02388.HK",
+    "name": "中银香港",
+    "market": "hk"
+  },
+  {
+    "code": "02469.HK",
+    "name": "粉笔",
+    "market": "hk"
+  },
+  {
+    "code": "02588.HK",
+    "name": "中银航空租赁",
+    "market": "hk"
+  },
+  {
+    "code": "02601.HK",
+    "name": "中国太保",
+    "market": "hk"
+  },
+  {
+    "code": "02618.HK",
+    "name": "京东物流",
+    "market": "hk"
+  },
+  {
+    "code": "02628.HK",
+    "name": "中国人寿",
+    "market": "hk"
+  },
+  {
+    "code": "02688.HK",
+    "name": "新奥能源",
+    "market": "hk"
+  },
+  {
+    "code": "02696.HK",
+    "name": "百丽时尚",
+    "market": "hk"
+  },
+  {
+    "code": "02899.HK",
+    "name": "紫金矿业",
+    "market": "hk"
+  },
+  {
+    "code": "03328.HK",
+    "name": "交通银行",
+    "market": "hk"
+  },
+  {
+    "code": "03333.HK",
+    "name": "中国恒大",
+    "market": "hk"
+  },
+  {
+    "code": "03380.HK",
+    "name": "龙光集团",
     "market": "hk"
   },
   {
     "code": "03690.HK",
-    "name": "美团",
+    "name": "美团-W",
+    "market": "hk"
+  },
+  {
+    "code": "03888.HK",
+    "name": "金山软件",
+    "market": "hk"
+  },
+  {
+    "code": "03968.HK",
+    "name": "招商银行",
     "market": "hk"
   },
   {
@@ -260,38 +22705,113 @@
     "market": "hk"
   },
   {
+    "code": "06098.HK",
+    "name": "碧桂园",
+    "market": "hk"
+  },
+  {
+    "code": "06160.HK",
+    "name": "百济神州",
+    "market": "hk"
+  },
+  {
+    "code": "06185.HK",
+    "name": "康龙化成",
+    "market": "hk"
+  },
+  {
     "code": "06618.HK",
     "name": "京东健康",
     "market": "hk"
   },
   {
+    "code": "06690.HK",
+    "name": "海尔智家",
+    "market": "hk"
+  },
+  {
+    "code": "06862.HK",
+    "name": "海底捞",
+    "market": "hk"
+  },
+  {
+    "code": "06969.HK",
+    "name": "思摩尔国际",
+    "market": "hk"
+  },
+  {
     "code": "09618.HK",
-    "name": "京东集团",
+    "name": "京东集团-SW",
     "market": "hk"
   },
   {
     "code": "09626.HK",
-    "name": "哔哩哔哩",
+    "name": "哔哩哔哩-W",
+    "market": "hk"
+  },
+  {
+    "code": "09633.HK",
+    "name": "农夫山泉",
+    "market": "hk"
+  },
+  {
+    "code": "09668.HK",
+    "name": "阅文集团",
+    "market": "hk"
+  },
+  {
+    "code": "09688.HK",
+    "name": "百度集团-SW",
+    "market": "hk"
+  },
+  {
+    "code": "09698.HK",
+    "name": "万国数据-SW",
+    "market": "hk"
+  },
+  {
+    "code": "09888.HK",
+    "name": "百度集团-SW",
+    "market": "hk"
+  },
+  {
+    "code": "09899.HK",
+    "name": "网易-S",
+    "market": "hk"
+  },
+  {
+    "code": "09901.HK",
+    "name": "新东方在线",
+    "market": "hk"
+  },
+  {
+    "code": "09961.HK",
+    "name": "携程集团-S",
+    "market": "hk"
+  },
+  {
+    "code": "09988.HK",
+    "name": "阿里巴巴-SW",
+    "market": "hk"
+  },
+  {
+    "code": "09999.HK",
+    "name": "网易-S",
+    "market": "hk"
+  },
+  {
+    "code": "001979",
+    "name": "招商蛇口",
+    "market": "sz"
+  },
+  {
+    "code": "02577.HK",
+    "name": "英诺赛科",
     "market": "hk"
   },
   {
     "code": "09868.HK",
     "name": "小鹏汽车",
-    "market": "hk"
-  },
-  {
-    "code": "09888.HK",
-    "name": "百度集团",
-    "market": "hk"
-  },
-  {
-    "code": "09988.HK",
-    "name": "阿里巴巴",
-    "market": "hk"
-  },
-  {
-    "code": "09999.HK",
-    "name": "网易",
     "market": "hk"
   },
   {
@@ -315,66 +22835,6 @@
     "market": "sz"
   },
   {
-    "code": "300014",
-    "name": "亿纬锂能",
-    "market": "sz"
-  },
-  {
-    "code": "300015",
-    "name": "爱尔眼科",
-    "market": "sz"
-  },
-  {
-    "code": "300059",
-    "name": "东方财富",
-    "market": "sz"
-  },
-  {
-    "code": "300122",
-    "name": "智飞生物",
-    "market": "sz"
-  },
-  {
-    "code": "300124",
-    "name": "汇川技术",
-    "market": "sz"
-  },
-  {
-    "code": "300274",
-    "name": "阳光电源",
-    "market": "sz"
-  },
-  {
-    "code": "300308",
-    "name": "中际旭创",
-    "market": "sz"
-  },
-  {
-    "code": "300433",
-    "name": "蓝思科技",
-    "market": "sz"
-  },
-  {
-    "code": "300498",
-    "name": "温氏股份",
-    "market": "sz"
-  },
-  {
-    "code": "300502",
-    "name": "新易盛",
-    "market": "sz"
-  },
-  {
-    "code": "300750",
-    "name": "宁德时代",
-    "market": "sz"
-  },
-  {
-    "code": "300760",
-    "name": "迈瑞医疗",
-    "market": "sz"
-  },
-  {
     "code": "510300",
     "name": "沪深300ETF",
     "market": "sz"
@@ -388,81 +22848,6 @@
     "code": "519674",
     "name": "银河创新成长混合",
     "market": "sz"
-  },
-  {
-    "code": "600000",
-    "name": "浦发银行",
-    "market": "sh"
-  },
-  {
-    "code": "600009",
-    "name": "上海机场",
-    "market": "sh"
-  },
-  {
-    "code": "600019",
-    "name": "宝钢股份",
-    "market": "sh"
-  },
-  {
-    "code": "600028",
-    "name": "中国石化",
-    "market": "sh"
-  },
-  {
-    "code": "600030",
-    "name": "中信证券",
-    "market": "sh"
-  },
-  {
-    "code": "600036",
-    "name": "招商银行",
-    "market": "sh"
-  },
-  {
-    "code": "600048",
-    "name": "保利发展",
-    "market": "sh"
-  },
-  {
-    "code": "600050",
-    "name": "中国联通",
-    "market": "sh"
-  },
-  {
-    "code": "600104",
-    "name": "上汽集团",
-    "market": "sh"
-  },
-  {
-    "code": "600276",
-    "name": "恒瑞医药",
-    "market": "sh"
-  },
-  {
-    "code": "600309",
-    "name": "万华化学",
-    "market": "sh"
-  },
-  {
-    "code": "600519",
-    "name": "贵州茅台",
-    "market": "sh"
-  },
-  {
-    "code": "600585",
-    "name": "海螺水泥",
-    "market": "sh"
-  },
-  {
-    "code": "600690",
-    "name": "海尔智家",
-    "market": "sh"
-  },
-  {
-    "code": "600900",
-    "name": "长江电力",
-    "market": "sh"
   },
   {
     "code": "601012",
@@ -560,73 +22945,8 @@
     "market": "sh"
   },
   {
-    "code": "830799",
-    "name": "艾融软件",
-    "market": "bj"
-  },
-  {
-    "code": "832491",
-    "name": "奥迪威",
-    "market": "bj"
-  },
-  {
-    "code": "833171",
-    "name": "国航远洋",
-    "market": "bj"
-  },
-  {
-    "code": "833533",
-    "name": "骏创科技",
-    "market": "bj"
-  },
-  {
-    "code": "834033",
-    "name": "康普化学",
-    "market": "bj"
-  },
-  {
-    "code": "834599",
-    "name": "同力股份",
-    "market": "bj"
-  },
-  {
     "code": "835185",
     "name": "贝特瑞",
-    "market": "bj"
-  },
-  {
-    "code": "835640",
-    "name": "富士达",
-    "market": "bj"
-  },
-  {
-    "code": "836077",
-    "name": "吉林碳谷",
-    "market": "bj"
-  },
-  {
-    "code": "836892",
-    "name": "广咨国际",
-    "market": "bj"
-  },
-  {
-    "code": "837344",
-    "name": "三元基因",
-    "market": "bj"
-  },
-  {
-    "code": "839167",
-    "name": "同享科技",
-    "market": "bj"
-  },
-  {
-    "code": "839725",
-    "name": "惠丰钻石",
-    "market": "bj"
-  },
-  {
-    "code": "872808",
-    "name": "曙光数创",
     "market": "bj"
   }
 ]

--- a/gui/templates/select_stock.html
+++ b/gui/templates/select_stock.html
@@ -206,6 +206,46 @@
         color: #777;
         font-size: 0.95rem;
       }
+
+      /* 选股后预缓存加载提示 */
+      #prefetch-overlay {
+        position: fixed;
+        top: 0; left: 0; right: 0; bottom: 0;
+        background: rgba(0,0,0,0.5);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 9999;
+      }
+      .prefetch-modal {
+        background: white;
+        border-radius: 12px;
+        padding: 2rem 3rem;
+        text-align: center;
+        box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+        max-width: 400px;
+      }
+      .prefetch-spinner {
+        width: 40px; height: 40px;
+        margin: 0 auto 1rem;
+        border: 4px solid #e0e0e0;
+        border-top-color: #1976d2;
+        border-radius: 50%;
+        animation: prefetch-spin 0.8s linear infinite;
+      }
+      @keyframes prefetch-spin {
+        to { transform: rotate(360deg); }
+      }
+      .prefetch-text {
+        margin: 0 0 0.5rem;
+        font-size: 1rem;
+        color: #333;
+      }
+      .prefetch-hint {
+        margin: 0;
+        font-size: 0.85rem;
+        color: #999;
+      }
     
 /* === 移动端响应式适配 === */
 @media (max-width: 640px) {
@@ -493,9 +533,20 @@
           });
       });
 
-      // 选择股票
+      // 选择股票 + 预缓存日线数据
       function selectStock(code, name) {
-        // 保存选择到后端session
+        // 显示加载提示
+        const overlay = document.createElement('div');
+        overlay.id = 'prefetch-overlay';
+        overlay.innerHTML =
+          '<div class="prefetch-modal">' +
+            '<div class="prefetch-spinner"></div>' +
+            '<p class="prefetch-text">正在下载 <strong>' + name + '</strong> 近5年日线数据...</p>' +
+            '<p class="prefetch-hint">首次下载可能需要几秒钟</p>' +
+          '</div>';
+        document.body.appendChild(overlay);
+
+        // 先保存股票到session
         fetch('/api/select_stock', {
           method: 'POST',
           headers: {
@@ -505,14 +556,22 @@
         })
         .then(response => response.json())
         .then(data => {
-          if (data.success) {
-            // 跳转到策略选择页面
-            window.location.href = '/select_strategy';
-          } else {
+          if (!data.success) {
+            document.body.removeChild(overlay);
             alert('选择失败：' + (data.error || '未知错误'));
+            return;
           }
+          // 触发预缓存（后台执行，不阻塞跳转）
+          fetch('/api/prefetch_stock/' + encodeURIComponent(code), { method: 'POST' })
+            .then(function() { /* 静默完成 — 数据已缓存 */ })
+            .catch(function() { /* 预缓存失败不阻止导航 */ });
+          // 延迟一小段时间后跳转
+          setTimeout(function() {
+            window.location.href = '/select_strategy';
+          }, 800);
         })
         .catch(err => {
+          document.body.removeChild(overlay);
           alert('选择失败：' + err.message);
         });
       }

--- a/gui/web.py
+++ b/gui/web.py
@@ -13,6 +13,9 @@ import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from flask import Flask, render_template, request, session, jsonify, Response
 
+# 股票预缓存模块 — 选股后自动下载5年日线数据
+from exchange.prefetch import prefetch_stock_data
+
 logger = logging.getLogger(__name__)
 
 # Ensure project root is on sys.path so sibling packages (e.g. `source`) can be imported
@@ -26,6 +29,8 @@ app.secret_key = os.environ.get('SECRET_KEY', 'stocks-quantitative-backtest-secr
 # 在应用启动时加载股票列表到内存，避免重复文件IO
 _STOCK_LIST = None
 _STOCK_INDEX = None
+_FULL_STOCK_LIST = None       # 全量股票缓存（含akshare动态加载）
+_FULL_STOCK_INDEX = None      # 全量股票索引
 _DOWNLOAD_SOURCES = ('akshare', 'baostock', 'tencent', 'sina', 'sohu', 'eastmoney', 'cailianpress', 'stooq')
 
 
@@ -590,6 +595,17 @@ def select_stock():
     _push_recent_stock(code)
 
     return jsonify({'success': True})
+
+
+@app.route('/api/prefetch_stock/<symbol>', methods=['POST'])
+def prefetch_stock_api(symbol):
+    """选股后自动预缓存5年日线数据"""
+    try:
+        result = prefetch_stock_data(symbol)
+        return jsonify(result)
+    except Exception as e:
+        logger.error("预缓存 %s 异常: %s", symbol, str(e))
+        return jsonify({'success': False, 'rows': 0, 'symbol': symbol, 'error': str(e)})
 
 
 @app.route('/api/select_strategy', methods=['POST'])


### PR DESCRIPTION
## 改动内容

股票搜索功能改进：预加载全量股票列表 + 选股后自动缓存5年日线数据

### Exchange 角色变更 (@EXCH)
- 新建 `exchange/prefetch.py` — `prefetch_stock_data(symbol, years=5)` 函数
  - 通过 `get_data()` 调用预取5年日线数据并自动缓存到 `data/{symbol}.csv`
  - 返回 `{'success': bool, 'rows': int, 'symbol': str, 'error': str | None}`

### GUI 角色变更 (@WEB)
- **股票搜索扩充**：`gui/stock_list.json` 从 126 只扩充到 4590 只（覆盖沪深北港全部 A 股+ETF）
- **选股后自动预缓存**：用户在搜索/点击选择股票后，自动触发 `/api/prefetch_stock/<symbol>` 预取5年日线
  - 展示转圈加载动画 + 状态文字提示
  - 预缓存失败不阻塞正常跳转（降级体验）
- 新增后端 API：
  - `POST /api/prefetch_stock/<symbol>` — 调用 `exchange.prefetch.prefetch_stock_data()`

### 测试
- ✅ 单元/集成测试 160 passed, 17 skipped
- ✅ 搜索 API 向后兼容（ETF/基金搜索正常）
- ✅ JSON 数据有效，无重复条目

Closes #183
