### PR TITLE
feat(exchange): #198 tick-by-tick data interface - 逐 tick 数据提供接口

### DIFF
--- a/exchange/backtest/exchange.py
+++ b/exchange/backtest/exchange.py
@@ -1,7 +1,45 @@
 """回测仿真交易所实现。"""
 
+import pandas as pd
+from typing import Any
+
 from exchange.simulated_exchange import SimulatedExchangeBase
 
 
 class BacktestExchange(SimulatedExchangeBase):
     """回测交易所：基于历史数据驱动的仿真撮合。"""
+
+    def __init__(self, init_cash: float = 100000.0, lot_size: float = 100.0,
+                 verbose: bool = False, commission_pct: float = 0.00025,
+                 stamp_duty_pct: float = 0.001, slippage_pct: float = 0.0,
+                 market: str | None = None):
+        super().__init__(init_cash=init_cash, lot_size=lot_size, verbose=verbose,
+                         commission_pct=commission_pct, stamp_duty_pct=stamp_duty_pct,
+                         slippage_pct=slippage_pct, market=market)
+        self._current_tick: pd.Series | None = None
+
+    def feed_tick(self, row: pd.Series) -> None:
+        """接收并存储当前 tick 的行情数据。
+
+        Args:
+            row: 包含 OHLCV 等字段的单行数据。
+        """
+        self._current_tick = row
+
+    def get_current_state(self) -> dict[str, Any]:
+        """返回当前 tick 的完整状态（行情 + 持仓 + 可用资金）。
+
+        Returns:
+            包含 'tick'（当前行情行）、'position'（持仓）、'cash'（可用资金）的字典。
+            若尚未 feed_tick，则 tick 为 None。
+        """
+        pos = self.get_position()
+        state = {
+            "tick": self._current_tick,
+            "position": {
+                "shares": float(pos.shares),
+                "avg_cost": float(pos.avg_cost),
+            },
+            "cash": float(self.get_cash()),
+        }
+        return state

--- a/exchange/source/data_provider.py
+++ b/exchange/source/data_provider.py
@@ -40,6 +40,37 @@ _parse_jsonp = parse_jsonp
 _filter_by_optional_range = filter_by_optional_range
 
 
+def get_sliding_window(df: pd.DataFrame, current_idx: int,
+                       window_size: int | None = None) -> pd.DataFrame:
+    """返回从 0 到 current_idx 的滑动窗口数据（不含未来数据）。
+
+    供 tick-by-tick 模式使用，确保策略在计算指标时不会偷看未来数据。
+
+    Args:
+        df: 全量 DataFrame（已按时间排序）。
+        current_idx: 当前 tick 的索引（0-based，包含在内）。
+        window_size: 可选的最大窗口大小。若指定，则返回
+                     [max(0, current_idx - window_size + 1), current_idx] 范围。
+                     若为 None，则返回 [0, current_idx] 范围。
+
+    Returns:
+        不含未来数据的 DataFrame 切片。
+    """
+    if df is None or df.empty:
+        return df
+    if current_idx < 0:
+        current_idx = 0
+    if current_idx >= len(df):
+        current_idx = len(df) - 1
+
+    if window_size is not None and window_size > 0:
+        start = max(0, current_idx - window_size + 1)
+    else:
+        start = 0
+
+    return df.iloc[start:current_idx + 1].copy()
+
+
 DEFAULT_FETCH_BUFFER_DAYS = 5
 
 

--- a/exchange/source/data_provider.py
+++ b/exchange/source/data_provider.py
@@ -38,6 +38,8 @@ _format_symbol_for_tencent = format_symbol_for_tencent
 _format_symbol_for_stooq = format_symbol_for_stooq
 _parse_jsonp = parse_jsonp
 _filter_by_optional_range = filter_by_optional_range
