### PR TITLE
[BUG] 收盘反转策略在 Web GUI 回测时报错 trade_price 不匹配

### DIFF
--- a/gui/web.py
+++ b/gui/web.py
@@ -956,6 +956,8 @@ def run():
     cash = float(request.form.get('cash') or 100000.0)
     strategy_params = _collect_strategy_form_params(strategy)
     tick_by_tick = request.form.get('tick_by_tick', '0') == '1'
+    # 根据策略支持的交易价格字段动态选择，避免硬编码 open 导致收盘策略报错
+    _spec = stocks.get_strategy_spec(strategy)
     request_payload = {
         'symbol': symbol,
         'strategy': strategy,
@@ -964,7 +966,7 @@ def run():
         'end_date': end,
         'lot_size': lot,
         'init_cash': cash,
-        'trade_price': stocks.TRADE_PRICE_OPEN,
+        'trade_price': _spec.supported_trade_prices[0],
         'strategy_params': strategy_params,
     }
 

--- a/tests/unit/test_stocks.py
+++ b/tests/unit/test_stocks.py
@@ -266,6 +266,30 @@ class TestStocksModule(unittest.TestCase):
             sell_ratio_pct=50.0,
         )
 
+    # ── close_reversal 策略的 trade_price 约束 ─────────────────────
+
+    def test_close_reversal_trade_price_is_close(self):
+        """收盘反转策略仅支持 close 交易价格"""
+        specs = {spec.key: spec for spec in stocks.list_strategy_specs()}
+        self.assertIn('close_reversal', specs)
+        self.assertEqual(specs['close_reversal'].supported_trade_prices, ('close',))
+
+    def test_close_reversal_accepts_close_price(self):
+        """收盘反转策略使用 trade_price='close' 创建回测请求应通过"""
+        request = stocks.create_backtest_request(
+            strategy='close_reversal',
+            trade_price='close',
+        )
+        self.assertEqual(request.trade_price, 'close')
+
+    def test_close_reversal_rejects_open_price(self):
+        """收盘反转策略使用 trade_price='open' 应抛出 ValueError"""
+        with self.assertRaises(ValueError):
+            stocks.create_backtest_request(
+                strategy='close_reversal',
+                trade_price='open',
+            )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## 修复内容

修复 Issue #224：收盘反转策略在 Web GUI 回测时报错 `trade_price` 不匹配。

### 根因
`gui/web.py` 的 `run()` 路由硬编码 `trade_price=open`。但收盘反转策略只支持 `supported_trade_prices: ["close"]`，`create_backtest_request()` 校验时发现 `open not in [close]` → ValueError。

### 修改
1. **gui/web.py** — 按策略的 `supported_trade_prices` 动态选第一项，不再硬编码
2. **tests/unit/test_stocks.py** — 加 3 个测试验证 trade_price 约束

### 验证
分支: feat/issue-224-fix-close-reversal-trade-price
commit: 2f8c648

Closes #224