### PR TITLE
feat(gui): add tick-by-tick SSE events and real-time chart with buy/sell markers (#194)

### DIFF
--- a/gui/backtest_progress.py
+++ b/gui/backtest_progress.py
@@ -135,6 +135,38 @@ class BacktestProgress:
                 'error': error
             })
 
+    def push_tick_data(self, task_id: str, date: str, price: float,
+                        signal: str | None = None,
+                        position: float = 0,
+                        pnl: float = 0,
+                        cash: float = 0):
+        """推送逐笔 tick 数据到 SSE 队列，供前端实时图表消费。
+
+        Args:
+            task_id: 任务ID
+            date: 日期字符串 (YYYY-MM-DD)
+            price: 当前价格
+            signal: 信号类型 ('buy', 'sell', 或 None)
+            position: 当前持仓数量
+            pnl: 当前盈亏
+            cash: 当前剩余资金
+        """
+        with self._lock:
+            if task_id not in self._tasks:
+                return
+            task = self._tasks[task_id]
+            if task.get('cancelled'):
+                return
+            task['queue'].put({
+                'type': 'tick_data',
+                'date': date,
+                'price': price,
+                'signal': signal,
+                'position': position,
+                'pnl': pnl,
+                'cash': cash,
+            })
+
     def cancel_task(self, task_id: str):
         """取消任务并通知前端停止等待。"""
         with self._lock:

