### PR TITLE
perf: #200 缓存差几天不全量重下 — buffer_days 5→1 + 小缺口优化 + 测试

### DIFF
--- a/exchange/source/data_provider.py
+++ b/exchange/source/data_provider.py
@@ -40,7 +40,7 @@ _parse_jsonp = parse_jsonp
 _filter_by_optional_range = filter_by_optional_range
 
 
-DEFAULT_FETCH_BUFFER_DAYS = 5
+DEFAULT_FETCH_BUFFER_DAYS = 1
 
 
 def _ensure_cache_dir(cache_dir: str):
@@ -190,6 +190,11 @@ _PROVIDER_FACTORIES = {
 
 ALL_SOURCES = list(_PROVIDER_FACTORIES.keys())
 
+# When cache is mostly present and only a small date gap (< 3 days) needs filling,
+# only try the fastest sources instead of the full 8-source auto traversal.
+# This avoids timeout stacking from slow/specialized sources.
+_CACHE_GAP_FAST_SOURCES = ALL_SOURCES[:3]  # akshare, baostock, tencent
+
 
 def _create_provider(source_name: str, max_attempts: int = 3):
     src = source_name.lower()
@@ -318,6 +323,27 @@ def get_data(symbol: str = "600900",
         )
         if not already_missing_today:
             missing_ranges.append((today_str, today_str))
+
+    # --- Optimize: for small cache gaps, limit source fallback ---
+    # When cache exists and only a few days are missing, don't traverse all 8 sources.
+    # Try the top-3 fastest sources only (akshare, baostock, tencent).
+    if (not force_refresh
+            and cached_raw is not None
+            and not cached_raw.empty
+            and len(sources) >= 4):
+        total_gap_days = 0
+        for fs, fe in missing_ranges:
+            if fs and fe:
+                fs_dt = parse_date_input(fs)
+                fe_dt = parse_date_input(fe)
+                if fs_dt is not None and fe_dt is not None:
+                    total_gap_days += (fe_dt - fs_dt).days
+        if 0 <= total_gap_days <= 3:
+            logger.info(
+                "缓存小缺口(%d天), 限制源为快速源: symbol=%s, %s",
+                total_gap_days, symbol, _CACHE_GAP_FAST_SOURCES,
+            )
+            sources = _CACHE_GAP_FAST_SOURCES
 
     errors = []
 

--- a/gui/templates/select_time_range.html
+++ b/gui/templates/select_time_range.html
@@ -491,6 +491,9 @@
       const submitBtn = document.querySelector('.submit-btn');
       let timeRangeChart = null;
       let refreshChartTimer = null;
+      let cachedChartData = null;
+      let cachedRequestedStart = null;
+      let cachedRequestedEnd = null;
 
       function setChartStatus(message, type) {
         chartStatus.textContent = message;
@@ -579,6 +582,26 @@
         };
       }
 
+      function filterCachedLabels(cachedLabels, requestedStart, requestedEnd) {
+        const startStr = requestedStart.slice(0, 4) + '-' + requestedStart.slice(4, 6) + '-' + requestedStart.slice(6, 8);
+        const endStr = requestedEnd.slice(0, 4) + '-' + requestedEnd.slice(4, 6) + '-' + requestedEnd.slice(6, 8);
+        const indices = [];
+        const filteredLabels = [];
+        for (let i = 0; i < cachedLabels.length; i++) {
+          if (cachedLabels[i] >= startStr && cachedLabels[i] <= endStr) {
+            filteredLabels.push(cachedLabels[i]);
+            indices.push(i);
+          }
+        }
+        return { labels: filteredLabels, indices };
+      }
+
+      function clearChartCache() {
+        cachedChartData = null;
+        cachedRequestedStart = null;
+        cachedRequestedEnd = null;
+      }
+
       function refreshChart(showLoading = true) {
         if (!validateDates()) {
           return Promise.resolve();
@@ -592,8 +615,24 @@
             timeRangeChart.destroy();
             timeRangeChart = null;
           }
+          clearChartCache();
           return Promise.resolve();
         }
+
+        // Check if requested range is fully within cached data
+        if (cachedChartData !== null &&
+            cachedRequestedStart !== null &&
+            cachedRequestedEnd !== null &&
+            range.start >= cachedRequestedStart &&
+            range.end <= cachedRequestedEnd) {
+          const filtered = filterCachedLabels(cachedChartData.labels, range.start, range.end);
+          const filteredPrices = filtered.indices.map(i => cachedChartData.open_prices[i]);
+          renderChart(filtered.labels, filteredPrices);
+          chartMeta.textContent = '显示 ' + cachedChartData.available_start + ' 至 ' + cachedChartData.available_end + ' 的日线开盘价，共 ' + cachedChartData.points + ' 个交易日。';
+          setChartStatus('走势图已更新（缓存）。', 'success');
+          return Promise.resolve();
+        }
+
         const params = new URLSearchParams(range);
         if (showLoading) {
           setChartStatus('正在加载走势图...', 'info');
@@ -605,6 +644,11 @@
             if (!ok) {
               throw new Error(data.error || '走势图加载失败');
             }
+
+            // Store response in frontend cache
+            cachedChartData = data;
+            cachedRequestedStart = range.start;
+            cachedRequestedEnd = range.end;
 
             renderChart(data.labels, data.open_prices);
             updateDateBounds(data);
@@ -625,6 +669,8 @@
           clearTimeout(refreshChartTimer);
           refreshChartTimer = null;
         }
+
+        clearChartCache();
 
         setBusy(true);
         setChartStatus('正在清除缓存并重新下载当前股票日线数据...', 'info');

