### PR TITLE
feat: add issue auto-routing & ai-in-progress watchdog workflows

### DIFF
--- a/.github/workflows/ai-progress-watchdog.yml
+++ b/.github/workflows/ai-progress-watchdog.yml
@@ -1,0 +1,212 @@
+name: AI Progress Watchdog
+
+# Scheduled workflow that monitors issues in ai-in-progress state.
+# - >22h without PR → post warning, tag needs-review
+# - >24h without PR → close issue, clean up branch
+
+on:
+  schedule:
+    # Every 30 minutes to catch ~22h and ~24h thresholds promptly
+    - cron: '*/30 * * * *'
+  # Manual trigger for debugging
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: ai-progress-watchdog
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/github-script@v9
+        id: watchdog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          script: |
+            const NOW = Date.now();
+            const DAY_MS = 24 * 3600 * 1000;
+            const HOUR_MS = 3600 * 1000;
+            const WARN_THRESHOLD = 22 * HOUR_MS;   // 22h → warning
+            const CLOSE_THRESHOLD = 24 * HOUR_MS + 30 * 60 * 1000;  // 24h30m → close (buffer for schedule)
+
+            const repo = context.repo;
+            const results = [];
+
+            // Fetch all open issues with ai-in-progress label
+            let page = 1;
+            let allIssues = [];
+            while (true) {
+              const { data: issues } = await github.rest.issues.listForRepo({
+                ...repo,
+                state: 'open',
+                labels: 'ai-in-progress',
+                per_page: 100,
+                page: page,
+              });
+              allIssues = allIssues.concat(issues);
+              if (issues.length < 100) break;
+              page++;
+            }
+
+            // Filter out PRs (GitHub API returns both)
+            const issues = allIssues.filter(i => !i.pull_request);
+            core.info(`Found ${issues.length} open issues with ai-in-progress`);
+
+            for (const issue of issues) {
+              const num = issue.number;
+              const title = issue.title;
+              const lastUpdated = new Date(issue.updated_at + 'Z').getTime();
+              const ageMs = NOW - lastUpdated;
+              const ageHours = (ageMs / HOUR_MS).toFixed(1);
+              const createdAt = new Date(issue.created_at + 'Z').getTime();
+              const totalAgeHours = ((NOW - createdAt) / HOUR_MS).toFixed(1);
+
+              // Check if there's a PR for this issue
+              let hasPR = false;
+              let prUrl = null;
+              try {
+                const { data: prs } = await github.rest.pulls.list({
+                  ...repo,
+                  state: 'all',
+                  head: `feat/issue-${num}`,
+                  per_page: 5,
+                });
+                if (prs.length > 0) {
+                  hasPR = true;
+                  prUrl = prs[0].html_url;
+                }
+              } catch (e) {
+                core.warning(`Could not check PR for #${num}: ${e.message}`);
+              }
+
+              core.info(`#${num}: age=${ageHours}h total=${totalAgeHours}h hasPR=${hasPR}`);
+
+              const issueLabels = issue.labels.map(l => l.name);
+              const isClosed = issue.state === 'closed';
+
+              // --- Case 1: >24h without PR → auto-close ---
+              if (ageMs > CLOSE_THRESHOLD && !hasPR && !isClosed) {
+                const closeComment = [
+                  `## ⏰ 自动关闭 — ai-in-progress 超时`,
+                  ``,
+                  `此 Issue 在 **ai-in-progress** 状态停留超过 **24 小时**（实际 ${ageHours}h），且未检测到关联 PR，已自动关闭。`,
+                  ``,
+                  `**统计：**`,
+                  `- 🕒 最后更新：${new Date(lastUpdated).toISOString()}`,
+                  `- ⏳ 超时时间：${ageHours} 小时`,
+                  `- 📊 Issue 总存活时间（从创建起）：${totalAgeHours} 小时`,
+                  `- 🔍 关联 PR：未找到`,
+                  ``,
+                  `> 如需重新打开，请先确认问题已解决或重新路由。`,
+                ].join('\n');
+
+                await github.rest.issues.createComment({
+                  ...repo,
+                  issue_number: num,
+                  body: closeComment,
+                });
+
+                await github.rest.issues.update({
+                  ...repo,
+                  issue_number: num,
+                  state: 'closed',
+                  state_reason: 'not_planned',
+                });
+
+                results.push(`🔴 #${num} CLOSED — ai-in-progress ${ageHours}h without PR (${title.slice(0,50)})`);
+                core.info(`Closed #${num} — stale ${ageHours}h`);
+
+                // Try to delete the associated branch
+                const branchName = `feat/issue-${num}`;
+                try {
+                  const { data: ref } = await github.rest.git.getRef({
+                    ...repo,
+                    ref: `heads/${branchName}`,
+                  });
+                  if (ref) {
+                    await github.rest.git.deleteRef({
+                      ...repo,
+                      ref: `heads/${branchName}`,
+                    });
+                    results.push(`  🗑️ Deleted branch ${branchName}`);
+                    core.info(`Deleted branch ${branchName} for closed #${num}`);
+                  }
+                } catch (e) {
+                  // Branch doesn't exist — that's fine
+                  core.info(`No branch ${branchName} to delete for #${num}`);
+                }
+                continue;
+              }
+
+              // --- Case 2: >22h without PR → post warning ---
+              if (ageMs > WARN_THRESHOLD && !hasPR && !isClosed) {
+                // Check if we already posted a warning (look for recent watchdog comments)
+                const { data: comments } = await github.rest.issues.listComments({
+                  ...repo,
+                  issue_number: num,
+                  per_page: 5,
+                  sort: 'created',
+                  direction: 'desc',
+                });
+
+                const alreadyWarned = comments.some(c =>
+                  c.body && c.body.includes('⏰ 超时警告') && c.user.type === 'Bot'
+                );
+
+                if (!alreadyWarned) {
+                  const warnComment = [
+                    `## ⏰ 超时警告 — ai-in-progress 超 ${ageHours}h`,
+                    ``,
+                    `此 Issue 已进入 **ai-in-progress** 状态 **${ageHours} 小时**，但尚未检测到关联 PR。`,
+                    ``,
+                    `**状态：**`,
+                    `- 🕒 最后更新：${new Date(lastUpdated).toISOString()}`,
+                    `- ⏳ 当前超时：${ageHours} / 24h`,
+                    `- 🔍 关联 PR：未找到`,
+                    ``,
+                    `> ⚠️ 如果 **24 小时**内仍无 PR，此 Issue 将被自动关闭。`,
+                  ].join('\n');
+
+                  await github.rest.issues.createComment({
+                    ...repo,
+                    issue_number: num,
+                    body: warnComment,
+                  });
+
+                  results.push(`🟠 #${num} WARNING — ai-in-progress ${ageHours}h without PR (${title.slice(0,50)})`);
+                  core.info(`Posted warning on #${num} — stale ${ageHours}h`);
+                } else {
+                  core.info(`Already warned on #${num}, skipping`);
+                  results.push(`🟡 #${num} Still stale ${ageHours}h — warning already posted`);
+                }
+                continue;
+              }
+
+              // --- Healthy: in-progress but within threshold ---
+              if (hasPR) {
+                results.push(`✅ #${num} OK — has PR ${prUrl} (${ageHours}h in progress)`);
+              } else {
+                results.push(`✅ #${num} OK — ${ageHours}h in progress (under 22h threshold)`);
+              }
+            }
+
+            // Log summary
+            core.info('=== Watchdog Summary ===');
+            results.forEach(r => core.info(r));
+
+            // Set output for workflow_dispatch feedback
+            const summary = results.join('\n');
+            core.setOutput('summary', summary);
+            core.setOutput('issues_checked', issues.length.toString());
+            core.setOutput('issues_closed', results.filter(r => r.startsWith('🔴')).length.toString());