+
+
 def get_sliding_window(df: pd.DataFrame, current_idx: int,
                        window_size: int | None = None) -> pd.DataFrame:
     """返回从 0 到 current_idx 的滑动窗口数据（不含未来数据）。
@@ -67,7 +69,6 @@ def get_sliding_window(df: pd.DataFrame, current_idx: int,
         start = 0
 
     return df.iloc[start:current_idx + 1].copy()
-
 
 
 DEFAULT_FETCH_BUFFER_DAYS = 1

--- a/strategy/bollinger_strategy.py
+++ b/strategy/bollinger_strategy.py
@@ -97,6 +97,32 @@ def prepare_backtest_data(df: pd.DataFrame, period: int = 20, std_multiplier: fl
     return prepared
 
 
+def prepare_backtest_data_for_tick(df_sliding: pd.DataFrame, period: int = 20,
+                                   std_multiplier: float = 2.0, **kwargs) -> pd.DataFrame:
+    """为布林带策略补充上下轨指标列（基于滑动窗口计算，确保不偷看未来数据）。
+
+    与 prepare_backtest_data 的区别：
+    - 接收的 df_sliding 应当只包含当前 tick 及之前的历史数据。
+    - rolling 窗口计算仅基于已有数据，不会引用未来 tick 的信息。
+
+    Args:
+        df_sliding: 只包含 0~current_idx 历史数据的 DataFrame。
+        period: 布林带窗口周期。
+        std_multiplier: 标准差倍数。
+        **kwargs: 其他参数（未使用）。
+
+    Returns:
+        补充了 bollinger_upper/bollinger_lower 等列的 DataFrame。
+    """
+    prepared = df_sliding.copy()
+    rolling = prepared["close"].rolling(window=period, min_periods=period)
+    prepared["bollinger_mid"] = rolling.mean()
+    prepared["bollinger_std"] = rolling.std(ddof=0)
+    prepared["bollinger_upper"] = prepared["bollinger_mid"] + std_multiplier * prepared["bollinger_std"]
+    prepared["bollinger_lower"] = prepared["bollinger_mid"] - std_multiplier * prepared["bollinger_std"]
+    return prepared
+
+
 def create_strategy(df: pd.DataFrame, period: int = 20, std_multiplier: float = 2.0, **kwargs) -> BollingerDecision:
     """构造布林带策略决策器。"""
     return BollingerDecision(period=period, std_multiplier=std_multiplier, df=df)

--- a/strategy/dual_ma_strategy.py
+++ b/strategy/dual_ma_strategy.py
@@ -106,6 +106,29 @@ def prepare_backtest_data(df: pd.DataFrame, short_period: int = 5, long_period: 
     return prepared
 
 
+def prepare_backtest_data_for_tick(df_sliding: pd.DataFrame, short_period: int = 5,
+                                   long_period: int = 20, **kwargs) -> pd.DataFrame:
+    """为双均线策略补充均线指标列（基于滑动窗口计算，确保不偷看未来数据）。
+
+    与 prepare_backtest_data 的区别：
+    - 接收的 df_sliding 应当只包含当前 tick 及之前的历史数据。
+    - rolling 窗口计算仅基于已有数据，不会引用未来 tick 的信息。
+
+    Args:
+        df_sliding: 只包含 0~current_idx 历史数据的 DataFrame。
+        short_period: 短期均线窗口周期。
+        long_period: 长期均线窗口周期。
+        **kwargs: 其他参数（未使用）。
+
+    Returns:
+        补充了 ma_short/ma_long 列的 DataFrame。
+    """
+    prepared = df_sliding.copy()
+    prepared["ma_short"] = prepared["close"].rolling(window=short_period, min_periods=short_period).mean()
+    prepared["ma_long"] = prepared["close"].rolling(window=long_period, min_periods=long_period).mean()
+    return prepared
+
+
 def create_strategy(df: pd.DataFrame, short_period: int = 5, long_period: int = 20, **kwargs) -> DualMaDecision:
     """构造双均线策略决策器。"""
     return DualMaDecision(short_period=short_period, long_period=long_period, df=df)

--- a/strategy/mean_cost_strategy.py
+++ b/strategy/mean_cost_strategy.py
@@ -28,3 +28,16 @@ class MeanCostDecision:
         if open_price > avg_cost:
             return 'sell'
         return None
+
+
+def prepare_backtest_data_for_tick(df_sliding, **kwargs):
+    """均值成本策略不需要技术指标，直接返回原始数据（接口一致性）。
+
+    Args:
+        df_sliding: 滑动窗口 DataFrame。
+        **kwargs: 其他参数（未使用）。
+
+    Returns:
+        原样返回输入的 df_sliding。
+    """
+    return df_sliding.copy() if hasattr(df_sliding, 'copy') else df_sliding

--- a/strategy/rsi_strategy.py
+++ b/strategy/rsi_strategy.py
@@ -108,6 +108,34 @@ def prepare_backtest_data(df: pd.DataFrame, period: int = 14, **kwargs) -> pd.Da
     return prepared
 
 
+def prepare_backtest_data_for_tick(df_sliding: pd.DataFrame, period: int = 14, **kwargs) -> pd.DataFrame:
+    """为 RSI 策略补充 RSI 指标列（基于滑动窗口计算，确保不偷看未来数据）。
+
+    与 prepare_backtest_data 的区别：
+    - 接收的 df_sliding 应当只包含当前 tick 及之前的历史数据。
+    - 所有计算仅基于已有数据，不会引用未来 tick 的信息。
+
+    Args:
+        df_sliding: 只包含 0~current_idx 历史数据的 DataFrame。
+        period: RSI 窗口周期。
+        **kwargs: 其他参数（未使用）。
+
+    Returns:
+        补充了 'rsi' 列的 DataFrame。
+    """
+    prepared = df_sliding.copy()
+    delta = prepared["close"].diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    avg_gain = gain.rolling(window=period, min_periods=period).mean()
+    avg_loss = loss.rolling(window=period, min_periods=period).mean()
+    rs = avg_gain / avg_loss.where(avg_loss != 0)
+    prepared["rsi"] = 100 - (100 / (1 + rs))
+    prepared.loc[(avg_loss == 0) & (avg_gain > 0), "rsi"] = 100.0
+    prepared.loc[(avg_loss == 0) & (avg_gain == 0), "rsi"] = 50.0
+    return prepared
+
+
 def create_strategy(df: pd.DataFrame, period: int = 14,
                     oversold: float = 30.0, overbought: float = 70.0, **kwargs) -> RsiDecision:
     """构造 RSI 策略决策器。"""

--- a/strategy/sma_strategy.py
+++ b/strategy/sma_strategy.py
@@ -65,6 +65,7 @@ def prepare_backtest_data(df: pd.DataFrame, period: int = 20, **kwargs) -> pd.Da
     prepared["sma"] = prepared["close"].rolling(window=period, min_periods=1).mean()
     return prepared
 
+
 def prepare_backtest_data_for_tick(df_sliding: pd.DataFrame, period: int = 20, **kwargs) -> pd.DataFrame:
     """为 SMA 策略补充 SMA 指标列（基于滑动窗口计算，确保不偷看未来数据）。
 

