### PR TITLE
feat(trader): tick-by-tick pacing engine for tick-by-tick backtest (#194)

### DIFF
--- a/gui/backtest_progress.py
+++ b/gui/backtest_progress.py
@@ -70,6 +70,25 @@ class BacktestProgress:
                 'percentage': percentage
             })
 
+    # TODO(@WEB): 当 WEB 端更新 web.py 的 progress_callback 后，新 tick 数据流将通过
+    # push_tick() 推送到队列。目前保留 update_progress() 以确保向后兼容。
+    def push_tick(self, task_id: str, tick_data: dict):
+        """推送结构化 tick 中间态到队列（tick-by-tick 模式用）。
+
+        Args:
+            task_id: 任务ID
+            tick_data: 结构化 tick 数据字典，包含 type, date, close_price, open_price,
+                       position, account, trade, indicators, progress 等字段。
+        """
+        with self._lock:
+            if task_id not in self._tasks:
+                return
+            task = self._tasks[task_id]
+            if task.get('cancelled'):
+                return
+            tick_data['type'] = 'tick'
+            task['queue'].put(tick_data)
+
     def set_result(self, task_id: str, result: Any):
         """设置任务结果
 

--- a/gui/web.py
+++ b/gui/web.py
@@ -971,9 +971,9 @@ def run():
     progress_mgr = get_progress_manager()
     task_id = progress_mgr.create_task()
 
-    # 创建进度回调函数
-    def progress_callback(current, total):
-        progress_mgr.update_progress(task_id, current, total)
+    # 创建进度回调函数（tick-by-tick 模式下接收结构化 tick_data）
+    def progress_callback(tick_data):
+        progress_mgr.push_tick(task_id, tick_data)
 
     # 在后台线程执行回测
     def run_backtest():
@@ -1110,8 +1110,8 @@ def run_multi():
     progress_mgr = get_progress_manager()
     task_id = progress_mgr.create_task()
 
-    def progress_callback(current, total):
-        progress_mgr.update_progress(task_id, current, total)
+    def progress_callback(tick_data):
+        progress_mgr.push_tick(task_id, tick_data)
 
     def run_multi_backtest():
         try:

--- a/tests/unit/test_backtest_progress.py
+++ b/tests/unit/test_backtest_progress.py
@@ -125,7 +125,7 @@ class TestSimulatorProgressCallback(unittest.TestCase):
     """测试模拟器进度回调"""
 
     def test_progress_callback_in_simulator(self):
-        """测试模拟器中的进度回调"""
+        """测试模拟器中的进度回调（tick-by-tick 结构化 tick_data）"""
         from trader.simulator import Simulator
         from strategy.mean_cost_strategy import MeanCostDecision
         import pandas as pd
@@ -143,22 +143,38 @@ class TestSimulatorProgressCallback(unittest.TestCase):
             'volume': [1000000] * 50
         })
 
-        # 记录进度回调
-        progress_calls = []
+        # 记录 tick_data 回调
+        tick_calls = []
 
-        def progress_callback(current, total):
-            progress_calls.append((current, total))
+        def progress_callback(tick_data):
+            tick_calls.append(tick_data)
 
-        # 运行模拟
+        # 运行模拟（禁用 pacing 加速测试）
         sim = Simulator(lot_size=100, init_cash=100000.0)
         strategy = MeanCostDecision()
         result = sim.simulate(df=df, strategy=strategy, symbol='TEST',
-                              progress_callback=progress_callback)
+                              progress_callback=progress_callback,
+                              tick_interval=0.0)
 
-        # 验证进度回调
-        self.assertGreater(len(progress_calls), 0)
-        self.assertEqual(progress_calls[-1][0], 50)  # 最后一次应该是50/50
-        self.assertEqual(progress_calls[-1][1], 50)
+        # 验证 tick_data 回调
+        self.assertGreater(len(tick_calls), 0)
+
+        # 验证第一个 tick 结构
+        first_tick = tick_calls[0]
+        self.assertEqual(first_tick["type"], "tick")
+        self.assertIn("date", first_tick)
+        self.assertIn("close_price", first_tick)
+        self.assertIn("open_price", first_tick)
+        self.assertIn("position", first_tick)
+        self.assertIn("account", first_tick)
+        self.assertIn("progress", first_tick)
+        self.assertEqual(first_tick["progress"]["total"], 50)
+        self.assertEqual(first_tick["progress"]["current"], 1)
+
+        # 验证最后一个 tick
+        last_tick = tick_calls[-1]
+        self.assertEqual(last_tick["progress"]["current"], 50)
+        self.assertEqual(last_tick["progress"]["total"], 50)
 
         # 验证结果
         self.assertIsNotNone(result)

--- a/trader/simulator.py
+++ b/trader/simulator.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
@@ -102,7 +103,7 @@ class BacktestExchangeRunner:
         end_date: Optional[str] = None,
         source: str = "auto",
         verbose: Optional[bool] = None,
-        progress_callback: Optional[Callable[[int, int], None]] = None,
+        progress_callback: Optional[Callable[[dict], None]] = None,
         trade_price: str = "open",
         granularity: str = "1d",
         enable_scheduled_orders: bool = False,
@@ -110,8 +111,14 @@ class BacktestExchangeRunner:
         require_base_position_for_t_plus_one_intraday: bool = False,
         base_position_lots: Optional[int] = None,
         mode: str = "backtest",
+        tick_interval: float = 0.04,
     ) -> Dict[str, Any]:
-        """执行回测。"""
+        """执行回测（tick-by-tick 模式）。
+
+        每 tick 推进一个交易日，tick_interval 控制 ticks 之间的间隔（秒）。
+        progress_callback 接收结构化 tick_data 字典，包含：
+            type, date, close_price, open_price, position, account, trade, indicators, progress
+        """
         if mode != "backtest":
             raise RuntimeError("当前执行器仅支持 backtest 模式，其它模式不运行")
 
@@ -318,17 +325,11 @@ class BacktestExchangeRunner:
             current_idx = tick.bar_index
             row = tick.row
 
-            if progress_callback:
-                try:
-                    progress_callback(tick.bar_index, tick.total_bars)
-                except Exception as e:
-                    if use_verbose:
-                        print(f"警告: 进度回调失败 - {e}")
-
             price_open = float(row["open"])
             price_close = float(row["close"])
             execution_price = _resolve_trade_price(row, trade_price)
             date = row["date"]
+            date_str = self._date_key(date)
 
             due_orders = [o for o in pending_orders if o.due_bar_index <= current_idx]
             if due_orders:
@@ -437,6 +438,56 @@ class BacktestExchangeRunner:
                 }
             )
             min_cash = min(min_cash, summary["cash"])
+
+            # ---- Tick-by-tick: structured intermediate state push ----
+            last_trade = trades_list[-1] if trades_list else None
+
+            # Collect extra indicator columns from the row (beyond standard OHLCV)
+            indicator_fields = {}
+            standard_fields = {"date", "open", "high", "low", "close", "volume"}
+            for col in row.index:
+                col_str = str(col)
+                if col_str not in standard_fields:
+                    try:
+                        indicator_fields[col_str] = float(row[col])
+                    except (ValueError, TypeError):
+                        indicator_fields[col_str] = str(row[col])
+
+            tick_data = {
+                "type": "tick",
+                "date": date_str,
+                "close_price": round(price_close, 4),
+                "open_price": round(price_open, 4),
+                "position": {
+                    "shares": float(engine.get_position().shares),
+                    "avg_cost": round(engine.get_position().avg_cost, 4),
+                },
+                "account": {
+                    "cash": round(summary["cash"], 2),
+                    "total_value": round(summary["total_value"], 2),
+                },
+                "trade": {
+                    "action": last_trade["action"],
+                    "price": last_trade["price"],
+                    "shares": last_trade["shares"],
+                } if last_trade else None,
+                "indicators": indicator_fields,
+                "progress": {
+                    "current": tick.bar_index,
+                    "total": tick.total_bars,
+                },
+            }
+
+            if progress_callback:
+                try:
+                    progress_callback(tick_data)
+                except Exception as e:
+                    if use_verbose:
+                        print(f"警告: 进度回调失败 - {e}")
+
+            # Tick-by-tick pacing: ~40ms between ticks => ~10s for 250 trading days
+            if tick_interval > 0 and tick.bar_index < tick.total_bars:
+                time.sleep(tick_interval)
 
         last_price = float(df.iloc[-1]["close"])
         final_summary = engine.get_summary(last_price)
@@ -563,7 +614,7 @@ class BacktestExchangeRunner:
         end_date: Optional[str] = None,
         source: str = "auto",
         verbose: Optional[bool] = None,
-        progress_callback: Optional[Callable[[int, int], None]] = None,
+        progress_callback: Optional[Callable[[dict], None]] = None,
         trade_price: str = "open",
         granularity: str = "1d",
         enable_scheduled_orders: bool = False,
@@ -571,6 +622,7 @@ class BacktestExchangeRunner:
         require_base_position_for_t_plus_one_intraday: bool = False,
         base_position_lots: Optional[int] = None,
         mode: str = "backtest",
+        tick_interval: float = 0.04,
     ) -> Dict[str, Any]:
         """兼容旧命名：simulate 等价于 run。"""
         return self.run(
@@ -589,6 +641,7 @@ class BacktestExchangeRunner:
             require_base_position_for_t_plus_one_intraday=require_base_position_for_t_plus_one_intraday,
             base_position_lots=base_position_lots,
             mode=mode,
+            tick_interval=tick_interval,
         )
 
 
@@ -603,7 +656,7 @@ def simulate_mean_cost(
     lot_size: float = 100.0,
     init_cash: float = 100000.0,
     source: str = "auto",
-    progress_callback: Optional[Callable[[int, int], None]] = None,
+    progress_callback: Optional[Callable[[dict], None]] = None,
     trade_price: str = "open",
     df=None,
 ) -> Dict[str, Any]:
@@ -634,7 +687,7 @@ def simulate_sma(
     period: int = 20,
     lot_size: float = 100.0,
     init_cash: float = 100000.0,
-    progress_callback: Optional[Callable[[int, int], None]] = None,
+    progress_callback: Optional[Callable[[dict], None]] = None,
     trade_price: str = "open",
 ):
     from strategy.sma_strategy import SmaDecision
@@ -671,7 +724,7 @@ def simulate_fixed_amount(
     init_cash: float = 100000.0,
     source: str = "auto",
     verbose: bool = False,
-    progress_callback: Optional[Callable[[int, int], None]] = None,
+    progress_callback: Optional[Callable[[dict], None]] = None,
     trade_price: str = "open",
     df=None,
 ) -> Dict[str, Any]:
@@ -703,7 +756,7 @@ def simulate_signal_template(
     strategy,
     lot_size: float = 100.0,
     init_cash: float = 100000.0,
-    progress_callback: Optional[Callable[[int, int], None]] = None,
+    progress_callback: Optional[Callable[[dict], None]] = None,
     trade_price: str = "open",
 ) -> Dict[str, Any]:
     """运行模板化信号策略回测。"""

--- a/trader/stocks.py
+++ b/trader/stocks.py
@@ -83,7 +83,7 @@ class BacktestRequest:
     init_cash: float = 100000.0
     trade_price: str = TRADE_PRICE_OPEN
     strategy_params: Dict[str, Any] = field(default_factory=dict)
-    progress_callback: Optional[Callable[[int, int], None]] = None
+    progress_callback: Optional[Callable[[dict], None]] = None
 
 
 def _validate_date_str(value: Optional[str]) -> Optional[str]:
@@ -431,7 +431,7 @@ def get_data(symbol: str = "600900",
 
 def run_mean_cost(symbol: str = "600900", start_date: Optional[str] = None, end_date: Optional[str] = None,
                   lot_size: float = 100.0, init_cash: float = 100000.0, source: object = "auto",
-                  progress_callback: Optional[Callable[[int, int], None]] = None,
+                  progress_callback: Optional[Callable[[dict], None]] = None,
                   trade_price: str = TRADE_PRICE_OPEN) -> Dict[str, Any]:
     """调用均值成本模拟（封装自 strategy.mean_cost_strategy.simulate_mean_cost）。"""
     if simulate_mean_cost is None:
@@ -449,7 +449,7 @@ def run_fixed_amount(symbol: str = "600900",
                      lot_size: float = 100.0,
                      init_cash: float = 100000.0,
                      source: object = "auto",
-                     progress_callback: Optional[Callable[[int, int], None]] = None,
+                     progress_callback: Optional[Callable[[dict], None]] = None,
                      trade_price: str = TRADE_PRICE_OPEN) -> Dict[str, Any]:
     """调用定投策略模拟（封装自 strategy.fixed_amount_strategy.simulate_fixed_amount）。
 
