### PR TITLE
feat: Add buffer_days tolerance to cache-hit check (#205)

### DIFF
--- a/exchange/source/data_provider.py
+++ b/exchange/source/data_provider.py
@@ -263,7 +263,7 @@ def get_data(symbol: str = "600900",
                 hist_covered = True
                 if sd is not None and sd < cache_min:
                     hist_covered = False
-                if ed is not None and ed > cache_max:
+                if ed is not None and ed > cache_max + pd.Timedelta(days=buffer_days):
                     hist_covered = False
 
                 if hist_covered:

--- a/tests/unit/test_data_provider_cache.py
+++ b/tests/unit/test_data_provider_cache.py
@@ -80,7 +80,6 @@ class TestDataProviderCacheFiltering(unittest.TestCase):
             self.assertEqual(out['date'].min().strftime('%Y-%m-%d'), '2023-01-03')
             self.assertEqual(out['date'].max().strftime('%Y-%m-%d'), '2023-01-05')
 
-
     # ── buffer_days tolerance cache-hit tests ──────────────────────────
 
     @patch('exchange.source.data_provider.AkshareProvider.fetch')

--- a/tests/unit/test_data_provider_cache.py
+++ b/tests/unit/test_data_provider_cache.py
@@ -81,5 +81,106 @@ class TestDataProviderCacheFiltering(unittest.TestCase):
             self.assertEqual(out['date'].max().strftime('%Y-%m-%d'), '2023-01-05')
 
 
+    # ── buffer_days tolerance cache-hit tests ──────────────────────────
+
+    @patch('exchange.source.data_provider.AkshareProvider.fetch')
+    def test_cache_hit_within_buffer_days(self, mock_fetch):
+        """Request end_date slightly beyond cache_max but within buffer_days → cache hit (no fetch)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_file = os.path.join(tmp, '600900.csv')
+            dates = pd.date_range(start='2023-01-01', periods=5, freq='D')
+            df = pd.DataFrame({
+                'date': dates,
+                'open': [100 + i for i in range(5)],
+                'high': [101 + i for i in range(5)],
+                'low': [99 + i for i in range(5)],
+                'close': [100 + i for i in range(5)],
+                'volume': [1000 + i * 10 for i in range(5)],
+            })
+            df.to_csv(cache_file, index=False)
+
+            out = get_data(
+                symbol='600900', source='akshare',
+                start_date='20230101', end_date='20230108',
+                cache_dir=tmp, buffer_days=5,
+            )
+            self.assertEqual(mock_fetch.call_count, 0)
+            self.assertIsNotNone(out)
+            self.assertEqual(out['date'].min().strftime('%Y-%m-%d'), '2023-01-01')
+            self.assertEqual(out['date'].max().strftime('%Y-%m-%d'), '2023-01-05')
+
+    @patch('exchange.source.data_provider.AkshareProvider.fetch')
+    def test_cache_miss_beyond_buffer_days(self, mock_fetch):
+        """Request end_date far beyond cache_max + buffer_days → cache miss (fetch needed)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_file = os.path.join(tmp, '600900.csv')
+            dates = pd.date_range(start='2023-01-01', periods=5, freq='D')
+            df = pd.DataFrame({
+                'date': dates,
+                'open': [100 + i for i in range(5)],
+                'high': [101 + i for i in range(5)],
+                'low': [99 + i for i in range(5)],
+                'close': [100 + i for i in range(5)],
+                'volume': [1000 + i * 10 for i in range(5)],
+            })
+            df.to_csv(cache_file, index=False)
+
+            mock_fetch.return_value = pd.DataFrame({
+                'date': pd.to_datetime([
+                    '2023-01-06', '2023-01-07', '2023-01-08',
+                    '2023-01-09', '2023-01-10', '2023-01-15',
+                ]),
+                'open': [105, 106, 107, 108, 109, 110],
+                'high': [106, 107, 108, 109, 110, 111],
+                'low': [104, 105, 106, 107, 108, 109],
+                'close': [105, 106, 107, 108, 109, 110],
+                'volume': [1100] * 6,
+            })
+
+            out = get_data(
+                symbol='600900', source='akshare',
+                start_date='20230101', end_date='20230115',
+                cache_dir=tmp, buffer_days=5,
+            )
+            self.assertEqual(mock_fetch.call_count, 1)
+            self.assertIsNotNone(out)
+            self.assertEqual(out['date'].min().strftime('%Y-%m-%d'), '2023-01-01')
+            self.assertEqual(out['date'].max().strftime('%Y-%m-%d'), '2023-01-15')
+
+    @patch('exchange.source.data_provider.AkshareProvider.fetch')
+    def test_cache_hit_buffer_days_zero(self, mock_fetch):
+        """buffer_days=0 → no tolerance; any request beyond cache_max is a miss (preserve existing behavior)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_file = os.path.join(tmp, '600900.csv')
+            dates = pd.date_range(start='2023-01-01', periods=5, freq='D')
+            df = pd.DataFrame({
+                'date': dates,
+                'open': [100 + i for i in range(5)],
+                'high': [101 + i for i in range(5)],
+                'low': [99 + i for i in range(5)],
+                'close': [100 + i for i in range(5)],
+                'volume': [1000 + i * 10 for i in range(5)],
+            })
+            df.to_csv(cache_file, index=False)
+
+            mock_fetch.return_value = pd.DataFrame({
+                'date': pd.to_datetime(['2023-01-06', '2023-01-07', '2023-01-08']),
+                'open': [105, 106, 107],
+                'high': [106, 107, 108],
+                'low': [104, 105, 106],
+                'close': [105, 106, 107],
+                'volume': [1100] * 3,
+            })
+
+            out = get_data(
+                symbol='600900', source='akshare',
+                start_date='20230101', end_date='20230107',
+                cache_dir=tmp, buffer_days=0,
+            )
+            self.assertEqual(mock_fetch.call_count, 1)
+            self.assertIsNotNone(out)
+            self.assertEqual(out['date'].max().strftime('%Y-%m-%d'), '2023-01-07')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Fixes #205

### Problem
Cache-hit check at line 266 used strict `ed > cache_max`, causing unnecessary re-downloads when request end_date is slightly beyond cache_max but within the configured `buffer_days` tolerance.

### Change
Added `pd.Timedelta(days=buffer_days)` to the cache-hit condition:

```python
# Before
if ed is not None and ed > cache_max:

# After
if ed is not None and ed > cache_max + pd.Timedelta(days=buffer_days):
```

`buffer_days` already exists as a parameter (default 5).

### Tests
- `test_cache_hit_within_buffer_days`: 0 fetch calls when end_date within buffer_days
- `test_cache_miss_beyond_buffer_days`: 1 fetch call when end_date beyond buffer_days
- `test_cache_hit_buffer_days_zero`: buffer_days=0 preserves original strict behavior

All 6 tests in `test_data_provider_cache.py` pass.