### PR TITLE
[STRAT] #195-4 策略接口适配 — 逐 tick 输入 + 逐步计算指标

### DIFF
--- a/strategy/bollinger_strategy.py
+++ b/strategy/bollinger_strategy.py
@@ -34,7 +34,12 @@ AUTO_STRATEGY_SPEC = {
 
 @dataclasses.dataclass
 class BollingerDecision:
-    """布林带低频策略。"""
+    """布林带低频策略。
+
+    This strategy is tick-safe (works with partial data slices).
+    """
+
+    __tick_safe__ = True
 
     period: int = 20
     std_multiplier: float = 2.0
@@ -78,9 +83,13 @@ def validate_strategy_parameters(period: int = 20, std_multiplier: float = 2.0, 
 
 
 def prepare_backtest_data(df: pd.DataFrame, period: int = 20, std_multiplier: float = 2.0, **kwargs) -> pd.DataFrame:
-    """为布林带策略补充上下轨指标列。"""
+    """为布林带策略补充上下轨指标列。
+
+    Uses min_periods=1 so early rows get valid indicators from partial data,
+    making this safe for tick-by-tick progression mode.
+    """
     prepared = df.copy()
-    rolling = prepared["close"].rolling(window=period, min_periods=period)
+    rolling = prepared["close"].rolling(window=period, min_periods=1)
     prepared["bollinger_mid"] = rolling.mean()
     prepared["bollinger_std"] = rolling.std(ddof=0)  # 使用固定的总体标准差实现，保持当前回测计算结果稳定
     prepared["bollinger_upper"] = prepared["bollinger_mid"] + std_multiplier * prepared["bollinger_std"]

--- a/strategy/dual_ma_strategy.py
+++ b/strategy/dual_ma_strategy.py
@@ -34,7 +34,12 @@ AUTO_STRATEGY_SPEC = {
 
 @dataclasses.dataclass
 class DualMaDecision:
-    """双均线交叉策略。"""
+    """双均线交叉策略。
+
+    This strategy is tick-safe (works with partial data slices).
+    """
+
+    __tick_safe__ = True
 
     short_period: int = 5
     long_period: int = 20
@@ -90,10 +95,14 @@ def validate_strategy_parameters(short_period: int = 5, long_period: int = 20, *
 
 
 def prepare_backtest_data(df: pd.DataFrame, short_period: int = 5, long_period: int = 20, **kwargs) -> pd.DataFrame:
-    """为双均线策略补充均线指标列。"""
+    """为双均线策略补充均线指标列。
+
+    Uses min_periods=1 so early rows get valid indicators from partial data,
+    making this safe for tick-by-tick progression mode.
+    """
     prepared = df.copy()
-    prepared["ma_short"] = prepared["close"].rolling(window=short_period, min_periods=short_period).mean()
-    prepared["ma_long"] = prepared["close"].rolling(window=long_period, min_periods=long_period).mean()
+    prepared["ma_short"] = prepared["close"].rolling(window=short_period, min_periods=1).mean()
+    prepared["ma_long"] = prepared["close"].rolling(window=long_period, min_periods=1).mean()
     return prepared
 
 

--- a/strategy/futures_open_hour_strategy.py
+++ b/strategy/futures_open_hour_strategy.py
@@ -36,7 +36,12 @@ AUTO_STRATEGY_SPEC = {
 
 @dataclasses.dataclass
 class FuturesOpenHourDecision:
-    """根据前一晚富时A50期货涨跌决定是否买入，并预约1小时后卖出。"""
+    """根据前一晚富时A50期货涨跌决定是否买入，并预约1小时后卖出。
+
+    This strategy is tick-safe (works with partial data slices).
+    """
+
+    __tick_safe__ = True
 
     futures_symbol: str = "CN00Y"
     source: object = "auto"

--- a/strategy/mean_cost_strategy.py
+++ b/strategy/mean_cost_strategy.py
@@ -11,7 +11,11 @@ class MeanCostDecision:
     - 否则若开盘价 < 平均成本：返回 'buy'
     - 否则若开盘价 > 平均成本：返回 'sell'
     - 否则返回 None
+
+    This strategy is tick-safe (works with partial data slices).
     """
+
+    __tick_safe__ = True
 
     def decide(self, open_price: float, close_price: float | None = None,
                avg_cost: float = 0.0, shares: float = 0.0, date: Any = None) -> str | None:

--- a/strategy/rsi_strategy.py
+++ b/strategy/rsi_strategy.py
@@ -41,7 +41,12 @@ AUTO_STRATEGY_SPEC = {
 
 @dataclasses.dataclass
 class RsiDecision:
-    """RSI 超买超卖策略。"""
+    """RSI 超买超卖策略。
+
+    This strategy is tick-safe (works with partial data slices).
+    """
+
+    __tick_safe__ = True
 
     period: int = 14
     oversold: float = 30.0
@@ -84,13 +89,18 @@ def validate_strategy_parameters(period: int = 14, oversold: float = 30.0, overb
 
 
 def prepare_backtest_data(df: pd.DataFrame, period: int = 14, **kwargs) -> pd.DataFrame:
-    """为 RSI 策略补充 RSI 指标列。"""
+    """为 RSI 策略补充 RSI 指标列。
+
+    Uses min_periods=1 in rolling calculations so early rows get valid
+    indicators from partial data, making this safe for tick-by-tick
+    progression mode.
+    """
     prepared = df.copy()
     delta = prepared["close"].diff()
     gain = delta.clip(lower=0)
     loss = -delta.clip(upper=0)
-    avg_gain = gain.rolling(window=period, min_periods=period).mean()
-    avg_loss = loss.rolling(window=period, min_periods=period).mean()
+    avg_gain = gain.rolling(window=period, min_periods=1).mean()
+    avg_loss = loss.rolling(window=period, min_periods=1).mean()
     rs = avg_gain / avg_loss.where(avg_loss != 0)
     prepared["rsi"] = 100 - (100 / (1 + rs))
     prepared.loc[(avg_loss == 0) & (avg_gain > 0), "rsi"] = 100.0

--- a/strategy/sma_strategy.py
+++ b/strategy/sma_strategy.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+import pandas as pd
+
 
 class SmaDecision:
     """决策器：用于 pandas 模拟的 SMA 决策逻辑。
@@ -7,7 +9,11 @@ class SmaDecision:
     - 当没有持仓且当日收盘价 > SMA(period) 时返回 'buy'
     - 当持仓且当日收盘价 < SMA(period) 时返回 'sell'
     - 否则返回 None
+
+    This strategy is tick-safe (works with partial data slices).
     """
+
+    __tick_safe__ = True
 
     def __init__(self, period: int = 20, df=None):
         self.period = period
@@ -47,3 +53,14 @@ class SmaDecision:
         if shares > 0 and close_price < sma:
             return 'sell'
         return None
+
+
+def prepare_backtest_data(df: pd.DataFrame, period: int = 20, **kwargs) -> pd.DataFrame:
+    """为 SMA 策略补充 SMA 指标列。
+
+    Uses min_periods=1 so early rows get valid SMA values from partial data,
+    making this safe for tick-by-tick progression mode.
+    """
+    prepared = df.copy()
+    prepared["sma"] = prepared["close"].rolling(window=period, min_periods=1).mean()
+    return prepared


### PR DESCRIPTION
## 实现内容

为策略接口适配逐 tick 推进模式。

### 改动

- 所有策略的 `prepare_backtest_data()` 使用 `min_periods=1` 确保早期行也能从部分数据中获得有效指标值
- 新增 `__tick_safe__ = True` 类属性标记策略为 tick 安全
- `sma_strategy.py` 新增 `prepare_backtest_data()` 函数
- 更新文档字符串说明 tick 兼容性

Closes #199