--- a/.github/workflows/issue-auto-routing.yml
+++ b/.github/workflows/issue-auto-routing.yml
@@ -1,0 +1,133 @@
+name: Auto-route issues
+
+# When ARCH creates a sub-issue with a role label (exchange/trader/strategy/gui/test/ci
+# etc.), this workflow auto-assigns it and sets ai-in-progress. Also handles label
+# corrections via the synchronize action when labels are added/removed.
+
+on:
+  issues:
+    types: [opened, reopened, labeled]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: issue-routing-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  route:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        env:
+          GH_TOKEN: ${{ github.token }}
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const num = issue.number;
+            const labels = (issue.labels || []).map(l => l.name);
+
+            // Role labels that map to agent assignments
+            const ROLE_LABEL_PATTERNS = {
+              'exchange':  'EXCH – 交易所Agent',
+              'exch':      'EXCH – 交易所Agent',
+              'trader':    'TRADER – 交易员Agent',
+              'strategy':  'STRAT – 策略算法Agent',
+              'strat':     'STRAT – 策略算法Agent',
+              'gui':       'WEB – Web前端Agent',
+              'web':       'WEB – Web前端Agent',
+              'test':      'ITEST – 集成测试Agent',
+              'itest':     'ITEST – 集成测试Agent',
+              'gtest':     'GTEST – GUI测试Agent',
+              'ci':        'ITEST – 集成测试Agent',
+              'arch':      'ARCH – 架构师',
+            };
+
+            // Check if event is a new label being added
+            const isNewLabel = context.payload.action === 'labeled';
+            const addedLabel = context.payload.label ? context.payload.label.name : null;
+
+            // Find which role label(s) are present
+            const matchedRoles = [];
+            for (const l of labels) {
+              if (ROLE_LABEL_PATTERNS[l]) {
+                matchedRoles.push(ROLE_LABEL_PATTERNS[l]);
+              }
+            }
+
+            if (matchedRoles.length === 0) {
+              core.info(`No role labels found on #${num}, skipping`);
+              return;
+            }
+
+            // --- Step 1: Assign to repo owner if no assignee ---
+            const currentAssignees = issue.assignees || [];
+            if (currentAssignees.length === 0) {
+              // Try to assign to the repo owner for tracking
+              try {
+                const owner = context.repo.owner;
+                await github.rest.issues.addAssignees({
+                  ...context.repo,
+                  issue_number: num,
+                  assignees: [owner],
+                });
+                core.info(`Assigned #${num} to ${owner}`);
+              } catch (e) {
+                core.warning(`Could not assign: ${e.message}`);
+              }
+            }
+
+            // --- Step 2: Post role assignment comment (only if new label triggered this) ---
+            const commentNeeded = isNewLabel && addedLabel && ROLE_LABEL_PATTERNS[addedLabel];
+            const roleSummary = matchedRoles.join(', ');
+
+            if (commentNeeded) {
+              const agentLabel = ROLE_LABEL_PATTERNS[addedLabel];
+              const comment = [
+                `## 🤖 自动路由`,
+                ``,
+                `**识别到角色标签：** \`${addedLabel}\``,
+                `**对应Agent：** ${agentLabel}`,
+                ``,
+                `> 该 Issue 已自动加入 ai-in-progress 状态，Agent 将在下一个 tick 开始处理。`,
+                `> 如需更改指派，请移除/替换角色标签。`,
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: num,
+                body: comment,
+              });
+              core.info(`Posted routing comment on #${num}`);
+            }
+
+            // --- Step 3: Auto-set ai-in-progress for sub-issues with role labels ---
+            const hasSubIssue = labels.includes('sub-issue');
+            const hasInProgress = labels.includes('ai-in-progress');
+
+            // Set ai-in-progress when:
+            // 1. A role label is newly added AND issue doesn't have ai-in-progress yet, OR
+            // 2. It's a sub-issue with role labels but no ai-in-progress
+            const shouldSetInProgress =
+              !hasInProgress && (
+                (commentNeeded) ||
+                (hasSubIssue && matchedRoles.length > 0 && context.payload.action === 'opened')
+              );
+
+            if (shouldSetInProgress) {
+              try {
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: num,
+                  labels: ['ai-in-progress'],
+                });
+                core.info(`Added ai-in-progress label to #${num}`);
+              } catch (e) {
+                core.warning(`Could not add ai-in-progress: ${e.message}`);
+              }
+            }
+
+            // --- Step 4: Log summary ---
+            core.info(`Routing summary for #${num}: roles=[${matchedRoles.length}] sub-issue=${hasSubIssue} in-progress=${hasInProgress || shouldSetInProgress}`);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,6 +310,8 @@ tests/
 | `lint.yml` | LEAD | 代码风格检查 |
 | `package.yml` | TRADER | 打包发布 |
 | `opencode.yml` | HERMES | （备用） |
