### PR TITLE
[需求] 收盘反转策略增加基金类型参数 — 区分场内/场外基金成交方式

### DIFF
--- a/gui/templates/strategy_config.html
+++ b/gui/templates/strategy_config.html
@@ -224,6 +224,13 @@
 
         {% for parameter in parameters %}
         <label>{{ parameter.label }}
+          {% if parameter.options %}
+          <select name="{{ parameter.name }}">
+            {% for opt_value, opt_label in parameter.options %}
+            <option value="{{ opt_value }}"{% if parameter.default == opt_value %} selected{% endif %}>{{ opt_label }}</option>
+            {% endfor %}
+          </select>
+          {% else %}
           <input
             type="{{ parameter.input_type }}"
             name="{{ parameter.name }}"
@@ -231,6 +238,7 @@
             {% if parameter.required %}required{% endif %}
             {% if parameter.input_step %}step="{{ parameter.input_step }}"{% endif %}
           />
+          {% endif %}
           {% if parameter.description %}
           <div class="param-hint">{{ parameter.description }}</div>
           {% endif %}

--- a/gui/web.py
+++ b/gui/web.py
@@ -391,6 +391,7 @@ def _build_strategy_parameter_view(strategy_key: str) -> list[dict]:
                 'required': parameter.required,
                 'input_type': input_type,
                 'input_step': input_step,
+                'options': parameter.options,
             }
         )
     return items

--- a/strategy/close_reversal_strategy.py
+++ b/strategy/close_reversal_strategy.py
@@ -1,9 +1,13 @@
 """每日收盘反转策略（Close Reversal Strategy）
 
-在每日 15:00 收盘时，根据当日涨跌幅生成反转信号：
+在接近收盘（14:58）时根据当日涨跌幅生成反转信号，区分场内/场外基金成交方式：
 - 当日上涨（收盘价 > 前一日收盘价）→ 卖出信号（卖出持仓）
 - 当日下跌（收盘价 < 前一日收盘价）→ 买入信号（买入开仓）
 - 当日持平（收盘价 == 前一日收盘价）→ 无操作
+
+基金类型区别：
+- 场内基金（on_exchange）：14:58 判断信号，即时市价成交（日线近似用 close 价）
+- 场外基金（off_exchange）：14:58 判断信号，按 15:00 收盘净值（close 价）成交
 """
 import dataclasses
 from typing import Any, Optional
@@ -26,8 +30,19 @@ AUTO_STRATEGY_SPEC = {
             "default": 0.0,
             "description": "涨跌幅绝对值低于该值时视为持平，不产生信号。例：0.1 表示±0.1%以内视为持平。",
         },
+        {
+            "name": "fund_type",
+            "label": "基金类型",
+            "caster": "str",
+            "default": "off_exchange",
+            "description": "场内基金（ETF）按14:58即时市价成交；场外基金按15:00收盘净值成交。日线回测均使用close价近似。",
+            "options": [
+                ["on_exchange", "场内基金（ETF，14:58即时价）"],
+                ["off_exchange", "场外基金（15:00收盘净值）"],
+            ],
+        },
     ],
-    "description": "每日收盘反转策略：当日上涨则卖出，当日下跌则买入。基于均值回归逻辑。",
+    "description": "每日收盘反转策略：当日上涨则卖出，当日下跌则买入。基于均值回归逻辑。支持场内/场外基金区分。",
     "supported_trade_prices": ["close"],
 }
 
@@ -41,6 +56,11 @@ class CloseReversalDecision:
     - 若涨幅超过 min_change_pct：返回 'sell'（卖出持仓）
     - 若跌幅超过 min_change_pct：返回 'buy'（买入开仓）
     - 若涨跌幅在 ±min_change_pct 范围内：返回 None（无操作）