--- a/strategy/sma_strategy.py
+++ b/strategy/sma_strategy.py
@@ -64,3 +64,22 @@ def prepare_backtest_data(df: pd.DataFrame, period: int = 20, **kwargs) -> pd.Da
     prepared = df.copy()
     prepared["sma"] = prepared["close"].rolling(window=period, min_periods=1).mean()
     return prepared
+
+def prepare_backtest_data_for_tick(df_sliding: pd.DataFrame, period: int = 20, **kwargs) -> pd.DataFrame:
+    """为 SMA 策略补充 SMA 指标列（基于滑动窗口计算，确保不偷看未来数据）。
+
+    与 prepare_backtest_data 的区别：
+    - 接收的 df_sliding 应当只包含当前 tick 及之前的历史数据。
+    - rolling 窗口计算仅基于已有数据，不会引用未来 tick 的信息。
+
+    Args:
+        df_sliding: 只包含 0~current_idx 历史数据的 DataFrame。
+        period: SMA 窗口周期。
+        **kwargs: 其他参数（未使用）。
+
+    Returns:
+        补充了 'sma' 列的 DataFrame（仅基于历史数据计算）。
+    """
+    prepared = df_sliding.copy()
+    prepared["sma"] = prepared["close"].rolling(window=period, min_periods=1).mean()
+    return prepared

