### PR TITLE
fix(#228): 无角色标签时添加 needs-triage 标签

### DIFF
--- a/.github/workflows/issue-auto-routing.yml
+++ b/.github/workflows/issue-auto-routing.yml
@@ -58,7 +58,17 @@ jobs:
             }
 
             if (matchedRoles.length === 0) {
-              core.info(`No role labels found on #${num}, skipping`);
+              core.warning(`No role labels on #${num}, adding needs-triage`);
+              try {
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: num,
+                  labels: ['needs-triage'],
+                });
+                core.info(`Added needs-triage label to #${num}`);
+              } catch (e) {
+                core.warning(`Could not add needs-triage: ${e.message}`);
+              }
               return;
             }
 


### PR DESCRIPTION
close #228

## 修改

`issue-auto-routing.yml` 第 60 行：
- **原行为：** 无角色标签时静默跳过
- **新行为：** 添加 `needs-triage` 标签

## 修改文件
- `.github/workflows/issue-auto-routing.yml`