+
+    基金类型（fund_type）：
+    - on_exchange（场内基金）：14:58 信号 + 即时市价成交
+    - off_exchange（场外基金，默认）：14:58 信号 + 15:00 收盘净值成交
+    日线回测下两者均使用 close 价近似计算。
 
     该策略是 tick-safe 的（仅依赖当前行与上一行数据）。
     """
@@ -109,10 +129,12 @@ class CloseReversalDecision:
         return None
 
 
-def validate_strategy_parameters(min_change_pct: float = 0.0, **kwargs) -> None:
+def validate_strategy_parameters(min_change_pct: float = 0.0, fund_type: str = 'off_exchange', **kwargs) -> None:
     """校验收盘反转策略参数。"""
     if min_change_pct < 0:
         raise ValueError("最小变动百分比不能为负数")
+    if fund_type not in ('on_exchange', 'off_exchange'):
+        raise ValueError(f"不支持的基金类型: {fund_type}，仅支持 on_exchange 和 off_exchange")
 
 
 def prepare_backtest_data(df: pd.DataFrame, **kwargs) -> pd.DataFrame:
@@ -144,6 +166,7 @@ def prepare_backtest_data_for_tick(df_sliding: pd.DataFrame, **kwargs) -> pd.Dat
 def create_strategy(
     df: pd.DataFrame,
     min_change_pct: float = 0.0,
+    fund_type: str = 'off_exchange',
     **kwargs,
 ) -> CloseReversalDecision:
     """构造收盘反转策略决策器。"""

--- a/tests/unit/test_close_reversal_strategy.py
+++ b/tests/unit/test_close_reversal_strategy.py
@@ -201,6 +201,21 @@ class TestCloseReversalValidateParameters(unittest.TestCase):
         with self.assertRaises(ValueError):
             validate_strategy_parameters(min_change_pct=-1.0)
 
+    def test_valid_fund_types(self):
+        """合法的基金类型不应抛出异常。"""
+        validate_strategy_parameters(fund_type='on_exchange')
+        validate_strategy_parameters(fund_type='off_exchange')
+
+    def test_invalid_fund_type_raises(self):
+        """非法的基金类型应抛出异常。"""
+        with self.assertRaises(ValueError):
+            validate_strategy_parameters(fund_type='invalid_type')
+
+    def test_invalid_fund_type_raises_with_default_message(self):
+        """非法基金类型的错误信息应包含支持的类型。"""
+        with self.assertRaisesRegex(ValueError, "on_exchange|off_exchange"):
+            validate_strategy_parameters(fund_type='unknown')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/trader/stocks.py
+++ b/trader/stocks.py
@@ -44,6 +44,7 @@ class StrategyParameter:
     default: Any
     description: str = ''
     required: bool = False
+    options: tuple = ()  # (value, label) 二元组列表，用于渲染下拉框
 
     def parse(self, raw_value: Any) -> Any:
         """将表单或外部输入转换为策略内部参数。"""
@@ -178,6 +179,11 @@ def _discover_auto_strategy_specs() -> Dict[str, StrategySpec]:
                 caster = caster_map.get(caster_name)
                 if caster is None:
                     continue
+                options_raw = item.get('options', []) or []
+                options = tuple(
+                    (str(v), str(l)) for v, l in options_raw
+                ) if options_raw else ()
+
                 parameters.append(
                     StrategyParameter(
                         name=str(item.get('name', '')).strip(),
@@ -186,6 +192,7 @@ def _discover_auto_strategy_specs() -> Dict[str, StrategySpec]:
                         default=item.get('default'),
                         description=str(item.get('description', '')).strip(),
                         required=bool(item.get('required', False)),
+                        options=options,
                     )
                 )
 


### PR DESCRIPTION
## 关联 Issue

Closes #225

## 改动内容

收盘反转策略增加 `fund_type` 参数，区分场内/场外基金成交方式：

| 文件 | 改动 |
|------|------|
| `strategy/close_reversal_strategy.py` | 新增 `fund_type` 参数（on_exchange/off_exchange），更新验证和创建函数 |
| `trader/stocks.py` | `StrategyParameter` 增加 `options` 字段，解析策略规格中的下拉选项 |
| `gui/web.py` | 传递 `options` 字段到前端模板 |
| `gui/templates/strategy_config.html` | 支持参数渲染为 `<select>` 下拉框 |
| `tests/unit/test_close_reversal_strategy.py` | 新增 fund_type 校验测试用例（合法类型 + 非法类型） |

## 使用说明

策略配置界面会显示"基金类型"下拉框：
- **场内基金（ETF，14:58即时价）** — `on_exchange`
- **场外基金（15:00收盘净值）** — `off_exchange`（默认）

日线回测下两种类型均使用 close 价近似计算。

## 类型

- [x] 新功能 (enhancement)