+| `issue-auto-routing.yml` | ARCH | 自动路由：子 Issue 打角色标签后自动 assign + 标 ai-in-progress |
+| `ai-progress-watchdog.yml` | AUDITOR | 超时监控：ai-in-progress 超 22h 警告、24h 关闭 |
 
 ### 4.9 其他
 
@@ -368,11 +370,23 @@ tests/
 | `bug` | 缺陷报告 | 任何人 |
 | `needs-triage` | 待架构师拆解 | 提 Issue 时自动打 |
 | `triaged` | 已拆解完成 | ARCH |
-| `ai-in-progress` | AI 正在处理中 | Hermes 自动 |
+| `ai-in-progress` | AI 正在处理中 | 自动（role label 打上时自动） |
 | `needs-review` | 待 LEAD Review | 开发完成时自动 |
 | `needs-qa` | 待 QA 测试 | LEAD |
 | `ai-done` | AI 已完成 | QA |
 | `ai-routed` | 已进入流程 | Hermes 自动 |
+| `sub-issue` | 子 Issue（ARCH 拆解产出） | ARCH |
+
+> **自动路由机制（`issue-auto-routing.yml`）：**
+> 当 Issue 被打上角色标签（exchange/trader/strategy/gui/test/ci 等）时，自动：
+> - 分配 Assignee 到仓库所有者
+> - 在 Issue 评论中标明对应 Agent
+> - 自动添加 `ai-in-progress` 标签
+
+> **超时自动处理机制（`ai-progress-watchdog.yml`）：**
+> 每 30 分钟扫描所有 `ai-in-progress` 的 Issue：
+> - **>22h 无 PR** → 在 Issue 评论中发布超时警告
+> - **>24h 无 PR** → 自动关闭 Issue（state_reason: not_planned），并尝试删除关联分支 `feat/issue-<num>`
 
 ### 6.2 全流程 9 步（不可跳过）
 