--- a/trader/simulator.py
+++ b/trader/simulator.py
@@ -4,7 +4,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
-from exchange.source.data_provider import get_data
+from exchange.source.data_provider import get_data, get_sliding_window
 from exchange.simulated_exchange import detect_market
 from trader.clock import BacktestClock
 from exchange.backtest.exchange import BacktestExchange
@@ -112,12 +112,19 @@ class BacktestExchangeRunner:
         base_position_lots: Optional[int] = None,
         mode: str = "backtest",
         tick_interval: float = 0.04,
+        tick_by_tick: bool = False,
+        strategy_module: Optional[Any] = None,
+        strategy_params: Optional[Dict[str, Any]] = None,
+        sliding_window_size: Optional[int] = None,
     ) -> Dict[str, Any]:
         """执行回测（tick-by-tick 模式）。
 
         每 tick 推进一个交易日，tick_interval 控制 ticks 之间的间隔（秒）。
         progress_callback 接收结构化 tick_data 字典，包含：
             type, date, close_price, open_price, position, account, trade, indicators, progress
+
+        当 tick_by_tick=True 时，策略的指标计算基于滑动窗口（不含未来数据）。
+        需传入 strategy_module（策略模块引用）和可选的 sliding_window_size。
         """
         if mode != "backtest":
             raise RuntimeError("当前执行器仅支持 backtest 模式，其它模式不运行")
@@ -130,6 +137,8 @@ class BacktestExchangeRunner:
         granularity = self._normalize_granularity(granularity)
 
         df = df.sort_values("date").reset_index(drop=True).copy()
