### PR TITLE
feat: fix publish screenshots pr (#245)

### DIFF
--- a/.github/workflows/testgui.yml
+++ b/.github/workflows/testgui.yml
@@ -65,7 +65,8 @@ jobs:
           retention-days: 30
 
       - name: Publish GUI screenshots to branch
-        if: always()
+        # Skip on PR events — GITHUB_TOKEN lacks push permission for guitest-assets branch
+        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 关联 Issue

Closes #245

## 变更内容

修改 `.github/workflows/testgui.yml`:
- 将 "Publish GUI screenshots to branch" 步骤的 `if: always()` 改为 `if: github.event_name == 'push'`
- 在 pull_request 事件上，GITHUB_TOKEN 没有权限推送到 `guitest-assets` 分支
- PR 评论步骤 (`Comment PR with GUI report`) 已正确使用 `if: github.event_name == 'pull_request'`

## QA Checklist

- [x] Publish 步骤只在 push 事件上运行
- [x] PR 评论步骤不受影响
- [x] 上传 artifacts 步骤不受影响 (已在 `if: always()` 上)