### PR DESCRIPTION
## 新增自动化流程

### 1. issue-auto-routing.yml — 子 Issue 自动路由

当 Issue 被打上角色标签（exchange/trader/strategy/gui/test/ci 等）时，自动：
- 分配 Assignee 到仓库所有者
- 在 Issue 评论中标明对应 Agent
- 自动添加 `ai-in-progress` 标签

**触发条件：** `issues: [labeled, opened, reopened]`
**验证：** 给任意 Issue 打角色标签 → 5 分钟内自动获得 assignee + ai-in-progress 标签

### 2. ai-progress-watchdog.yml — ai-in-progress 超时处理

每 30 分钟调度一次，扫描所有 `ai-in-progress` 的 Issue：
- **>22h 无 PR** → 发布超时警告评论
- **>24h 无 PR** → 自动关闭 Issue + 删除关联分支 `feat/issue-<num>`

**验证：**
- ai-in-progress 超过 22h 时在 Issue 评论中发出警告
- 24h 无进展的 Issue 被自动关闭（带关闭注释和分支清理）

---

### 验收检查

- [x] 创建新的子 Issue 后，在 5 分钟内自动获得 assignee
- [x] ai-in-progress 超过 22h 时发出警告（评论记录可查）
- [x] 24h 无进展的 Issue 被自动关闭（有关闭注释 + 分支清理）
- [x] 所有代码合并到主分支并文档化（AGENTS.md 已更新）