@@ -479,7 +479,7 @@ def run_fixed_amount(symbol: str = "600900",
 def run_sma_backtest(symbol: str = "600900", source: object = "auto",
                      start_date: Optional[str] = None, end_date: Optional[str] = None,
                      lot_size: float = 100.0, init_cash: float = 100000.0, period: int = 20,
-                     progress_callback: Optional[Callable[[int, int], None]] = None,
+                     progress_callback: Optional[Callable[[dict], None]] = None,
                      trade_price: str = TRADE_PRICE_OPEN) -> Dict[str, Any]:
     """使用统一模拟器运行 SMA 回测并返回统一的展示结果。
 
@@ -515,7 +515,7 @@ def run_sma_backtest(symbol: str = "600900", source: object = "auto",
 def run_module_strategy_backtest(symbol: str = "600900", source: object = "auto",
                                  start_date: Optional[str] = None, end_date: Optional[str] = None,
                                  lot_size: float = 100.0, init_cash: float = 100000.0,
-                                 progress_callback: Optional[Callable[[int, int], None]] = None,
+                                 progress_callback: Optional[Callable[[dict], None]] = None,
                                  trade_price: str = TRADE_PRICE_OPEN,
                                  strategy_key: str = '',
                                  **strategy_params: Any) -> Dict[str, Any]:
@@ -592,7 +592,7 @@ def run_futures_a50_prev_night(symbol: str = "600900", source: object = "auto",
                                lot_size: float = 100.0, init_cash: float = 100000.0,
                                futures_symbol: str = "CN00Y",
                                base_position_lots: int = 2,
-                               progress_callback: Optional[Callable[[int, int], None]] = None,
+                               progress_callback: Optional[Callable[[dict], None]] = None,
                                trade_price: str = TRADE_PRICE_OPEN) -> Dict[str, Any]:
     """前一晚 A50 涨跌信号策略：上涨则买入并预约1小时后卖出。"""
     try:
@@ -645,7 +645,7 @@ def run_signal_template(
     end_date: Optional[str] = None,
     lot_size: float = 100.0,
     init_cash: float = 100000.0,
-    progress_callback: Optional[Callable[[int, int], None]] = None,
+    progress_callback: Optional[Callable[[dict], None]] = None,
     trade_price: str = TRADE_PRICE_OPEN,
     buy_trigger: str = 'price_below',
     buy_price_value: float = 0.0,
@@ -785,7 +785,7 @@ def create_backtest_request(symbol: str = '600900',
                             init_cash: float = 100000.0,
                             trade_price: str = TRADE_PRICE_OPEN,
                             strategy_params: Optional[Mapping[str, Any]] = None,
-                            progress_callback: Optional[Callable[[int, int], None]] = None) -> BacktestRequest:
+                            progress_callback: Optional[Callable[[dict], None]] = None) -> BacktestRequest:
     """构造并校验统一回测请求。"""
     spec = get_strategy_spec(strategy)
     if trade_price not in SUPPORTED_TRADE_PRICE_FIELDS:
@@ -900,7 +900,7 @@ def run_multi_strategy_backtest(
     trade_price: str = TRADE_PRICE_OPEN,
     strategies: Optional[list[str]] = None,
     strategies_params: Optional[dict[str, dict[str, Any]]] = None,
-    progress_callback: Optional[Callable[[int, int], None]] = None,
+    progress_callback: Optional[Callable[[dict], None]] = None,
 ) -> Dict[str, Any]:
     """多策略对比回测：一次获取行情数据，多个策略共享运行。
 
@@ -958,7 +958,15 @@ def run_multi_strategy_backtest(
 
     for idx, strategy_key in enumerate(strategies):
         if progress_callback:
-            progress_callback(idx, total)
+            try:
+                progress_callback({
+                    "type": "multi_strategy",
+                    "current_strategy": idx + 1,
+                    "total_strategies": total,
+                    "strategy_key": strategy_key,
+                })
+            except Exception:
+                pass
 
         spec = get_strategy_spec(strategy_key)
         params = strategies_params.get(strategy_key, {})


### PR DESCRIPTION
## 概述

为 Issue #194 (tick-by-tick 回测引擎) 实现 TRADER 角色工作。

从已有的 `feat/issue-196-tick-engine` 分支（commit `9ca1b71`）cherry-pick tick-by-tick 引擎变更。

## 变更文件

| 文件 | 变更 |
|------|------|
| `trader/simulator.py` | tick-by-tick 时间流逝推进引擎：新增 `tick_interval` 参数（默认 0.04s），每个 tick 推送结构化 `tick_data` 字典 |
| `trader/stocks.py` | 所有 `progress_callback` 签名从 `Callable[[int, int], None]` 改为 `Callable[[dict], None]`，多策略回调也发送结构化数据 |
| `gui/backtest_progress.py` | 新增 `push_tick()` 方法，支持结构化 tick 数据入队 |
| `gui/web.py` | `progress_callback` 改为接收 `tick_data` 字典并调用 `push_tick()` |
| `tests/unit/test_backtest_progress.py` | 更新测试用例以验证结构化 `tick_data` 格式 |

## tick_data 格式

```python
{
    "type": "tick",
    "date": "YYYY-MM-DD",
    "close_price": float,
    "open_price": float,
    "position": {"shares": int, "avg_cost": float},
    "account": {"cash": float, "total_value": float},
    "trade": {"action": str, "price": float, "shares": int} | None,
    "indicators": {col_name: value, ...},
    "progress": {"current": int, "total": int},
}
```

## 关联

- 修复 #194
- 依赖这个分支的 WEB 工作：PR #206 (feat/issue-194-tick-by-tick-gui)
- 代码源自已关闭的 feat/issue-196-tick-engine