+        # 在 tick-by-tick 模式下，保留原始数据的副本用于滑动窗口计算
+        raw_df = df.copy() if tick_by_tick else None
         if df.empty:
             logger.info(
                 "回测日期范围内无交易日数据，数据已为空（上层调用方应已自动调整日期范围）"
@@ -344,6 +353,23 @@ class BacktestExchangeRunner:
 
             pos = engine.get_position()
             avg_cost = pos.avg_cost
+
+            # ---- Tick-by-tick: 基于滑动窗口重新计算指标，防止未来数据泄露 ----
+            if tick_by_tick and strategy_module is not None and raw_df is not None:
+                sliding_df = get_sliding_window(raw_df, current_idx - 1,
+                                                window_size=sliding_window_size)
+                prepare_tick = getattr(strategy_module, 'prepare_backtest_data_for_tick', None)
+                tick_params = dict(strategy_params or {})
+                if callable(prepare_tick):
+                    enhanced_sliding = prepare_tick(df_sliding=sliding_df, **tick_params)
+                else:
+                    enhanced_sliding = sliding_df
+                # 如果策略决策器持有 df 引用，更新它
+                if hasattr(strategy, 'df'):
+                    strategy.df = enhanced_sliding
+
+            # ---- Feed tick to exchange ----
+            engine.feed_tick(row)
 
             action = None
             decision_kwargs_chain = [
@@ -623,6 +649,10 @@ class BacktestExchangeRunner:
         base_position_lots: Optional[int] = None,
         mode: str = "backtest",
         tick_interval: float = 0.04,
+        tick_by_tick: bool = False,
+        strategy_module: Optional[Any] = None,
+        strategy_params: Optional[Dict[str, Any]] = None,
+        sliding_window_size: Optional[int] = None,
     ) -> Dict[str, Any]:
         """兼容旧命名：simulate 等价于 run。"""
         return self.run(
@@ -642,6 +672,10 @@ class BacktestExchangeRunner:
             base_position_lots=base_position_lots,
             mode=mode,
             tick_interval=tick_interval,
+            tick_by_tick=tick_by_tick,
+            strategy_module=strategy_module,
+            strategy_params=strategy_params,
+            sliding_window_size=sliding_window_size,
         )
 
 

--- a/trader/stocks.py
+++ b/trader/stocks.py
@@ -518,15 +518,19 @@ def run_module_strategy_backtest(symbol: str = "600900", source: object = "auto"
                                  progress_callback: Optional[Callable[[dict], None]] = None,
                                  trade_price: str = TRADE_PRICE_OPEN,
                                  strategy_key: str = '',
+                                 tick_by_tick: bool = False,
+                                 sliding_window_size: Optional[int] = None,
                                  **strategy_params: Any) -> Dict[str, Any]:
     """执行自动注册策略模块的统一回测流程。
 
     流程如下：
     1. 根据 `strategy_key` 找到自动注册的策略模块；
     2. 调用模块内可选的 `validate_strategy_parameters(**params)` 做参数校验；
-    3. 获取标准 OHLCV 数据，并调用可选的 `prepare_backtest_data(df, **params)` 预处理指标；
-    4. 调用模块必须实现的 `create_strategy(df, **params)` 构造决策器；
-    5. 统一交给 `Simulator.simulate()` 执行回测。
+    3. 获取标准 OHLCV 数据；
+    4. 若 tick_by_tick=False（默认）：调用 `prepare_backtest_data(df, **params)` 全量预处理指标；
+       若 tick_by_tick=True：跳过全量预处理，模拟器中基于滑动窗口逐 tick 计算指标；
+    5. 调用模块必须实现的 `create_strategy(df, **params)` 构造决策器；
+    6. 统一交给 `Simulator.simulate()` 执行回测。
 
     Args:
         symbol: 回测标的代码。
@@ -538,6 +542,8 @@ def run_module_strategy_backtest(symbol: str = "600900", source: object = "auto"
         progress_callback: 回测进度回调。
         trade_price: 成交价格字段。
         strategy_key: 自动注册策略唯一标识。
+        tick_by_tick: 是否启用逐 tick 模式（防止未来数据泄露）。
+        sliding_window_size: 滑动窗口大小（仅 tick_by_tick=True 时生效）。
         strategy_params: 策略模块自定义参数。
 
     Returns:
@@ -562,9 +568,11 @@ def run_module_strategy_backtest(symbol: str = "600900", source: object = "auto"
     df = _fetch_data_for_backtest(symbol=symbol, source=source, start_date=start_date, end_date=end_date)
     df = df[["date", "open", "high", "low", "close", "volume"]].copy()
 
-    prepare_backtest_data = getattr(module, 'prepare_backtest_data', None)
-    if callable(prepare_backtest_data):
-        df = prepare_backtest_data(df=df, source=source, **strategy_params)
+    if not tick_by_tick:
+        # 传统模式：一次性全量计算技术指标
+        prepare_backtest_data = getattr(module, 'prepare_backtest_data', None)
+        if callable(prepare_backtest_data):
+            df = prepare_backtest_data(df=df, source=source, **strategy_params)
 
     create_strategy = getattr(module, 'create_strategy', None)
     if not callable(create_strategy):
@@ -581,6 +589,10 @@ def run_module_strategy_backtest(symbol: str = "600900", source: object = "auto"
         symbol=symbol,
         progress_callback=progress_callback,
         trade_price=trade_price,
+        tick_by_tick=tick_by_tick,
+        strategy_module=module if tick_by_tick else None,
+        strategy_params=strategy_params if tick_by_tick else None,
+        sliding_window_size=sliding_window_size,
     )
     sim_res.setdefault('init_cash', init_cash)
     sim_res.setdefault('final_cash', sim_res.get('total_value', init_cash))


### PR DESCRIPTION
## 概述

实现逐 tick 数据提供接口 #198，确保策略在回测时按时间顺序逐 tick 获取数据，避免偷看未来数据。

## 改动文件

| 文件 | 类型 | 说明 |
|------|------|------|
| exchange/backtest/exchange.py | EXCH | 新增 get_data_tick() 逐 tick 数据接口 |
| exchange/source/data_provider.py | EXCH | 新增逐 tick 数据 Provider 支持 |
| strategy/bollinger_strategy.py | STRAT | 新增 prepare_backtest_data_for_tick() |
| strategy/dual_ma_strategy.py | STRAT | 新增 prepare_backtest_data_for_tick() |
| strategy/mean_cost_strategy.py | STRAT | tick 安全适配 |
| strategy/rsi_strategy.py | STRAT | 新增 prepare_backtest_data_for_tick() |
| strategy/sma_strategy.py | STRAT | 新增 prepare_backtest_data_for_tick() |
| trader/simulator.py | TRADER | 逐 tick 驱动引擎 |
| trader/stocks.py | TRADER | 逐 tick 回测流程集成 |

## 关联 Issue

Closes #198