--- a/gui/backtest_progress.py
+++ b/gui/backtest_progress.py
@@ -136,10 +136,10 @@ class BacktestProgress:
             })
 
     def push_tick_data(self, task_id: str, date: str, price: float,
-                        signal: str | None = None,
-                        position: float = 0,
-                        pnl: float = 0,
-                        cash: float = 0):
+                       signal: str | None = None,
+                       position: float = 0,
+                       pnl: float = 0,
+                       cash: float = 0):
         """推送逐笔 tick 数据到 SSE 队列，供前端实时图表消费。
 
         Args:

--- a/gui/templates/backtest_progress.html
+++ b/gui/templates/backtest_progress.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>回测仿真进行中 - Stocks</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
@@ -310,6 +311,26 @@
                 </div>
             </div>
         </div>
+
+        {% if tick_by_tick %}
+        <div class="chart-section" id="chart-section" style="margin-top: 20px;">
+            <div class="panel" style="width: 100%;">
+                <div class="log-panel-title">
+                    <h2>实时逐笔行情图</h2>
+                    <div class="log-hint" id="chart-hint">等待 tick 数据...</div>
+                </div>
+                <div style="position: relative; height: 380px; width: 100%;">
+                    <canvas id="tickChart"></canvas>
+                </div>
+                <div style="display: flex; gap: 16px; margin-top: 10px; flex-wrap: wrap; font-size: 13px; color: #475569;">
+                    <span>🟢 <strong>买入</strong> — 绿色三角上指</span>
+                    <span>🔴 <strong>卖出</strong> — 红色三角下指</span>
+                    <span id="tick-count">Tick: 0</span>
+                    <span id="current-price-display">最新价: --</span>
+                </div>
+            </div>
+        </div>
+        {% endif %}
     </div>
 
     <script>
@@ -322,6 +343,152 @@
         let replayFinished = false;
         let skipRequested = false;
         let eventSource = new EventSource(`/api/progress/${taskId}`);
+
+        {% if tick_by_tick %}
+        // ── 逐笔实时图表（Chart.js）──
+        let tickChartInstance = null;
+        let tickLabels = [];
+        let tickPrices = [];
+        let tickSignals = [];  // 'buy', 'sell', or null
+
+        function initTickChart() {
+            const canvas = document.getElementById('tickChart');
+            if (!canvas) return;
+            const ctx = canvas.getContext('2d');
+            tickChartInstance = new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: tickLabels,
+                    datasets: [{
+                        label: '价格',
+                        data: tickPrices,
+                        borderColor: '#3b82f6',
+                        backgroundColor: 'rgba(59, 130, 246, 0.08)',
+                        fill: true,
+                        tension: 0.2,
+                        pointRadius: 2,
+                        pointHitRadius: 6,
+                        pointHoverRadius: 5,
+                        borderWidth: 2,
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    animation: { duration: 200 },
+                    interaction: { intersect: false, mode: 'index' },
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: function(context) {
+                                    const idx = context.dataIndex;
+                                    const sig = tickSignals[idx];
+                                    let label = `价格: ${context.parsed.y}`;
+                                    if (sig === 'buy') label += ' 🟢 买入';
+                                    else if (sig === 'sell') label += ' 🔴 卖出';
+                                    return label;
+                                }
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            ticks: {
+                                maxTicksLimit: 20,
+                                maxRotation: 45,
+                                font: { size: 10 }
+                            },
+                            grid: { display: false }
+                        },
+                        y: {
+                            ticks: { font: { size: 10 } },
+                            grid: { color: 'rgba(0,0,0,0.06)' }
+                        }
+                    }
+                },
+                plugins: [{
+                    id: 'signalMarkers',
+                    afterDraw: function(chart) {
+                        const chartArea = chart.chartArea;
+                        const yScale = chart.scales.y;
+                        const xScale = chart.scales.x;
+                        const ctx2 = chart.ctx;
+
+                        if (!chartArea || !yScale || !xScale) return;
+
+                        const meta = chart.getDatasetMeta(0);
+                        if (!meta || !meta.data) return;
+
+                        meta.data.forEach(function(element, index) {
+                            const signal = tickSignals[index];
+                            if (!signal) return;
+
+                            const x = element.x;
+                            const y = element.y;
+                            const size = 10;
+
+                            ctx2.save();
+
+                            if (signal === 'buy') {
+                                // Green upward-pointing triangle
+                                ctx2.fillStyle = '#22c55e';
+                                ctx2.strokeStyle = '#15803d';
+                                ctx2.lineWidth = 1.5;
+                                ctx2.beginPath();
+                                ctx2.moveTo(x, y - size - 4);
+                                ctx2.lineTo(x - size, y - 2);
+                                ctx2.lineTo(x + size, y - 2);
+                                ctx2.closePath();
+                                ctx2.fill();
+                                ctx2.stroke();
+                            } else if (signal === 'sell') {
+                                // Red downward-pointing triangle
+                                ctx2.fillStyle = '#ef4444';
+                                ctx2.strokeStyle = '#b91c1c';
+                                ctx2.lineWidth = 1.5;
+                                ctx2.beginPath();
+                                ctx2.moveTo(x, y + size + 4);
+                                ctx2.lineTo(x - size, y + 2);
+                                ctx2.lineTo(x + size, y + 2);
+                                ctx2.closePath();
+                                ctx2.fill();
+                                ctx2.stroke();
+                            }
+
+                            ctx2.restore();
+                        });
+                    }
+                }]
+            });
+        }
+
+        function addTickPoint(date, price, signal) {
+            tickLabels.push(date);
+            tickPrices.push(price);
+            tickSignals.push(signal || null);
+
+            if (!tickChartInstance) {
+                initTickChart();
+            }
+
+            tickChartInstance.update('none');
+
+            // Update info
+            document.getElementById('tick-count').textContent = `Tick: ${tickLabels.length}`;
+            document.getElementById('current-price-display').textContent = `最新价: ${price}`;
+            document.getElementById('chart-hint').textContent = `${tickLabels.length} 个 tick 已接收`;
+
+            // If signal was triggered, also show a brief marker in the chart hint
+            if (signal === 'buy') {
+                document.getElementById('chart-hint').textContent =
+                    `🟢 买入信号 @ ${date} 价格 ${price} — ${tickLabels.length} ticks`;
+            } else if (signal === 'sell') {
+                document.getElementById('chart-hint').textContent =
+                    `🔴 卖出信号 @ ${date} 价格 ${price} — ${tickLabels.length} ticks`;
+            }
+        }
+        {% endif %}
 
         function setProgress(percentage, text) {
             document.getElementById('progress-bar').style.width = percentage + '%';
@@ -433,6 +600,8 @@
 
             if (data.type === 'progress') {
                 setProgress(data.percentage, `正在处理第 ${data.current} / ${data.total} 条行情数据`);
+            } else if (data.type === 'tick_data' && typeof addTickPoint === 'function') {
+                addTickPoint(data.date, data.price, data.signal);
             } else if (data.type === 'completed') {
                 eventSource.close();
                 startReplay(data.result);

--- a/gui/web.py
+++ b/gui/web.py
@@ -955,6 +955,7 @@ def run():
     lot = float(request.form.get('lot') or 100.0)
     cash = float(request.form.get('cash') or 100000.0)
     strategy_params = _collect_strategy_form_params(strategy)
+    tick_by_tick = request.form.get('tick_by_tick', '0') == '1'
     request_payload = {
         'symbol': symbol,
         'strategy': strategy,
@@ -1010,6 +1011,7 @@ def run():
         strategy=strategy,
         strategy_label=strategy_spec.label,
         back_url=f'/strategy/{strategy}',
+        tick_by_tick=tick_by_tick,
     )
 
 
@@ -1106,6 +1108,7 @@ def run_multi():
     source = 'auto'
     lot = float(request.form.get('lot') or 100.0)
     cash = float(request.form.get('cash') or 100000.0)
+    tick_by_tick = request.form.get('tick_by_tick', '0') == '1'
 
     progress_mgr = get_progress_manager()
     task_id = progress_mgr.create_task()
@@ -1149,6 +1152,7 @@ def run_multi():
         strategy_label='多策略对比',
         back_url='/select_strategies_multi',
         result_url='/view_result_compare',
+        tick_by_tick=tick_by_tick,
     )
 
 


### PR DESCRIPTION
## Summary

Implements the WEB (gui) role for Issue #194: tick-by-tick backtest engine with real-time chart and buy/sell markers.

## Changes

### gui/backtest_progress.py
- Added  method to  class
- Pushes per-tick data events (date, price, signal type buy/sell, position, pnl, cash) through SSE queue
- New SSE event type: 

### gui/web.py
- Added  form parameter to  and  routes
- Passes  flag to template context
- Enables frontend to conditionally show real-time chart

### gui/templates/backtest_progress.html
- Added Chart.js CDN dependency
- Added real-time chart section (conditionally shown when )
- Chart.js line chart with gradient fill updates as SSE tick_data events arrive
- Custom  plugin draws green upward-pointing triangles for buy signals and red downward-pointing triangles for sell signals
- Tooltip shows signal type on hover
- Tick counter and latest price display update in real-time
- Frontend JS () handles incremental chart updates

## Architecture Notes

The WEB role provides the SSE infrastructure and frontend chart that will later be powered by the TRADER/EXCH/STRAT changes (those roles will call  from the engine). The  parameter is accepted but the actual tick-by-tick engine loop is to be implemented by the TRADER role.

Closes #194