--- a/tests/unit/test_data_provider_cache.py
+++ b/tests/unit/test_data_provider_cache.py
@@ -4,10 +4,14 @@ import pandas as pd
 import unittest
 from unittest.mock import patch
 
-from exchange.source.data_provider import get_data
+from exchange.source.data_provider import get_data, DEFAULT_FETCH_BUFFER_DAYS
 
 
 class TestDataProviderCacheFiltering(unittest.TestCase):
+    def test_default_buffer_days_is_one(self):
+        """DEFAULT_FETCH_BUFFER_DAYS should be 1 to reduce overlap on partial fetches."""
+        self.assertEqual(DEFAULT_FETCH_BUFFER_DAYS, 1)
+
     def test_cache_filtered_by_date_range(self):
         with tempfile.TemporaryDirectory() as tmp:
             cache_file = os.path.join(tmp, '600900.csv')
@@ -79,6 +83,63 @@ class TestDataProviderCacheFiltering(unittest.TestCase):
             self.assertEqual(mock_fetch.call_args.kwargs['end_date'], '20230110')
             self.assertEqual(out['date'].min().strftime('%Y-%m-%d'), '2023-01-03')
             self.assertEqual(out['date'].max().strftime('%Y-%m-%d'), '2023-01-05')
+
+    @patch('exchange.source.data_provider.AkshareProvider.fetch')
+    @patch('exchange.source.data_provider.BaostockProvider.fetch')
+    @patch('exchange.source.data_provider.TencentProvider.fetch')
+    @patch('exchange.source.data_provider.SinaProvider.fetch')
+    @patch('exchange.source.data_provider.SohuProvider.fetch')
+    @patch('exchange.source.data_provider.EastmoneyProvider.fetch')
+    @patch('exchange.source.data_provider.CailianpressProvider.fetch')
+    @patch('exchange.source.data_provider.StooqProvider.fetch')
+    def test_small_cache_gap_limits_to_fast_sources(
+        self,
+        mock_stooq, mock_cailianpress, mock_eastmoney,
+        mock_sohu, mock_sina,
+        mock_tencent, mock_baostock, mock_akshare,
+    ):
+        """When cache has a gap ≤ 3 days, only fast sources (akshare, baostock, tencent) are tried."""
+        with tempfile.TemporaryDirectory() as tmp:
+            cache_file = os.path.join(tmp, '600900.csv')
+            dates = pd.date_range(start='2023-01-01', periods=5, freq='D')
+            cached_df = pd.DataFrame({
+                'date': dates,
+                'open': [10, 11, 12, 13, 14],
+                'high': [11, 12, 13, 14, 15],
+                'low': [9, 10, 11, 12, 13],
+                'close': [10, 11, 12, 13, 14],
+                'volume': [100] * 5,
+            })
+            cached_df.to_csv(cache_file, index=False)
+
+            # All fast sources return no data → they are tried but fail
+            mock_akshare.return_value = None
+            mock_baostock.return_value = None
+            mock_tencent.return_value = None
+            # Remaining sources should NOT be called when gap ≤ 3
+            mock_sina.side_effect = AssertionError("sina should not be called")
+            mock_sohu.side_effect = AssertionError("sohu should not be called")
+            mock_eastmoney.side_effect = AssertionError("eastmoney should not be called")
+            mock_cailianpress.side_effect = AssertionError("cailianpress should not be called")
+            mock_stooq.side_effect = AssertionError("stooq should not be called")
+
+            # Request 2023-01-01 to 2023-01-06 (1-day gap past cache end of 2023-01-05)
+            # Even though no provider returns data for the gap, cached partial data is returned
+            out = get_data(
+                symbol='600900', source='auto',
+                start_date='20230101', end_date='20230106',
+                cache_dir=tmp,
+            )
+
+            # Returned cached data (2023-01-01 to 2023-01-05) — partial result
+            self.assertIsNotNone(out)
+            self.assertEqual(len(out), 5)
+            # Verify the gap was detected — fast sources were all tried
+            mock_akshare.assert_called_once()
+            mock_baostock.assert_called_once()
+            mock_tencent.assert_called_once()
+            # Slow sources were never tried (no AssertionError raised)
+            mock_sina.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## 问题

select_time_range 走势图加载慢：缓存差几天就全量重下所有源。

## 变更

### P0 — EXCH: exchange/source/data_provider.py

1. DEFAULT_FETCH_BUFFER_DAYS 从 5 减到 1：减少 partial fetch 的 overlap 数据量，避免不必要的全量重下。
2. 小缺口快速源限制：缓存 gap ≤3 天时，只尝试前 3 个最快源（akshare, baostock, tencent），跳过其他 5 个慢源，避免超时叠加。

### P0 — 测试: tests/unit/test_data_provider_cache.py

- test_default_buffer_days_is_one — 验证 DEFAULT_FETCH_BUFFER_DAYS=1
- test_small_cache_gap_limits_to_fast_sources — 验证 gap ≤3 天时慢源不被调用

### P1 — WEB: gui/templates/select_time_range.html

1. 前端走势图缓存：添加客户端缓存变量 cachedChartData / cachedRequestedStart / cachedRequestedEnd
2. 缓存命中直接渲染：如果新选的日期范围完全落在已缓存的数据范围内，直接从缓存过滤数据渲染，跳过 API 请求
3. 缓存清除联动：手动刷新缓存时自动清除前端缓存状态

## 验证

- P0 单元测试 5/5 通过
- P1 前端缓存：首次请求走 API，后续相同/缩小范围从缓存渲染，无网络请求
- 语义正确：只改变 cache miss 时的 fallback 行为 + 前端缓存优化

Closes: #200
